### PR TITLE
build(ethcl): also link libcrypto from /usr/lib64

### DIFF
--- a/packages/EthCLLib/lakefile.toml
+++ b/packages/EthCLLib/lakefile.toml
@@ -6,7 +6,9 @@ defaultTargets = ["EthCLLib"]
 # `libcrypto` flag its `native_decide` self-tests need transitively through
 # SizzLean's FFI SHA-256. The blst / c-kzg archives propagate automatically
 # as `extern_lib`s, only the system shared lib needs re-stating here.
-moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-l:libcrypto.so.3"]
+# Two `-L` paths cover the common Linux libdir layouts (Debian multiarch and
+# `/usr/lib64` on Gentoo / Fedora / RHEL); the linker ignores whichever is absent.
+moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib64", "-l:libcrypto.so.3"]
 moreLeancArgs = ["-march=native"]
 
 # SizzLean supplies the SSZ machinery (SSZRepr, Box, the cache, sszGet /

--- a/packages/EthCLSpecs/lakefile.toml
+++ b/packages/EthCLSpecs/lakefile.toml
@@ -3,7 +3,9 @@ defaultTargets = ["EthCLSpecs"]
 
 # Re-supply the system libcrypto flag (does not propagate across `require`); the
 # blst / c-kzg archives propagate transitively from the LeanHazmat packages.
-moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-l:libcrypto.so.3"]
+# Two `-L` paths cover the common Linux libdir layouts (Debian multiarch and
+# `/usr/lib64` on Gentoo / Fedora / RHEL); the linker ignores whichever is absent.
+moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib64", "-l:libcrypto.so.3"]
 moreLeancArgs = ["-march=native"]
 
 # The framework. Pulls in SizzLean (SSZ), LeanHazmatBls / LeanHazmatKzg (crypto)


### PR DESCRIPTION
The `EthCLLib` and `EthCLSpecs` lakefiles link the system `libcrypto` with a
single `-L/usr/lib/x86_64-linux-gnu`, which is the Debian/Ubuntu multiarch path.
Fine on Debian. But on distros that keep their libraries in `/usr/lib64` (Gentoo,
Fedora, RHEL) the linker never finds `libcrypto.so.3` and the build dies at the
link step. Hit this on Gentoo.

The fix is one extra `-L/usr/lib64` next to the existing path in both files. The
linker skips whichever directory isn't there, so the same flag list works on both
layouts and nothing has to be configured per-distro.

Both lakefiles need it because both pull in `libcrypto` for the `native_decide`
self-tests that go through SizzLean's FFI SHA-256, and the flag doesn't propagate
across `require`, so each package restates it (and each had the same
multiarch-only assumption). Same two-line change in each.

Build config only, no Lean sources touched. Debian/Ubuntu is unaffected, the
original path still resolves there first. Verified with `lake build` on Gentoo,
where the single-path version wouldn't link.
