### PR TITLE
feat(ethclspecs): Gloas EIP-8282 + re-pin consensus-specs to v1.7.0-alpha.11

### DIFF
--- a/packages/EthCLLib/lakefile.toml
+++ b/packages/EthCLLib/lakefile.toml
@@ -6,7 +6,9 @@ defaultTargets = ["EthCLLib"]
 # `libcrypto` flag its `native_decide` self-tests need transitively through
 # SizzLean's FFI SHA-256. The blst / c-kzg archives propagate automatically
 # as `extern_lib`s, only the system shared lib needs re-stating here.
-moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-l:libcrypto.so.3"]
+# Two `-L` paths cover the common Linux libdir layouts (Debian multiarch and
+# `/usr/lib64` on Gentoo / Fedora / RHEL); the linker ignores whichever is absent.
+moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib64", "-l:libcrypto.so.3"]
 moreLeancArgs = ["-march=native"]
 
 # SizzLean supplies the SSZ machinery (SSZRepr, Box, the cache, sszGet /

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
@@ -137,6 +137,9 @@ abbrev maxValidatorsPerCommittee : Nat := 2048
 abbrev maxDepositRequestsPerPayload : Nat := 8192
 abbrev maxWithdrawalRequestsPerPayload : Nat := 16
 abbrev maxConsolidationRequestsPerPayload : Nat := 2
+-- EIP-8282 (Gloas builder deposits / exits): 2**8 and 2**4, identical across presets.
+abbrev maxBuilderDepositRequestsPerPayload : Nat := 256
+abbrev maxBuilderExitRequestsPerPayload : Nat := 16
 abbrev maxAttestationsElectra : Nat := 8
 abbrev maxAttesterSlashingsElectra : Nat := 1
 abbrev maxPendingDepositsPerEpoch : Nat := 16
@@ -225,6 +228,9 @@ abbrev maxPayloadAttestations : Nat := 4
 abbrev builderPaymentThresholdNumerator : UInt64 := 6
 abbrev builderPaymentThresholdDenominator : UInt64 := 10
 abbrev builderWithdrawalPrefix : UInt8 := 0x03
+/-- `PAYLOAD_BUILDER_VERSION = uint8(0)` (EIP-8282): the version stamped on a
+builder onboarded at the fork (`add_builder_to_registry`). -/
+abbrev payloadBuilderVersion : UInt8 := 0
 abbrev builderIndexFlag : UInt64 := 0x10000000000
 /-- `BUILDER_INDEX_SELF_BUILD = BuilderIndex(UINT64_MAX)`: the bid's `builder_index`
 sentinel marking a proposer self-build (no external builder). -/
@@ -234,6 +240,9 @@ this is what `get_blob_parameters(epoch).max_blobs_per_block` returns. -/
 abbrev maxBlobsPerBlockElectra : Nat := 9
 abbrev domainBeaconBuilder : ByteArray := ⟨#[0x0B, 0, 0, 0]⟩
 abbrev domainPtcAttester : ByteArray := ⟨#[0x0C, 0, 0, 0]⟩
+-- EIP-8282 `DOMAIN_BUILDER_DEPOSIT` (`0x0E000000`). Consumed by the deferred
+-- builder-deposit signature check; recorded now alongside the other domain tags.
+abbrev domainBuilderDeposit : ByteArray := ⟨#[0x0E, 0, 0, 0]⟩
 /-- ePBS fork-choice payload statuses for a `ForkChoiceNode`. -/
 abbrev payloadStatusEmpty : UInt8 := 0
 abbrev payloadStatusFull : UInt8 := 1

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -34,7 +34,7 @@ namespace EthCLSpecs.Fulu.Interface
 /-- Pinned upstream spec / vectors release (`SPEC_AUTHORING_MODEL.md` §10). The
 latest `consensus-spec-tests` release; confirmed to carry both Fulu and Gloas
 minimal vectors. -/
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
 
 /-- Decode a `BeaconState` at preset `P` into a `FastBox`, or the runner's `decode`
 error (a well-formed vector should always decode, so a parse failure is our bug, not a

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas.lean
@@ -5,8 +5,9 @@ import EthCLSpecs.Gloas.Interface
 /-!
 # `EthCLSpecs.Gloas`: the Gloas fork (EIP-7732 ePBS), a diff over Fulu
 
-`fork Gloas from Fulu` plus the ePBS container diff, the `upgradeToGloas`
-lifecycle entry, and the fork-interface instance. Pinned to the v1.7.0-alpha.10
+`fork Gloas from Fulu` plus the ePBS + EIP-8282 container diff, the `upgradeToGloas`
+lifecycle entry, and the fork-interface instance. Pinned to the v1.7.0-alpha.11
 spec shape (the pyspec vectors' version). The transition spine, operations,
-and fork choice are inherited from / diffed over Fulu as that port matures.
+and fork choice are inherited from / diffed over Fulu as that port matures. The
+EIP-8282 builder-deposit / builder-exit operation processing is deferred (xfail).
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers.lean
@@ -11,13 +11,15 @@ brings it all into scope; it holds no declarations of its own. The pieces:
 - the `fork Gloas from Fulu` lineage and fork-version values (`Constants`);
 - the ePBS containers, one file per container under `Containers/`: the builder
   registry (`Builder`), the payload bid (`PayloadBid`), the builder-payment queue
-  (`BuilderPayment`), the payload-attestation family (`PayloadAttestation`), and
-  the revealed payload / envelope (`Execution`);
+  (`BuilderPayment`), the EIP-8282 builder requests and the extended
+  `ExecutionRequests` (`ExecutionRequests`), the payload-attestation family
+  (`PayloadAttestation`), and the revealed payload / envelope (`Execution`);
 - the changed `BeaconState` and its boxed view (`State`);
 - the ePBS `BeaconBlockBody` / `BeaconBlock` (`Block`).
 
 The unchanged component and operation containers (`Validator`, `Eth1Data`,
 `Checkpoint`, `Withdrawal`, the attestation / slashing / deposit / exit families,
-`ExecutionRequests`, `SyncAggregate`, …) are reused from Fulu directly
-(`open EthCLSpecs.Fulu`); Gloas redefines only the containers whose shape changed.
+`SyncAggregate`, …) are reused from Fulu directly (`open EthCLSpecs.Fulu`); Gloas
+redefines only the containers whose shape changed (EIP-8282 makes `ExecutionRequests`
+one of them).
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/BuilderPayment.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/BuilderPayment.lean
@@ -21,9 +21,11 @@ forkcontainer BuilderPendingWithdrawal where
   amount       : Gwei
   builderIndex : BuilderIndex
 
-/-- A pending builder payment, weighting a pending withdrawal. -/
+/-- A pending builder payment, weighting a pending withdrawal. EIP-8282 records the
+proposer that produced it so a proposer slashing only clears its own payment. -/
 forkcontainer BuilderPendingPayment where
-  weight     : Gwei
-  withdrawal : BuilderPendingWithdrawal
+  weight        : Gwei
+  withdrawal    : BuilderPendingWithdrawal
+  proposerIndex : ValidatorIndex
 
 end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/ExecutionRequests.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/ExecutionRequests.lean
@@ -1,0 +1,43 @@
+import EthCLSpecs.Gloas.Containers.BuilderPayment
+
+/-!
+# `EthCLSpecs.Gloas.Containers.ExecutionRequests`: EIP-8282 builder requests
+
+EIP-8282 adds two execution-layer-triggered request types, `BuilderDepositRequest`
+and `BuilderExitRequest`, and appends them as two lists to `ExecutionRequests`. Gloas
+therefore overrides the inherited Fulu `ExecutionRequests` (3 lists) with this 5-list
+version; the extra fields change its Merkle root, which cascades through `inherit` to
+everything that embeds it (`BeaconBlockBody.parentExecutionRequests`,
+`ExecutionPayloadEnvelope.executionRequests`). `DepositRequest` / `WithdrawalRequest`
+/ `ConsolidationRequest` are the Fulu types inherited in `Gloas.Inherited`.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Gloas
+
+/-- An execution-layer-triggered builder deposit (EIP-8282). -/
+forkcontainer BuilderDepositRequest where
+  pubkey                : BLSPubkey
+  withdrawalCredentials : Bytes32
+  amount                : Gwei
+  signature             : BLSSignature
+
+/-- An execution-layer-triggered builder exit (EIP-8282). -/
+forkcontainer BuilderExitRequest where
+  sourceAddress : ExecutionAddress
+  pubkey        : BLSPubkey
+
+/-- The execution requests bundled with a payload (Gloas / EIP-8282): the Electra
+three plus the two builder-request lists. -/
+forkcontainer ExecutionRequests where
+  deposits        : SSZList DepositRequest Const.maxDepositRequestsPerPayload
+  withdrawals     : SSZList WithdrawalRequest Const.maxWithdrawalRequestsPerPayload
+  consolidations  : SSZList ConsolidationRequest Const.maxConsolidationRequestsPerPayload
+  builderDeposits : SSZList BuilderDepositRequest Const.maxBuilderDepositRequestsPerPayload
+  builderExits    : SSZList BuilderExitRequest Const.maxBuilderExitRequestsPerPayload
+
+end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/PayloadAttestation.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Containers/PayloadAttestation.lean
@@ -1,4 +1,4 @@
-import EthCLSpecs.Gloas.Containers.BuilderPayment
+import EthCLSpecs.Gloas.Containers.ExecutionRequests
 
 /-!
 # `EthCLSpecs.Gloas.Containers.PayloadAttestation`: the payload-attestation family (EIP-7732)

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/EpochProcessing.lean
@@ -221,7 +221,7 @@ inherit processProposerLookahead
 
 /-! ## Gloas-new epoch substep (EIP-7732) -/
 
-/-- `process_builder_pending_payments` (v1.7.0-alpha.10): for each of the previous
+/-- `process_builder_pending_payments` (v1.7.0-alpha.11): for each of the previous
 epoch's pending payments whose weight clears the quorum threshold
 (`get_total_active_balance / SLOTS_PER_EPOCH * NUMERATOR / DENOMINATOR`, `>=`),
 queue its withdrawal directly; then shift the payment window down by
@@ -247,7 +247,7 @@ forkdef processBuilderPendingPayments : StateTransition Unit := do
       shiftWindow (sszGet state builderPendingPayments) Const.slotsPerEpoch Const.slotsPerEpoch
         (fun _ => empty)
 
-/-- `compute_ptc` (v1.7.0-alpha.10, EIP-7732): the payload-timeliness committee for
+/-- `compute_ptc` (v1.7.0-alpha.11, EIP-7732): the payload-timeliness committee for
 `slot`, with possible duplicates. Concatenate every beacon committee for the slot in
 order, then take a `PTC_SIZE` balance-weighted selection with no shuffle. The seed
 mixes `DOMAIN_PTC_ATTESTER` and the slot. -/
@@ -260,7 +260,7 @@ forkdef computePtc (state : State) (slot : Slot) : Vector ValidatorIndex Const.p
   let sel := computeBalanceWeightedSelection state indices seed Const.ptcSize false
   Vector.ofFn (fun i : Fin Const.ptcSize => sel[i.val]!)
 
-/-- `process_ptc_window` (v1.7.0-alpha.10, EIP-7732): shift the cached PTC window down
+/-- `process_ptc_window` (v1.7.0-alpha.11, EIP-7732): shift the cached PTC window down
 by `SLOTS_PER_EPOCH` and recompute the last epoch's per-slot PTCs from the snapshot
 state. The window length is `(2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH = 3 *
 SLOTS_PER_EPOCH` (MIN_SEED_LOOKAHEAD = 1). -/

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -5,7 +5,7 @@ import EthCLLib.Spec.FiniteMap
 /-!
 # `EthCLSpecs.Gloas.ForkChoice`: the EIP-7732 (ePBS) node-based fork choice
 
-The Gloas fork choice (`specs/gloas/fork-choice.md`, v1.7.0-alpha.10) replaces the
+The Gloas fork choice (`specs/gloas/fork-choice.md`, v1.7.0-alpha.11) replaces the
 phase0 root-walks with a `ForkChoiceNode = (root, payload_status)` abstraction: a
 block's two payload realisations (empty / full) and an undecided pending node are
 distinct fork-choice vertices, so `get_ancestor` / `is_ancestor` / `get_weight` /

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Inherited.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Inherited.lean
@@ -43,7 +43,6 @@ inherit Deposit
 inherit DepositRequest
 inherit Eth1Data
 inherit WithdrawalRequest
-inherit ExecutionRequests
 inherit Fork
 inherit HistoricalSummary
 inherit PendingConsolidation

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -31,7 +31,7 @@ namespace EthCLSpecs.Gloas.Interface
 
 /-- Pinned upstream release; Gloas tracks the same tag as Fulu while it is
 pre-release. -/
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
 
 /-- `stateRoot`: decode a Gloas `BeaconState` at preset `P` and take its root. -/
 private def stateRootImpl (P : Preset) (bytes : ByteArray) :
@@ -150,9 +150,10 @@ private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
     | .attesterSlashing       => (decodeOp (@AttesterSlashing P) opBytes).map processAttesterSlashing
     | .attestation            => (decodeOp (@Attestation P) opBytes).map processAttestation
     | .payloadAttestation     => (decodeOp (@PayloadAttestation P) opBytes).map processPayloadAttestation
-    -- The bid / parent-payload handlers decode a full `BeaconBlock`, not a single
-    -- operation container (the spec functions read `block.body` / `block.slot`).
-    | .executionPayloadBid    => (decodeOp (@BeaconBlock P) opBytes).map processExecutionPayloadBid
+    -- The parent-payload handler decodes a full `BeaconBlock` (it reads `block.body` /
+    -- `parentExecutionRequests`). alpha.11's bid handler takes the
+    -- `SignedExecutionPayloadBid` operand directly and reads slot / parent root from state.
+    | .executionPayloadBid    => (decodeOp (@SignedExecutionPayloadBid P) opBytes).map processExecutionPayloadBid
     | .parentExecutionPayload => (decodeOp (@BeaconBlock P) opBytes).map processParentExecutionPayload
     | .blockHeader            => (decodeOp (@BeaconBlock P) opBytes).map processBlockHeader
     -- `process_withdrawals` (Gloas) takes no operand; it runs purely from state.
@@ -373,6 +374,8 @@ private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
   | "BeaconState"                => runStatic (@Gloas.BeaconState P) typeName bytes
   | "BLSToExecutionChange"       => runStatic (@Gloas.BLSToExecutionChange P) typeName bytes
   | "Builder"                    => runStatic (@Gloas.Builder P) typeName bytes
+  | "BuilderDepositRequest"      => runStatic (@Gloas.BuilderDepositRequest P) typeName bytes
+  | "BuilderExitRequest"         => runStatic (@Gloas.BuilderExitRequest P) typeName bytes
   | "BuilderPendingPayment"      => runStatic (@Gloas.BuilderPendingPayment P) typeName bytes
   | "BuilderPendingWithdrawal"   => runStatic (@Gloas.BuilderPendingWithdrawal P) typeName bytes
   | "Checkpoint"                 => runStatic (@Gloas.Checkpoint P) typeName bytes

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
@@ -40,6 +40,12 @@ inherit processBlockHeader
 inherit processBlsToExecutionChange
 inherit processWithdrawalRequest
 inherit processConsolidationRequest
+-- alpha.11 reverted the Gloas `process_deposit_request` and `process_voluntary_exit`
+-- overrides: builder onboarding / exit moved to the dedicated EIP-8282
+-- `process_builder_deposit_request` / `process_builder_exit_request`, so a `DepositRequest`
+-- is just queued and a builder-index `VoluntaryExit` is rejected by the inherited handlers.
+inherit processDepositRequest
+inherit processVoluntaryExit
 inherit processSyncAggregate
 
 /-! ## Builder-registry helpers (EIP-7732) -/
@@ -78,7 +84,9 @@ state's queue (`process_deposit_request`) or an in-progress accumulator
 forkdef isPendingValidator (pendingDeposits : Array PendingDeposit) (pubkey : BLSPubkey) : Bool :=
   pendingDeposits.any fun d =>
     d.pubkey == pubkey && isValidDepositSignature d.pubkey d.withdrawalCredentials d.amount d.signature
-/-- `initiate_builder_exit`. -/
+/-- `initiate_builder_exit`. Retained for the deferred EIP-8282
+`process_builder_exit_request` (alpha.11 moved builder exits off `process_voluntary_exit`
+to this EL-triggered path); not yet wired, so it currently has no caller. -/
 forkdef initiateBuilderExit (builderIndex : BuilderIndex) : StateTransition Unit := do
   let epoch := currentEpochOf (← get)
   modifyState fun state =>
@@ -90,23 +98,25 @@ forkdef getIndexForNewBuilder (state : State) : BuilderIndex := Id.run do
   for i in [0:bs.size] do
     if (bs[i]?.getD default).withdrawableEpoch ≤ epoch && (bs[i]?.getD default).balance == 0 then return UInt64.ofNat i
   return UInt64.ofNat bs.size
-/-- `add_builder_to_registry` (set-or-append at the recyclable index). -/
-forkdef addBuilderToRegistry (pubkey : BLSPubkey) (wc : Bytes32) (amount : Gwei) (slot : Slot) :
-    StateTransition Unit := do
+/-- `withdrawal_credentials[12:]` as a 20-byte execution address. -/
+private def addressOfCred (wc : Bytes32) : ExecutionAddress := Vector.ofFn (fun i : Fin 20 => wc[12 + i.val])
+
+/-- `add_builder_to_registry` (EIP-8282): set-or-append a `Builder` at the recyclable
+index with the supplied `version` / `executionAddress`. -/
+forkdef addBuilderToRegistry (pubkey : BLSPubkey) (version : UInt8) (executionAddress : ExecutionAddress)
+    (amount : Gwei) (slot : Slot) : StateTransition Unit := do
   let state ← get
   let idx := (getIndexForNewBuilder state).toNat
   let b : Builder :=
-    { pubkey, version := credPrefix wc, executionAddress := addressOfCred wc, balance := amount,
+    { pubkey, version, executionAddress, balance := amount,
       depositEpoch := computeEpochAtSlot slot, withdrawableEpoch := Const.farFutureEpoch }
   modifyState fun state =>
     if idx < (sszGet state builders).size then
       sszUpdate state with builders[idx]! := b
     else sszAppend state builders b
-where
-  /-- `withdrawal_credentials[12:]` as a 20-byte execution address. -/
-  addressOfCred (wc : Bytes32) : ExecutionAddress := Vector.ofFn (fun i : Fin 20 => wc[12 + i.val])
-/-- `apply_deposit_for_builder`: top up an existing builder, or add a new one with a
-valid proof-of-possession. -/
+/-- `apply_deposit_for_builder` (retained as a helper; the spec inlines it into
+`onboard_builders_from_pending_deposits`): top up an existing builder, or add a new one
+with a valid proof-of-possession, stamped `PAYLOAD_BUILDER_VERSION`. -/
 forkdef applyDepositForBuilder (pubkey : BLSPubkey) (wc : Bytes32) (amount : Gwei)
     (sig : BLSSignature) (slot : Slot) : StateTransition Unit := do
   let state ← get
@@ -114,7 +124,8 @@ forkdef applyDepositForBuilder (pubkey : BLSPubkey) (wc : Bytes32) (amount : Gwe
   | some builderIndex => modifyState fun state =>
       sszModify state builders[builderIndex]! as b => { b with balance := b.balance + amount }
   | none =>
-    if isValidDepositSignature pubkey wc amount sig then addBuilderToRegistry pubkey wc amount slot
+    if isValidDepositSignature pubkey wc amount sig then
+      addBuilderToRegistry pubkey Const.payloadBuilderVersion (addressOfCred wc) amount slot
 
 /-- `onboard_builders_from_pending_deposits`: at the fork, drain the pending-deposit
 queue, applying builder deposits (existing builder pubkey, or a builder-credential
@@ -142,48 +153,6 @@ forkdef onboardBuildersFromPendingDeposits : StateTransition Unit := do
 
 /-! ## Gloas-modified operations -/
 
-/-- `process_voluntary_exit` (Gloas): a builder-index exit branch precedes the
-validator path. -/
-forkdef processVoluntaryExit (sve : SignedVoluntaryExit) : StateTransition Unit := do
-  let state ← get
-  let ve := sve.message
-  let domain := computeDomain Const.domainVoluntaryExit Const.capellaForkVersion (sszGet state genesisValidatorsRoot)
-  let signingRoot := computeSigningRoot ve domain
-  assert (currentEpochOf state ≥ ve.epoch)
-
-  if isBuilderIndex ve.validatorIndex then
-    let builderIndex := toBuilderIndex ve.validatorIndex
-    let hb ← assertH (builderIndex.toNat < (sszGet state builders).size)
-    assert (isActiveBuilder state builderIndex)
-    assert (getPendingBalanceToWithdrawForBuilder state builderIndex == 0)
-    let pubkey := ((sszGet state builders)[builderIndex.toNat]'hb.down).pubkey
-    assert (blsVerify pubkey signingRoot sve.signature)
-    initiateBuilderExit builderIndex
-  else
-    let hb ← assertH (ve.validatorIndex.toNat < (sszGet state validators).size)
-    let validator := (sszGet state validators)[ve.validatorIndex.toNat]'hb.down
-    assert (isActiveValidator validator (currentEpochOf state))
-    assert (hasNotInitiatedExit validator)
-    assert (passedShardCommitteePeriod validator (currentEpochOf state))
-    assert (getPendingBalanceToWithdraw state ve.validatorIndex == 0)
-    assert (blsVerify validator.pubkey signingRoot sve.signature)
-    initiateValidatorExit ve.validatorIndex
-
-/-- `process_deposit_request` (Gloas): a builder deposit (builder pubkey, or a
-builder-credential deposit for a not-yet-known validator) applies immediately;
-otherwise the deposit is queued. -/
-forkdef processDepositRequest (dr : DepositRequest) : StateTransition Unit := do
-  let state ← get
-  let isBuilder := (sszGet state builders).any (·.pubkey == dr.pubkey)
-  let isValidator := (sszGet state validators).any (·.pubkey == dr.pubkey)
-  if isBuilder || (isBuilderWithdrawalCredential dr.withdrawalCredentials && !isValidator
-      && !isPendingValidator (sszGet state pendingDeposits).toArray dr.pubkey) then
-    applyDepositForBuilder dr.pubkey dr.withdrawalCredentials dr.amount dr.signature (sszGet state slot)
-  else
-    modifyState fun state => sszAppend state pendingDeposits
-      { pubkey := dr.pubkey, withdrawalCredentials := dr.withdrawalCredentials, amount := dr.amount,
-        signature := dr.signature, slot := sszGet state slot }
-
 /-- `process_proposer_slashing` (Gloas): Fulu's checks and `slash_validator`, plus
 the EIP-7732 step that voids the slashed proposal's `BuilderPendingPayment` if it
 is still in the two-epoch payment window. -/
@@ -203,17 +172,19 @@ forkdef processProposerSlashing (ps : ProposerSlashing) : StateTransition Unit :
   assert (blsVerifySigned proposer.pubkey h2
     (getDomain state Const.domainBeaconProposer (computeEpochAtSlot h2.slot)) ps.signedHeader2.signature)
 
-  -- Void the slashed proposal's pending payment if it is still in the two-epoch window.
-  -- The SSZ zero value: `default` is field-wise `default`, the all-zero container, so this
-  -- clears the slot without restating the literal.
+  -- Void the slashed proposal's pending payment only if it is still in the two-epoch
+  -- window AND the recorded payment belongs to this proposer (EIP-8282). `default` is
+  -- the all-zero `BuilderPendingPayment`, so this clears the slot without restating it.
   let empty : BuilderPendingPayment := default
   let proposalEpoch := computeEpochAtSlot h1.slot
   if proposalEpoch == currentEpochOf state then
-    modifyState fun state =>
-      sszUpdate state with builderPendingPayments[builderPaymentIndex h1.slot true]! := empty
+    let idx := builderPaymentIndex h1.slot true
+    if ((sszGet state builderPendingPayments)[idx]!).proposerIndex == h1.proposerIndex then
+      modifyState fun state => sszUpdate state with builderPendingPayments[idx]! := empty
   else if proposalEpoch == previousEpochOf state then
-    modifyState fun state =>
-      sszUpdate state with builderPendingPayments[builderPaymentIndex h1.slot false]! := empty
+    let idx := builderPaymentIndex h1.slot false
+    if ((sszGet state builderPendingPayments)[idx]!).proposerIndex == h1.proposerIndex then
+      modifyState fun state => sszUpdate state with builderPendingPayments[idx]! := empty
 
   slashValidator h1.proposerIndex
 
@@ -334,7 +305,7 @@ where
         return (okAcc && attesters > 0, off + committee.size))
       (true, 0)
 
-/-- `get_ptc` (v1.7.0-alpha.10): read the cached PTC for `slot` from `ptc_window`.
+/-- `get_ptc` (v1.7.0-alpha.11): read the cached PTC for `slot` from `ptc_window`.
 For a slot in the previous epoch the window's first `SLOTS_PER_EPOCH` entries hold
 it; otherwise an `(epoch - state_epoch + 1) * SLOTS_PER_EPOCH` offset applies. The
 spec asserts the slot is within `[state_epoch-1, state_epoch + MIN_SEED_LOOKAHEAD]`;
@@ -418,36 +389,41 @@ forkdef settleBuilderPayment (paymentIndex : Nat) : StateTransition Unit := do
   modifyState fun state =>
     sszUpdate state with builderPendingPayments[paymentIndex]! := empty
 
-/-- `process_execution_payload_bid` (NEW, EIP-7732): validate the signed bid (self-build
-sentinel or an active, funded, correctly-signed builder), check it commits to the right
-slot / parent / randao, record the `BuilderPendingPayment`, and cache the bid. -/
-forkdef processExecutionPayloadBid (block : BeaconBlock) : StateTransition Unit := do
+/-- `process_execution_payload_bid` (EIP-7732, alpha.11 signature): validate the signed
+bid (self-build sentinel, or an active, payload-builder-versioned, funded, correctly-signed
+builder), check it commits to the current slot / parent / randao, record the
+`BuilderPendingPayment`, and cache the bid. alpha.11 takes the `SignedExecutionPayloadBid`
+directly (not a `BeaconBlock`) and reads the slot / parent root from state. -/
+forkdef processExecutionPayloadBid (signedBid : SignedExecutionPayloadBid) : StateTransition Unit := do
   let state ← get
-  let signedBid := block.body.signedExecutionPayloadBid
   let bid := signedBid.message
   let builderIndex := bid.builderIndex
   let amount := bid.value
 
-  -- A self-build sentinel carries no value or signature; a real builder must be
-  -- active, funded, and the signer of the bid.
+  -- A self-build sentinel carries no value or signature; a real builder must be active,
+  -- a payload builder (`PAYLOAD_BUILDER_VERSION`), funded, and the signer of the bid.
   if builderIndex == Const.builderIndexSelfBuild then
     assert (amount == 0)
     assert (signedBid.signature == Const.g2PointAtInfinity)
   else
     assert (isActiveBuilder state builderIndex)
+    assert ((sszGet state builders[builderIndex.toNat]!).version == Const.payloadBuilderVersion)
     assert (canBuilderCoverBid state builderIndex amount)
     assert (verifyExecutionPayloadBidSignature state signedBid)
 
   assert (bid.blobKzgCommitments.size ≤ Const.maxBlobsPerBlockElectra)
-  assert (bid.slot == block.slot)
+  assert (bid.slot == sszGet state slot)
+  assert ((sszGet state slot) > Const.genesisSlot)
   assert (bid.parentBlockHash == sszGet state latestBlockHash)
-  assert (bid.parentBlockRoot == block.parentRoot)
+  assert (bid.parentBlockRoot == getBlockRootAtSlot state ((sszGet state slot) - 1))
   let randaoMix ← getRandaoMix (currentEpochOf state)
   assert (bid.prevRandao == randaoMix)
 
   if amount > 0 then
     let pending : BuilderPendingPayment :=
-      { weight := 0, withdrawal := { feeRecipient := bid.feeRecipient, amount := amount, builderIndex := builderIndex } }
+      { weight := 0,
+        withdrawal := { feeRecipient := bid.feeRecipient, amount := amount, builderIndex := builderIndex },
+        proposerIndex := getBeaconProposerIndex state }
     modifyState fun state =>
       sszUpdate state with builderPendingPayments[builderPaymentIndex bid.slot true]! := pending
 
@@ -465,6 +441,10 @@ forkdef applyParentExecutionPayload (requests : ExecutionRequests) : StateTransi
   for d in requests.deposits do processDepositRequest d
   for w in requests.withdrawals do processWithdrawalRequest w
   for c in requests.consolidations do processConsolidationRequest c
+  -- Deferred: EIP-8282 builder-deposit / builder-exit request processing is not yet
+  -- ported; a non-empty list xfails the runner (todo) rather than diverging the root.
+  unless requests.builderDeposits.size == 0 && requests.builderExits.size == 0 do
+    throw (StateTransitionError.todo "gloas builder_deposit/builder_exit processing: EIP-8282 not yet ported")
 
   -- Settle the parent's payment if it is still in the two-epoch window; outside it,
   -- queue any remaining value directly as a builder withdrawal.

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/State.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/State.lean
@@ -3,7 +3,7 @@ import EthCLSpecs.Gloas.Containers.Execution
 /-!
 # `EthCLSpecs.Gloas.State`: the Gloas `BeaconState` and its boxed view (EIP-7732)
 
-The Gloas `BeaconState` (v1.7.0-alpha.10, 46 fields), then the `State` abbrev that
+The Gloas `BeaconState` (v1.7.0-alpha.11, 46 fields), then the `State` abbrev that
 views it as an SSZ box. The eth1 fields remain; `latestExecutionPayloadHeader` is
 dropped (its slot now holds `latestBlockHash`), and the ePBS block is appended
 after `proposerLookahead`. The unchanged component containers are Fulu's
@@ -17,7 +17,7 @@ open EthCLSpecs.Fulu
 
 namespace EthCLSpecs.Gloas
 
-/-- The Gloas `BeaconState` (v1.7.0-alpha.10, 46 fields). The eth1 fields remain;
+/-- The Gloas `BeaconState` (v1.7.0-alpha.11, 46 fields). The eth1 fields remain;
 `latestExecutionPayloadHeader` is dropped (its slot now holds `latestBlockHash`),
 and the ePBS block is appended after `proposerLookahead`. The unchanged component
 containers are Fulu's. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Transition.lean
@@ -99,7 +99,7 @@ forkdef processBlock (block : BeaconBlock) : StateTransition Unit := do
   processParentExecutionPayload block
   processBlockHeader block
   processWithdrawals
-  processExecutionPayloadBid block
+  processExecutionPayloadBid block.body.signedExecutionPayloadBid
   processRandao block.body
   processEth1Data block.body
   processOperations block.body

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Upgrade.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Upgrade.lean
@@ -9,7 +9,7 @@ import EthCLSpecs.Fulu.Committees
 Gloas one, so it lives in Gloas and names both forks. It is the `fork` vector
 format's entry point.
 
-Ported verbatim from the v1.7.0-alpha.10 `specs/gloas/fork.md`: common fields carry
+Ported verbatim from the v1.7.0-alpha.11 `specs/gloas/fork.md`: common fields carry
 across (the unchanged component containers are reused, so the copies are
 direct, no conversion); the fork version bumps (`previous := pre.fork.current`,
 `current := GLOAS_FORK_VERSION`, `epoch := get_current_epoch(pre)`);
@@ -132,7 +132,7 @@ def upgradeToGloas [Preset] [HasherTag] (gloasForkVersion : Version) (pre : Fulu
       { (default : Gloas.ExecutionPayloadBid) with
           blockHash             := pre.latestExecutionPayloadHeader.blockHash
           gasLimit              := pre.latestExecutionPayloadHeader.gasLimit
-          executionRequestsRoot := htr (default : Fulu.ExecutionRequests) }
+          executionRequestsRoot := htr (default : Gloas.ExecutionRequests) }
     nextWithdrawalIndex           := pre.nextWithdrawalIndex
     nextWithdrawalValidatorIndex  := pre.nextWithdrawalValidatorIndex
     historicalSummaries           := pre.historicalSummaries.mapCap cvHistoricalSummary

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -26,7 +26,7 @@ import yaml
 # The pinned release: the latest consensus-specs release, confirmed to
 # carry both Fulu and Gloas minimal vectors (matches
 # EthCLSpecs.Fulu.Interface.pyspecPinnedVersion).
-PINNED_VERSION = "v1.7.0-alpha.10"
+PINNED_VERSION = "v1.7.0-alpha.11"
 CACHE_DIR = Path.home() / ".cache" / "sizzlean"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -58,7 +58,7 @@ forkdef processBlock (block : BeaconBlock) : StateTransition Unit := do
   processParentExecutionPayload block
   processBlockHeader block
   processWithdrawals
-  processExecutionPayloadBid block
+  processExecutionPayloadBid block.body.signedExecutionPayloadBid
   processRandao block.body
   processEth1Data block.body
   processOperations block.body

--- a/packages/EthCLSpecs/lakefile.toml
+++ b/packages/EthCLSpecs/lakefile.toml
@@ -3,7 +3,9 @@ defaultTargets = ["EthCLSpecs"]
 
 # Re-supply the system libcrypto flag (does not propagate across `require`); the
 # blst / c-kzg archives propagate transitively from the LeanHazmat packages.
-moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-l:libcrypto.so.3"]
+# Two `-L` paths cover the common Linux libdir layouts (Debian multiarch and
+# `/usr/lib64` on Gentoo / Fedora / RHEL); the linker ignores whichever is absent.
+moreLinkArgs = ["-L/usr/lib/x86_64-linux-gnu", "-L/usr/lib64", "-l:libcrypto.so.3"]
 moreLeancArgs = ["-march=native"]
 
 # The framework. Pulls in SizzLean (SSZ), LeanHazmatBls / LeanHazmatKzg (crypto)


### PR DESCRIPTION
Stacked on #4, which is the base of this branch. Until #4 merges the diff here
shows both commits (the libcrypto build fix from #4 plus the Gloas work); it
drops to just the Gloas commit once #4 lands.

This re-pins EthCLSpecs from consensus-specs v1.7.0-alpha.10 to v1.7.0-alpha.11
and brings Gloas up to the alpha.11 shape. I want it in mainly as the base for the
Heze (EIP-7805 FOCIL) work I'm doing next, which stacks on top of this.

One caveat up front: I'm not sure whether anyone else has already started the
alpha.11 Gloas update. If someone has a better implementation going I'm happy to
rebase onto it or step aside, just say so.

## EIP-8282 (builder deposits / exits)

New `BuilderDepositRequest` / `BuilderExitRequest` containers, two more lists on
`ExecutionRequests` (`builder_deposits`, `builder_exits`), a `proposer_index`
field on `BuilderPendingPayment`, and the matching constants.

## Keep-green for the alpha.11 spec diff

The conformance run surfaced two changes the spec text didn't telegraph:
- `process_execution_payload_bid` now takes the signed bid directly and reads slot
  and parent root from state, with a payload-builder-version check.
- `process_deposit_request` and `process_voluntary_exit` fall back to the inherited
  handlers; builder onboarding and exit moved to the dedicated EL-triggered requests.
- `process_proposer_slashing` only clears a builder payment it actually owns, and
  the fork bid root uses the 5-list `ExecutionRequests`.

## Deferred

EIP-8282 builder-deposit/exit operation *processing* is still xfail. Follow-up,
not wired here yet.

## Conformance

gloas minimal: 6542 passed, 0 failed. fulu: 152p/44xf (unchanged). gloas mainnet:
1003 passed, 0 failed (161 xfail).

