### PR TITLE
feat(ethclspecs): add Heze (EIP-7805 FOCIL) for v1.7.0-alpha.11

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,11 @@
 #
 # The pyspec recipes need a Python venv. Run `just setup-python` once first.
 
+# xdist worker count for the full pyspec sweeps; `auto` (one per core) is the
+# historical default. Override on memory-constrained machines:
+# `PYTEST_JOBS=2 just ethcl-pyspec-full`.
+pytest_jobs := env_var_or_default("PYTEST_JOBS", "auto")
+
 # List every recipe with its description
 default:
     @just --list --unsorted
@@ -251,24 +256,27 @@ ethcl-pyspec args="": _ensure-venv
 # xfail as the Phase-2 work-queue, so the run is green (exit 0) iff no in-scope
 # vector hits a bug-smell or a real mismatch. Mainnet / full sweep run on demand.
 
-# CI smoke gate: EthCLSpecs pyspec dev subset for both forks at minimal
+# CI smoke gate: EthCLSpecs pyspec dev subset for all three forks at minimal
 [group('ethcl')]
 ethcl-pyspec-smoke: _ensure-venv
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=fulu --subset=2
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=gloas --subset=2
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=heze --subset=2
 
 # The complete in-scope sweep: every collected vector (`--subset=0`) for the
-# full matrix of {fulu, gloas} × {minimal, mainnet}, sharded across cores. The
-# two minimal forks finish quickly; the two mainnet forks are the long poles
+# full matrix of {fulu, gloas, heze} × {minimal, mainnet}, sharded across cores. The
+# three minimal forks finish quickly; the three mainnet forks are the long poles
 # (real-size SSZ + crypto). Each xdist worker holds its own warm `pyspec_server`.
 
-# Full EthCLSpecs pyspec sweep: {fulu,gloas} × {minimal,mainnet}, sharded across cores
+# Full EthCLSpecs pyspec sweep: {fulu,gloas,heze} × {minimal,mainnet}, sharded across cores
 [group('ethcl')]
 ethcl-pyspec-full: _ensure-venv
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=minimal --fork=fulu
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=minimal --fork=gloas
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=mainnet --fork=fulu
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=mainnet --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=fulu
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=heze
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=fulu
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=heze
 
 # ═════════════════════════════════════════════════════════════════════════
 # SizzLean — SSZ library

--- a/Justfile
+++ b/Justfile
@@ -229,7 +229,7 @@ _ensure-venv:
     fi
 
 # ═════════════════════════════════════════════════════════════════════════
-# EthCLSpecs — consensus-spec framework + Fulu / Gloas fork bodies
+# EthCLSpecs — consensus-spec framework + Fulu / Gloas / Heze fork bodies
 #
 # EthCLLib + EthCLSpecs (the consensus-spec framework + Fulu/Gloas bodies). The
 # `*Tests` libs carry the framework + spec `#guard` / `native_decide` self-tests
@@ -237,7 +237,7 @@ _ensure-venv:
 # building them fires the gates.
 # ═════════════════════════════════════════════════════════════════════════
 
-# EthCLLib + EthCLSpecs self-tests (framework + Fulu/Gloas spec gates)
+# EthCLLib + EthCLSpecs self-tests (framework + fork spec gates)
 [group('ethcl')]
 ethcl-test:
     lake build EthCLLib EthCLLibTests EthCLSpecs EthCLSpecsTests
@@ -252,7 +252,7 @@ ethcl-pyspec args="": _ensure-venv
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q {{ args }}
 
 # CI smoke gate for EthCLSpecs pyspec: the dev subset (a few cases per
-# handler) at minimal for both forks. Currently-green formats pass; the rest
+# handler) at minimal for all three forks. Currently-green formats pass; the rest
 # xfail as the Phase-2 work-queue, so the run is green (exit 0) iff no in-scope
 # vector hits a bug-smell or a real mismatch. Mainnet / full sweep run on demand.
 
@@ -288,7 +288,7 @@ ethcl-pyspec-full: _ensure-venv
 # boolean, the test-only containers); the EIP-7495 / 7916 / 8016 progressive /
 # stable / compatible forms are out of `SizzLean`'s universe and xfail. The
 # per-fork consensus-container `ssz_static` vectors run inside the EthCLSpecs
-# `ethcl-pyspec*` recipes (Fulu + Gloas), not here.
+# `ethcl-pyspec*` recipes (the fork bodies), not here.
 # ═════════════════════════════════════════════════════════════════════════
 
 # `SizzLeanTests.PendingListShrink` Cases 4/5/7 deliberately drive

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Upstream repository: <https://github.com/etheorem/etheorem>.
 ```
 LeanSha256 ─────────────┐
                         ├─→ SizzLean ──→ EthCLLib ──→ EthCLSpecs
-LeanHazmatSha256 ───────┘   (SSZ +       (consensus    (Fulu / Gloas
+LeanHazmatSha256 ───────┘   (SSZ +       (consensus    (Fulu…Heze
    (FFI SHA-256)            cache)        framework)    fork bodies)
 
 LeanHazmat* (FFI crypto family):  Sha256 · Bls · Kzg   (consumed à la carte)
@@ -40,10 +40,10 @@ independent build target:
 - **[`packages/EthCLLib/`](packages/EthCLLib/)** +
   **[`packages/EthCLSpecs/`](packages/EthCLSpecs/README.md)**: the
   consensus-spec framework (the fork-authoring DSL, the effect monad, the SSZ
-  container front-end, the pyspec driver) and the executable Fulu and
-  Gloas fork bodies built on it. EthCLSpecs declares its containers in-spec and
+  container front-end, the pyspec driver) and the executable Fulu, Gloas,
+  and Heze fork bodies built on it. EthCLSpecs declares its containers in-spec and
   ships the `pyspec_server` runner that drives the state-transition,
-  fork-choice, and `ssz_static` pyspec runs for both forks.
+  fork-choice, and `ssz_static` pyspec runs for all three forks.
 - **[`packages/LeanSha256/`](packages/LeanSha256/README.md)**: pure-Lean
   SHA-256 reference. NIST CAVP-validated, kernel-reducible. No FFI.
 - **[`packages/SizzLean/`](packages/SizzLean/README.md)**: SSZ
@@ -84,12 +84,13 @@ pure-Lean `Sha256Spec` reference, and the cache layer
 gindex-driven `setManyAt`, fused commit `Node.commitAndHash`,
 closure-based pending overlay, `sszUpdate` macro,
 `SSZ.Box` user surface) are all landed. The executable consensus
-spec covers the Fulu and Gloas forks (state transition, fork choice,
-and the SSZ containers declared in-spec, including Fulu's
-`proposer_lookahead` and the Gloas ePBS additions: the nine EIP-7732
-`BeaconState` fields plus the `Builder` / `ExecutionPayloadBid` types).
+spec covers the Fulu, Gloas, and Heze forks (state transition, fork
+choice, and the SSZ containers declared in-spec, including Fulu's
+`proposer_lookahead`, the Gloas ePBS additions: the nine EIP-7732
+`BeaconState` fields plus the `Builder` / `ExecutionPayloadBid` types,
+and Heze's EIP-7805 FOCIL inclusion-list layer).
 Pyspec pinned at consensus-spec-tests
-[v1.7.0-alpha.10](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.10)
+[v1.7.0-alpha.11](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.11)
 in the pytest harnesses. The universal proof set
 (`decode_encode`, `serialize_injective`, `encode_size_le_max`
 over `SSZType.Supported`) and the AVX-512 SIMD inner loop for
@@ -108,7 +109,7 @@ Per-subpackage design docs live next to the code they describe:
   [`FRAMEWORK_ARCHITECTURE.md`](packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md)
   (the EthCLLib framework and fork-authoring DSL), and
   [`SPECS_ARCHITECTURE.md`](packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md)
-  (how the Fulu and Gloas specs are organized, ported, and tested).
+  (how the fork specs are organized, ported, and tested).
   [`PLAN.md`](packages/EthCLSpecs/docs/PLAN.md) sequences the
   implementation phases; `IMPLEMENTATION_NOTES.md`, `DISCREPANCIES.md`,
   and `FUTURE_WORK.md` track deviations, spec disagreements, and
@@ -188,7 +189,7 @@ Toolchain pinned in [`lean-toolchain`](lean-toolchain) (elan picks it up).
 
 ```bash
 # From the repo root — common targets by name:
-lake build EthCLSpecs       # consensus spec (Fulu / Gloas); pulls in EthCLLib + SizzLean
+lake build EthCLSpecs       # consensus spec (Fulu / Gloas / Heze); pulls in EthCLLib + SizzLean
 lake build SizzLean         # SSZ library (serialize / deserialize / Merkleization)
 lake build LeanSha256       # pure-Lean SHA-256 reference
 lake build LeanPoseidon     # standalone Poseidon2 island (fires its anchor KAT)
@@ -257,7 +258,7 @@ Two `pytest-xdist` harnesses drive long-lived Lean servers against the
 server, so there is no per-vector Lean startup.
 
 - **EthCLSpecs** (`packages/EthCLSpecs/PySpecTests/`, the `pyspec_server`
-  runner): the Fulu and Gloas state transition, fork choice, and per-fork
+  runner): the Fulu, Gloas, and Heze state transition, fork choice, and per-fork
   `ssz_static` container vectors.
 - **SizzLean** (`packages/SizzLean/PySpecTests/`, the `ssz_generic_runner`):
   the fork-agnostic `ssz_generic` wire-format suite (uints, basic vectors,
@@ -269,18 +270,18 @@ server, so there is no per-vector Lean startup.
 just setup-python
 
 # Dev-subset smoke gates (a few cases per handler):
-just ethcl-pyspec-smoke         # Fulu + Gloas: transition / fork choice / ssz_static
+just ethcl-pyspec-smoke         # all three forks: transition / fork choice / ssz_static
 just sizzlean-pyspec-smoke   # ssz_generic
 
 # Full sweeps:
-just ethcl-pyspec-full               # both presets, both forks
+just ethcl-pyspec-full               # both presets, all three forks
 just sizzlean-pyspec-full    # every in-scope wire-format vector
 ```
 
 ### Coverage
 
 Pinned at consensus-spec-tests
-[v1.7.0-alpha.10](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.10).
+[v1.7.0-alpha.11](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.11).
 
 - **`ssz_generic`** (SizzLean): 2188 in-scope cases pass across every handler
   (uints, basic_vector, bitvector, bitlist, boolean, containers). The 292
@@ -288,7 +289,8 @@ Pinned at consensus-spec-tests
   SizzLean's `SSZType` universe and xfail. The test-only container shapes
   (`VarTestStruct`, `ComplexTestStruct`, `BitsStruct`, …) are hard-coded in
   `packages/SizzLean/SszGenericRunner.lean`.
-- **`ssz_static`** (EthCLSpecs, Fulu + Gloas): the consensus containers
+- **`ssz_static`** (EthCLSpecs, Gloas + Heze; Fulu's containers ride on
+  SizzLean's own suites): the consensus containers
   EthCLSpecs models pass at both the minimal and mainnet presets; the types it
   does not model (light-client, gossip-aggregation, networking identifiers,
   signing helpers) xfail as out of scope. Earlier forks (Phase 0 through

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -68,8 +68,8 @@ structure CaseMeta where
 
 /-- One step of a `fork_choice` vector's `steps.yaml`, decoded by the runner.
 `checks` carries the expected store values to compare; `unsupported` marks a step
-the runner does not model (a `get_proposer_head` / `should_override` check), so the
-case is reported out-of-scope rather than falsely passing. -/
+the runner does not model (a `should_override` check, an unrecognized key), so the
+case reports `todo` (an xfail) rather than falsely passing. -/
 inductive FcStep where
   /-- `{tick: t}`: advance the store clock to absolute time `t` (seconds). -/
   | tick (time : Nat)
@@ -112,8 +112,8 @@ inductive FcStep where
   | checkTime (t : Nat)
   /-- `checks.genesis_time`. -/
   | checkGenesisTime (t : Nat)
-  /-- A check the runner does not model (`get_proposer_head` /
-  `should_override_forkchoice_update`); the case is out-of-scope. -/
+  /-- A check the runner does not model (`should_override_forkchoice_update`, an
+  unrecognized step or check key); the case reports `todo`, an xfail. -/
   | unsupported (reason : String)
   deriving Inhabited
 
@@ -271,7 +271,7 @@ class ForkInterface where
   block, fold the `steps`, and verify each `checks` step. `.ok` ⇒ every check
   matched; `.error e` carries a `RunError StoreTransitionError` the harness
   classifies: a `.decode` is a likely bug, and a wrapped `.spec` reject classifies
-  by its constructor (`.todo` an out-of-scope deferral, `.assert` an expected
+  by its constructor (`.todo` an unmodeled-branch xfail, `.assert` an expected
   rejection, `.missingKey` / a wrapped `.outOfBounds` a likely bug). Drives
   `fork_choice/*`. -/
   runForkChoice : ByteArray → ByteArray → Array FcStep → Except (RunError StoreTransitionError) Unit

--- a/packages/EthCLLib/EthCLLib/Spec.lean
+++ b/packages/EthCLLib/EthCLLib/Spec.lean
@@ -9,6 +9,7 @@ import EthCLLib.Spec.Assert
 import EthCLLib.Spec.Header
 import EthCLLib.Spec.Forms
 import EthCLLib.Spec.Crypto
+import EthCLLib.Spec.Engine
 
 /-!
 # `EthCLLib.Spec`: the author-facing surface

--- a/packages/EthCLLib/EthCLLib/Spec/Engine.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Engine.lean
@@ -1,0 +1,55 @@
+/-!
+# `EthCLLib.Spec.Engine`: the `[ExecutionEngine]` seam
+
+The spec's `ExecutionEngine` predicates are Engine-API calls answered by an
+external execution layer, so their verdicts are EL-implementation-defined and
+cannot be modeled as fixed values without hiding the trust boundary. Like
+`[CryptoBackend]` one file over, this seam lets a consumer swap the backend at
+the call boundary: the default instance below is the optimistic always-`true`
+mock (every conformance path stays on the accepting branch with no call-site
+change), and a test supplies a refuting local instance to drive the
+discriminating `false` branch.
+
+Unlike `CryptoBackend`, whose currency is raw `ByteArray` wire buffers, the
+engine predicates take the fork's own SSZ types. `ExecutionPayload` is a
+fork-namespaced twin (nominally distinct per fork); `Transaction` is today a
+single shared abbrev, parameterized here anyway so a fork that ever twins it
+needs no seam change. The class is generic over both; the optimistic instance
+is generic too, so every fork resolves it without per-fork glue, and a local
+`letI` at one fork's concrete types overrides it where a test needs the
+refuting branch.
+
+One deliberate difference from `CryptoBackend`: that seam ships named backends
+(`ffi` / `verifyOff` / `symbolic`) a consumer must inject, so a forgotten
+injection is a compile error; this one registers the optimistic mock as a
+global instance, so every conformance path works with zero wiring. The cost is
+that a consumer wiring a real EL verdict must remember the local override,
+nothing forces it.
+
+Heze's FOCIL gate (`is_inclusion_list_satisfied`) is the first consumer.
+Gloas's engine predicates (`verify_and_notify_new_payload`,
+`is_data_available`) are still modeled as inline constants and can migrate
+here as a follow-up.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Spec
+
+/-- The execution-layer seam: `ExecutionEngine` predicates whose verdict an
+external EL owns. Generic over the fork's payload / transaction types (they are
+fork-namespaced or shared types a framework class cannot name concretely). -/
+class ExecutionEngine (Payload : Type) (Tx : Type) where
+  /-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
+  (EIP-7805): whether the payload includes the required inclusion-list
+  transactions. Body is EL-implementation-defined. -/
+  isInclusionListSatisfied : Payload → Array Tx → Bool
+
+/-- The default engine: the optimistic always-`true` mock, the residual EL trust
+boundary of every engine-gated spec branch. Generic, so it serves every fork; a
+consumer wanting a real (or refuting) verdict overrides `[ExecutionEngine]`
+locally with a `letI` at the concrete fork types. -/
+instance instExecutionEngineOptimistic {Payload Tx : Type} : ExecutionEngine Payload Tx where
+  isInclusionListSatisfied _ _ := true
+
+end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/Engine.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Engine.lean
@@ -2,19 +2,20 @@
 # `EthCLLib.Spec.Engine`: the `[ExecutionEngine]` seam
 
 The spec's `ExecutionEngine` predicates are Engine-API calls answered by an
-external execution layer, so their verdicts are EL-implementation-defined and
-cannot be modeled as fixed values without hiding the trust boundary. Like
-`[CryptoBackend]` one file over, this seam lets a consumer swap the backend at
-the call boundary: the default instance below is the optimistic always-`true`
-mock (every conformance path stays on the accepting branch with no call-site
-change), and a test supplies a refuting local instance to drive the
-discriminating `false` branch.
+external execution layer (EL), so their verdicts are EL-implementation-defined
+and cannot be modeled as fixed values without hiding the trust boundary. Like
+`[CryptoBackend]` one file over, this is an injection seam, a typeclass
+boundary where the consumer picks the implementation (`FRAMEWORK_ARCHITECTURE.md`
+§1): the default instance below is the optimistic always-`true` mock (every
+conformance path stays on the accepting branch with no call-site change), and
+a test supplies a local instance returning `false` to exercise the rejecting
+branch.
 
-Unlike `CryptoBackend`, whose currency is raw `ByteArray` wire buffers, the
-engine predicates take the fork's own SSZ types. `ExecutionPayload` is a
-fork-namespaced twin (nominally distinct per fork); `Transaction` is today a
-single shared abbrev, parameterized here anyway so a fork that ever twins it
-needs no seam change. The class is generic over both; the optimistic instance
+`CryptoBackend` works on raw `ByteArray` wire buffers; the engine predicates
+instead take the fork's own SSZ types. `ExecutionPayload` is re-declared per
+fork namespace, each fork's copy a nominally distinct type; `Transaction` is
+today a single shared abbrev, parameterized here anyway so a fork that ever
+re-declares it needs no seam change. The class is generic over both; the optimistic instance
 is generic too, so every fork resolves it without per-fork glue, and a local
 `letI` at one fork's concrete types overrides it where a test needs the
 refuting branch.

--- a/packages/EthCLSpecs/EthCLSpecs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs.lean
@@ -1,6 +1,7 @@
 import EthCLSpecs.Forms
 import EthCLSpecs.Fulu
 import EthCLSpecs.Gloas
+import EthCLSpecs.Heze
 import EthCLSpecs.Proofs
 
 /-!

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
@@ -140,6 +140,10 @@ abbrev maxConsolidationRequestsPerPayload : Nat := 2
 -- EIP-8282 (Gloas builder deposits / exits): 2**8 and 2**4, identical across presets.
 abbrev maxBuilderDepositRequestsPerPayload : Nat := 256
 abbrev maxBuilderExitRequestsPerPayload : Nat := 16
+-- EIP-7805 (Heze FOCIL): inclusion-list committee members per slot. A preset-file
+-- value, identical across presets at v1.7.0-alpha.11 (both say 2**4); re-check at
+-- every re-pin, and promote to a `Preset` field (like `ptcSize`) if they diverge.
+abbrev inclusionListCommitteeSize : Nat := 16
 abbrev maxAttestationsElectra : Nat := 8
 abbrev maxAttesterSlashingsElectra : Nat := 1
 abbrev maxPendingDepositsPerEpoch : Nat := 16
@@ -243,6 +247,10 @@ abbrev domainPtcAttester : ByteArray := ⟨#[0x0C, 0, 0, 0]⟩
 -- EIP-8282 `DOMAIN_BUILDER_DEPOSIT` (`0x0E000000`). Consumed by the deferred
 -- builder-deposit signature check; recorded now alongside the other domain tags.
 abbrev domainBuilderDeposit : ByteArray := ⟨#[0x0E, 0, 0, 0]⟩
+-- EIP-7805 `DOMAIN_INCLUSION_LIST_COMMITTEE` (`0x10000000`). The FOCIL inclusion-list
+-- committee signature domain; consumed by `Heze.isValidInclusionListSignature`. Recorded
+-- here with the other domain tags (where every fork's domains live, Heze's included).
+abbrev domainInclusionListCommittee : ByteArray := ⟨#[0x10, 0, 0, 0]⟩
 /-- ePBS fork-choice payload statuses for a `ForkChoiceNode`. -/
 abbrev payloadStatusEmpty : UInt8 := 0
 abbrev payloadStatusFull : UInt8 := 1
@@ -270,6 +278,10 @@ abbrev kzgCommitmentsInclusionProofDepth : Nat := 4
 (`ATTESTATION_DUE_BPS_GLOAS`, `PAYLOAD_ATTESTATION_DUE_BPS`). -/
 abbrev attestationDueBpsGloas : UInt64 := 2500
 abbrev payloadAttestationDueBps : UInt64 := 7500
+/-- `INCLUSION_LIST_DUE_BPS` (Heze:EIP7805, ~67% of the slot): the timeliness deadline
+for an inclusion list, in basis points of the slot
+(`consensus-specs/specs/heze/fork-choice.md:38`). -/
+abbrev inclusionListDueBps : UInt64 := 6667
 /-- `PROPOSER_SCORE_BOOST` (percent of the per-slot committee weight). -/
 abbrev proposerScoreBoost : Nat := 40
 /-- `BASIS_POINTS` denominator for the slot-component durations. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -255,9 +255,20 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
       let proposerHead := getProposerHead store (getHead store) (getCurrentSlot store)
       assert (proposerHead == root)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
-    -- ePBS-only steps (envelope, PTC message, payload-status / vote checks) never
-    -- appear in Fulu vectors; ignore them so the shared `FcStep` stays exhaustive.
-    | _ => pure ()
+    -- ePBS-only steps (Gloas, EIP-7732): impossible in a well-formed fulu vector, so
+    -- surface one as `todo` (an xfail) rather than passing it vacuously. Explicit arms
+    -- keep the match exhaustive over `FcStep`, so a newly added constructor is a build
+    -- error here too, not just in the Gloas / Heze interpreters.
+    | .executionPayload _ _ =>
+      throw (StoreTransitionError.todo "execution_payload step: ePBS-only, not applicable to fulu")
+    | .payloadAttestationMessage _ _ =>
+      throw (StoreTransitionError.todo "payload_attestation_message step: ePBS-only, not applicable to fulu")
+    | .checkHeadPayloadStatus _ =>
+      throw (StoreTransitionError.todo "head.payload_status check: ePBS-only, not applicable to fulu")
+    | .checkPayloadTimelinessVote _ _ =>
+      throw (StoreTransitionError.todo "payload_timeliness_vote check: ePBS-only, not applicable to fulu")
+    | .checkPayloadDataAvailabilityVote _ _ =>
+      throw (StoreTransitionError.todo "payload_data_availability_vote check: ePBS-only, not applicable to fulu")
   pure ()
 
 /-- `runForkChoice`: decode the anchor state / block, build the store, and run the

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -329,9 +329,11 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
     | .checkTime t => assert (store.time.toNat == t)
     | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
-    -- Fulu-only checks (e.g. get_proposer_head) never appear in Gloas vectors; ignore
-    -- them so the shared `FcStep` match stays exhaustive.
-    | _ => pure ()
+    -- `get_proposer_head` is Gloas-Modified but not ported, and no alpha.11 vector exercises it;
+    -- surface it as unmodeled (a `todo` xfail) rather than passing it vacuously. This arm makes
+    -- the match exhaustive over `FcStep`, so a newly added constructor becomes a build error rather
+    -- than a silent pass through a catch-all.
+    | .checkProposerHead _ => throw (StoreTransitionError.todo "get_proposer_head check: not modeled")
   pure ()
 
 /-- `runForkChoice` (Gloas): decode the anchor state / block, build the ePBS store,

--- a/packages/EthCLSpecs/EthCLSpecs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze.lean
@@ -9,10 +9,13 @@ import EthCLSpecs.Heze.Signing
 /-!
 # `EthCLSpecs.Heze`: the Heze fork (EIP-7805 FOCIL), a thin diff over Gloas
 
-At alpha.11 Heze adds the `InclusionList` family (PR #5371 reverted the bid change) and the
-`upgradeToHeze` near-passthrough. EIP-7805 changes no state transition, so the spine is the
-Gloas spine re-instantiated over Heze types (`EpochProcessing` / `Operations` / `Withdrawals` /
-`Transition`, pulled in via `Interface`); the fork-interface drives every tested runner.
+At alpha.11 Heze adds the `InclusionList`
+family (PR #5371 reverted the bid change) and the `upgradeToHeze` near-passthrough. EIP-7805
+changes no state transition, so the spine (the `process_slots` / `process_block` /
+`process_epoch` pipeline) is the Gloas one re-instantiated over Heze types.
+`EpochProcessing` / `Operations` / `Withdrawals` / `Transition` carry that
+re-instantiation, pulled in via `Interface`, and the fork-interface drives every tested
+runner. The as-built divergence catalogue is `IMPLEMENTATION_NOTES.md`, "Heze diff".
 
 The FOCIL functions land in concern files, following the ePBS shape rather than a per-feature
 file. `get_inclusion_list_committee` sits with the committee accessors (`Committees`);
@@ -24,6 +27,7 @@ The fork choice (`ForkChoice`) is Gloas's with the EIP-7805 inclusion-list layer
 `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
 `get_inclusion_list_due_ms` helpers, the `should_extend_payload` and
 `on_execution_payload_envelope` overrides, and the new `on_inclusion_list` handler. FOCIL has no
-conformance vector, so that layer is pinned to the spec by the `InclusionListStore` `#guard`s in
-`ForkChoice` rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
+behavioral conformance vector (the two new containers do pass their `ssz_static` suites), so that
+layer is pinned to the spec by the build-enforced pins in `ForkChoice`, kernel `#guard`s plus
+`native_decide` examples, rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze.lean
@@ -1,0 +1,29 @@
+import EthCLSpecs.Heze.Containers
+import EthCLSpecs.Heze.Upgrade
+import EthCLSpecs.Heze.Interface
+import EthCLSpecs.Heze.Committees
+-- Load-bearing: `isValidInclusionListSignature` has no in-model caller, so this import is the
+-- only path that pulls `Signing` into the build. Do not drop it as a "redundant" sibling.
+import EthCLSpecs.Heze.Signing
+
+/-!
+# `EthCLSpecs.Heze`: the Heze fork (EIP-7805 FOCIL), a thin diff over Gloas
+
+At alpha.11 Heze adds the `InclusionList` family (PR #5371 reverted the bid change) and the
+`upgradeToHeze` near-passthrough. EIP-7805 changes no state transition, so the spine is the
+Gloas spine re-instantiated over Heze types (`EpochProcessing` / `Operations` / `Withdrawals` /
+`Transition`, pulled in via `Interface`); the fork-interface drives every tested runner.
+
+The FOCIL functions land in concern files, following the ePBS shape rather than a per-feature
+file. `get_inclusion_list_committee` sits with the committee accessors (`Committees`);
+`is_valid_inclusion_list_signature` with the signing surface (`Signing`); the `InclusionListStore`
+and its three helpers with fork choice (`ForkChoice`), folded into the fork-choice `Store`.
+
+The fork choice (`ForkChoice`) is Gloas's with the EIP-7805 inclusion-list layer added: the
+`InclusionListStore` and its three helpers, folded into the fork-choice `Store`, the
+`is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
+`get_inclusion_list_due_ms` helpers, the `should_extend_payload` and
+`on_execution_payload_envelope` overrides, and the new `on_inclusion_list` handler. FOCIL has no
+conformance vector, so that layer is pinned to the spec by the `InclusionListStore` `#guard`s in
+`ForkChoice` rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
+-/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
@@ -5,9 +5,9 @@ import EthCLSpecs.Heze.Containers.InclusionList
 
 `BeaconBlockBody` / `BeaconBlock` / `SignedBeaconBlock` are Gloas's, unchanged (EIP-7805
 touches none of them), so all three are `inherit`ed verbatim, including the signed wrapper.
-The `Containers.InclusionList` import is the load-order entry (it pulls `Heze.Inherited` +
-the `fork Heze from Gloas` lineage that `inherit` resolves against); it is load-bearing,
-do not drop it.
+The `Containers.InclusionList` import looks unused but is required: it transitively loads
+`Heze.Inherited` and the `fork Heze from Gloas` declaration that `inherit` resolves
+against. Do not remove it.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
@@ -1,0 +1,24 @@
+import EthCLSpecs.Heze.Containers.InclusionList
+
+/-!
+# `EthCLSpecs.Heze.Block`: the Heze block containers (inherited from Gloas)
+
+`BeaconBlockBody` / `BeaconBlock` / `SignedBeaconBlock` are Gloas's, unchanged (EIP-7805
+touches none of them), so all three are `inherit`ed verbatim, including the signed wrapper.
+The `Containers.InclusionList` import is the load-order entry (it pulls `Heze.Inherited` +
+the `fork Heze from Gloas` lineage that `inherit` resolves against); it is load-bearing,
+do not drop it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit BeaconBlockBody
+inherit BeaconBlock
+inherit SignedBeaconBlock
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -1,0 +1,70 @@
+import EthCLSpecs.Heze.EpochProcessing
+
+/-!
+# `EthCLSpecs.Heze.Committees`: the EIP-7805 (FOCIL) inclusion-list committee accessor
+
+Heze inherits `Committees` from Fulu verbatim; this file adds the one new committee accessor
+EIP-7805 introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
+`consensus-specs/specs/heze/beacon-chain.md:95-110`) samples a fixed-size committee from the
+slot's beacon committees. It leans on accessors inherited over `Heze.State` in `EpochProcessing`
+(`getBeaconCommittee`, `getCommitteeCountPerSlot`, `computeEpochAtSlot`). FOCIL adds no state
+transition, so this is a pure accessor rather than a transition step.
+
+`get_inclusion_list_committee` is reached from the `on_execution_payload_envelope` vectors (via
+`get_inclusion_list_transactions`) but against an empty store, so the Python is the oracle. The
+accessor mirrors it branch-for-branch, and the build-enforced `#guard`s below pin the load-bearing
+cyclic resampling to values worked out by hand from the spec's list comprehension.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-- The cyclic resampling `get_inclusion_list_committee` uses to fill its fixed-length
+result: element `i` is `xs[i % xs.size]`, wrapping back to the front once `i` passes the end
+of the concatenated committees (the spec's `indices[i % len(indices)]`,
+`consensus-specs/specs/heze/beacon-chain.md:108-110`). Factored out of the accessor so the
+wrap-around index arithmetic is unit-checkable below without building a whole `BeaconState`.
+`xs.getD … default` is total via `[Inhabited α]`; on the spec path `xs` is the non-empty committee
+concatenation, so `i % xs.size < xs.size` and `getD` always returns a real element. The `default`
+fallback covers only the unreachable empty-`xs` case (a state a real beacon chain never reaches),
+which `getD` returns silently rather than panicking to stderr as `xs[…]!` would. -/
+private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : Vector α n :=
+  Vector.ofFn (fun i : Fin n => xs.getD (i.val % xs.size) default)
+
+-- Pins for the cyclic resampling, expected values computed by hand from the Python
+-- comprehension `[indices[i % len(indices)] for i in range(n)]`. First: a size-3 source over
+-- n = 8 wraps as i % 3 = 0,1,2,0,1,2,0,1. Second: a size-2 source over the real
+-- `INCLUSION_LIST_COMMITTEE_SIZE` (= 16) alternates 0,1,…; the 16-element result also pins
+-- the constant, since a different size would change the list length and fail the `=`.
+#guard (cyclicSample (#[10, 20, 30] : Array UInt64) 8).toList
+  = [10, 20, 30, 10, 20, 30, 10, 20]
+#guard (cyclicSample (#[7, 8] : Array UInt64) Const.inclusionListCommitteeSize).toList
+  = [7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8]
+
+state_section
+
+/-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
+`consensus-specs/specs/heze/beacon-chain.md:95-110`): concatenate every beacon committee for
+`slot` in committee-index order, then take the first `INCLUSION_LIST_COMMITTEE_SIZE` members
+cyclically. Mirrors the Python branch-for-branch: `epoch = compute_epoch_at_slot(slot)`, the
+`range(committees_per_slot)` accumulation that `extend`s each `get_beacon_committee`, and the
+`indices[i % len(indices)]` `Vector` fill (here `cyclicSample`). `get_beacon_committee` takes
+a `Nat` committee index in this framework, so the loop counter `i` is passed directly; the
+Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee case the
+Python would hit with a `ZeroDivisionError` (`len(indices) == 0`) is instead a total read here
+(`i % 0 = i`, default element), a state a real beacon chain never reaches. -/
+forkdef getInclusionListCommittee (state : State) (slot : Slot) :
+    Vector ValidatorIndex Const.inclusionListCommitteeSize :=
+  let epoch := computeEpochAtSlot slot
+  let committeesPerSlot := getCommitteeCountPerSlot state epoch
+  let indices := (Array.range committeesPerSlot).foldl
+    (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
+  cyclicSample indices Const.inclusionListCommitteeSize
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -4,7 +4,7 @@ import EthCLSpecs.Heze.EpochProcessing
 # `EthCLSpecs.Heze.Committees`: the EIP-7805 (FOCIL) inclusion-list committee accessor
 
 Heze inherits `Committees` from Fulu verbatim; this file adds the one new committee accessor
-EIP-7805 introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
+EIP-7805 (FOCIL) introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
 `consensus-specs/specs/heze/beacon-chain.md:95-110`) samples a fixed-size committee from the
 slot's beacon committees. It leans on accessors inherited over `Heze.State` in `EpochProcessing`
 (`getBeaconCommittee`, `getCommitteeCountPerSlot`, `computeEpochAtSlot`). FOCIL adds no state
@@ -45,6 +45,10 @@ private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : 
 #guard (cyclicSample (#[7, 8] : Array UInt64) Const.inclusionListCommitteeSize).toList
   = [7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8]
 
+-- `state_section` is the framework's header macro (`SPEC_AUTHORING_MODEL.md` §4): it opens
+-- the section and emits the `variable` line, `[Preset]` / `[Config]` / `[HasherTag]` /
+-- `[CryptoBackend]` plus the `StateTransition` monad variable and its constraints, which the
+-- `forkdef`s below take implicitly (`EthCLLib.Spec.Header`).
 state_section
 
 /-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
@@ -54,9 +58,8 @@ cyclically. Mirrors the Python branch-for-branch: `epoch = compute_epoch_at_slot
 `range(committees_per_slot)` accumulation that `extend`s each `get_beacon_committee`, and the
 `indices[i % len(indices)]` `Vector` fill (here `cyclicSample`). `get_beacon_committee` takes
 a `Nat` committee index in this framework, so the loop counter `i` is passed directly; the
-Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee case the
-Python would hit with a `ZeroDivisionError` (`len(indices) == 0`) is instead a total read here
-(`i % 0 = i`, default element), a state a real beacon chain never reaches. -/
+Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee read is
+total here where the Python would raise; `cyclicSample` above carries the mechanics. -/
 forkdef getInclusionListCommittee (state : State) (slot : Slot) :
     Vector ValidatorIndex Const.inclusionListCommitteeSize :=
   let epoch := computeEpochAtSlot slot

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Constants.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Constants.lean
@@ -1,0 +1,29 @@
+import EthCLSpecs.Gloas.Constants
+
+/-!
+# `EthCLSpecs.Heze.Constants`: the Heze fork declaration + version values
+
+Heze is a diff over Gloas, adding EIP-7805 (FOCIL). At alpha.11 it modifies no Gloas
+container (PR #5371 reverted the bid change), so the only Heze-specific constants here
+are the two `HEZE_FORK_VERSION` values. `fork Heze from Gloas` records the lineage so
+`inherit` replays Gloas (and through Gloas, Fulu) declarations in the Heze namespace.
+The FOCIL `DOMAIN_INCLUSION_LIST_COMMITTEE` tag lives with every other BLS domain in
+`Fulu.Const` (`Const.domainInclusionListCommittee`); the FOCIL
+`is_valid_inclusion_list_signature` predicate (`Heze/Signing.lean`) verifies signatures under it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+fork Heze from Gloas
+
+/-- `HEZE_FORK_VERSION` at the `minimal` config (`0x08000001`). -/
+def hezeForkVersionMinimal : Version := ⟨#[0x08, 0x00, 0x00, 0x01], by decide⟩
+/-- `HEZE_FORK_VERSION` at the `mainnet` config (`0x08000000`). -/
+def hezeForkVersionMainnet : Version := ⟨#[0x08, 0x00, 0x00, 0x00], by decide⟩
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers.lean
@@ -1,0 +1,11 @@
+import EthCLSpecs.Heze.State
+import EthCLSpecs.Heze.Block
+
+/-!
+# `EthCLSpecs.Heze.Containers`: the Heze container re-export root
+
+A single `import EthCLSpecs.Heze.Containers` brings the whole Heze container layer into
+scope; it holds no declarations of its own. The only Heze-new containers are the
+`InclusionList` family (`Containers.InclusionList`); the rest are inherited from Gloas /
+Fulu (`Inherited`, `State`, `Block`).
+-/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
@@ -7,6 +7,13 @@ The two containers EIP-7805 adds at alpha.11: an `InclusionList` (a committee me
 committed transactions for a slot) and its signed wrapper. `Transaction` and
 `MAX_TRANSACTIONS_PER_PAYLOAD` are the existing Fulu/Gloas types. These are the *only*
 new Heze containers; the bid is unchanged at alpha.11.
+
+The two DSL forms: `forkcontainer` declares an SSZ container in the fork namespace and
+captures it for a later fork's `inherit`. Field order is declaration order, and that order
+fixes both the SSZ serialization and the hash-tree-root. `signedwrapper SignedX wraps X`
+expands to the two-field `forkcontainer { message : X, signature : BLSSignature }`, in that
+order (`EthCLLib.Spec.Forms` documents `forkcontainer`; `EthCLSpecs.Forms` documents
+`signedwrapper`).
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
@@ -1,0 +1,30 @@
+import EthCLSpecs.Heze.Inherited
+
+/-!
+# `EthCLSpecs.Heze.Containers.InclusionList`: the FOCIL inclusion list (EIP-7805, new)
+
+The two containers EIP-7805 adds at alpha.11: an `InclusionList` (a committee member's
+committed transactions for a slot) and its signed wrapper. `Transaction` and
+`MAX_TRANSACTIONS_PER_PAYLOAD` are the existing Fulu/Gloas types. These are the *only*
+new Heze containers; the bid is unchanged at alpha.11.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-- An inclusion list (EIP-7805): the transactions an inclusion-list-committee member
+commits to for a slot. -/
+forkcontainer InclusionList where
+  slot                       : Slot
+  validatorIndex             : ValidatorIndex
+  inclusionListCommitteeRoot : Root
+  transactions               : SSZList Transaction Const.maxTransactionsPerPayload
+
+/-- A signed inclusion list. -/
+signedwrapper SignedInclusionList wraps InclusionList
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
@@ -5,7 +5,8 @@ import EthCLSpecs.Gloas.EpochProcessing
 # `EthCLSpecs.Heze.EpochProcessing`: the inherited epoch substeps (Gloas over Heze state)
 
 EIP-7805 (FOCIL) changes no epoch processing. Every Gloas epoch substep and accessor is
-`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` re-elaborates in the Heze
+`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` (the DSL stores every
+`forkdef`'s source for inheritance; `SPEC_AUTHORING_MODEL.md` §8) re-elaborates in the Heze
 namespace against `Heze.State` (`= SSZ.Box _ Heze.BeaconState`), its sibling calls
 rebinding to the Heze copies. No substep body is restated. The order matches Gloas's so
 each callee is declared before its caller.

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
@@ -1,0 +1,115 @@
+import EthCLSpecs.Heze.Containers
+import EthCLSpecs.Gloas.EpochProcessing
+
+/-!
+# `EthCLSpecs.Heze.EpochProcessing`: the inherited epoch substeps (Gloas over Heze state)
+
+EIP-7805 (FOCIL) changes no epoch processing. Every Gloas epoch substep and accessor is
+`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` re-elaborates in the Heze
+namespace against `Heze.State` (`= SSZ.Box _ Heze.BeaconState`), its sibling calls
+rebinding to the Heze copies. No substep body is restated. The order matches Gloas's so
+each callee is declared before its caller.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit computeEpochAtSlot
+inherit computeStartSlotAtEpoch
+inherit getCurrentEpoch
+inherit getPreviousEpoch
+inherit getRandaoMix
+inherit modBalance
+inherit increaseBalance
+inherit decreaseBalance
+inherit modValidator
+inherit computeActivationExitEpoch
+inherit currentEpochOf
+inherit previousEpochOf
+inherit getBeaconProposerIndex
+inherit getBlockRootAtSlot
+inherit getBlockRoot
+inherit isActiveValidator
+inherit isSlashableValidator
+inherit isEligibleForActivationQueue
+inherit isEligibleForActivation
+inherit credPrefix
+inherit hasEth1WithdrawalCredential
+inherit hasCompoundingWithdrawalCredential
+inherit hasExecutionWithdrawalCredential
+inherit getMaxEffectiveBalance
+inherit hasNotInitiatedExit
+inherit passedShardCommitteePeriod
+inherit getActiveValidatorIndices
+inherit getTotalBalance
+inherit getTotalActiveBalance
+inherit getBaseRewardPerIncrement
+inherit getBaseReward
+inherit getUnslashedParticipatingIndices
+inherit getEligibleValidatorIndices
+inherit validatorIndexByPubkey?
+inherit getFinalityDelay
+inherit isInInactivityLeak
+inherit getBalanceChurnLimit
+inherit getActivationExitChurnLimit
+inherit getExitChurnLimit
+inherit getActivationChurnLimit
+inherit computeExitEpochAndUpdateChurn
+inherit initiateValidatorExit
+inherit slashValidator
+inherit getDomain
+inherit getPendingBalanceToWithdraw
+inherit getConsolidationChurnLimit
+inherit computeConsolidationEpochAndUpdateChurn
+inherit queueExcessActiveBalance
+inherit switchToCompoundingValidator
+inherit getValidatorFromDeposit
+inherit addValidatorToRegistry
+inherit isValidDepositSignature
+inherit applyPendingDeposit
+inherit computeShuffledPermutation
+inherit getSeed
+inherit getCommitteeCountPerSlot
+inherit computeCommittee
+inherit getBeaconCommittee
+inherit getCommitteeIndices
+inherit cbwsAux
+inherit computeBalanceWeightedSelection
+inherit computeProposerIndices
+inherit getNextSyncCommittee
+inherit getBeaconProposerIndices
+inherit weighJustificationAndFinalization
+inherit processJustificationAndFinalization
+inherit processInactivityUpdates
+inherit getFlagIndexDeltas
+inherit getInactivityPenaltyDeltas
+inherit applyDeltas
+inherit processRewardsAndPenalties
+inherit processRegistryUpdates
+inherit processSlashings
+inherit DepositScan
+inherit ppdLoop
+inherit processPendingDeposits
+inherit pcLoop
+inherit processPendingConsolidations
+inherit processEffectiveBalanceUpdates
+inherit processSlashingsReset
+inherit processRandaoMixesReset
+inherit processEth1DataReset
+inherit processHistoricalSummariesUpdate
+inherit processParticipationFlagUpdates
+inherit processSyncCommitteeUpdates
+inherit processProposerLookahead
+inherit processBuilderPendingPayments
+inherit computePtc
+inherit processPtcWindow
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -7,14 +7,19 @@ import EthCLLib.Spec.Engine
 /-!
 # `EthCLSpecs.Heze.ForkChoice`: the ePBS node-based fork choice with EIP-7805 (FOCIL)
 
-Heze inherits Gloas's whole ePBS node fork choice and adds the EIP-7805 inclusion-list layer
-on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` / `LatestMessage` are
-`inherit`ed unchanged; the `Store` is re-declared (a `forkstruct` rather than an `inherit`) to
-carry the two `[New in Heze:EIP7805]` fields, `payloadInclusionListSatisfaction` and the folded-in
-`inclusionListStore`. The spec keeps a separate process-lifetime `InclusionListStore`, but this
-framework's pure `EStateM` fork choice threads one `Store`, so the inclusion-list store rides inside
-it (see the `InclusionListStore` block below for the full rationale). Most handlers are
-inherited verbatim; the FOCIL touch points are re-declared here:
+Heze inherits the whole node-based fork choice of Gloas's ePBS (EIP-7732) and adds the
+EIP-7805 FOCIL layer on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` /
+`LatestMessage` are `inherit`ed unchanged (`inherit` replays an ancestor fork's captured
+declaration in this namespace; the inheritance mechanism is `SPEC_AUTHORING_MODEL.md` §8).
+The three node smart constructors and the `deriving` lines are plain declarations in Gloas,
+which the capture does not cover, so they are restated here. The `Store` is re-declared as a
+fresh `forkstruct` (the framework's fork-aware `structure` form, capturable for a later
+fork's `inherit`) instead of an `inherit`, to carry the two `[New in Heze:EIP7805]` fields:
+`payloadInclusionListSatisfaction` and the folded-in `inclusionListStore`. The spec keeps a
+separate process-lifetime `InclusionListStore`; this framework's fork choice threads one
+`Store` value through the generic `StoreTransition` monad, so the inclusion-list store rides
+inside it (the `InclusionListStore` declaration below carries the full rationale). Most
+handlers are inherited verbatim; the FOCIL touch points are re-declared here:
 
 * `get_forkchoice_store` seeds the two new store fields empty;
 * `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
@@ -23,19 +28,24 @@ inherited verbatim; the FOCIL touch points are re-declared here:
 * `on_execution_payload_envelope` records satisfaction before storing the payload;
 * `on_inclusion_list` is the new wire handler.
 
-EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it through
-`notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both are the production-side Engine-API
-surface a proposer drives to build its own payload, so they sit outside the modeled
-state-transition and fork-choice scope and stay unmodeled here, the same boundary every fork keeps.
-Only the consumption-side `is_inclusion_list_satisfied` is modeled, through the `[ExecutionEngine]`
-seam that `record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
+EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it
+through `notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both belong to the
+production-side Engine-API surface, the calls a proposer drives to build its own payload.
+That surface sits outside the modeled state-transition and fork-choice scope, the boundary
+every fork keeps, so both stay unmodeled here. Only the consumption side is modeled:
+`is_inclusion_list_satisfied`, through the `[ExecutionEngine]` seam (one of the injection
+seams, `FRAMEWORK_ARCHITECTURE.md` §1; defined in `EthCLLib.Spec.Engine`) that
+`record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
 
-The `on_execution_payload_envelope` fork_choice vectors do drive the two overrides, but only the
-empty-inclusion-list, always-satisfied path they share with Gloas; the FOCIL-specific behavior (the
-discriminating satisfaction gate and `on_inclusion_list`) has no vector, so the pinned alpha.11 spec
-is its oracle. Each override mirrors its Python branch-for-branch, and the `InclusionListStore`
-`#guard`s below pin the inclusion-list store logic. The three node smart constructors and the `deriving` lines are
-plain declarations in Gloas (not captured), so they are restated here.
+Vector coverage is partial, and the split matters. The `on_execution_payload_envelope`
+fork_choice vectors do drive `onExecutionPayloadEnvelope` and `shouldExtendPayload`, but only
+on the empty-inclusion-list, always-satisfied path they share with Gloas. The FOCIL-specific
+behavior (the discriminating satisfaction gate and `on_inclusion_list`) has no vector; the
+pinned spec text (`consensus-specs` at tag `v1.7.0-alpha.11`) is its oracle
+(`IMPLEMENTATION_NOTES.md`, "Heze diff", is the catalogue). Each override mirrors its Python
+branch-for-branch, and the build-enforced pin sections below fix the inclusion-list logic's
+expected outcomes at build time: kernel `#guard`s where the outcome is hash-free,
+`native_decide` examples where a hash-tree-root must be computed.
 -/
 
 set_option autoImplicit false
@@ -56,19 +66,24 @@ inherit LatestMessage
 deriving instance Inhabited for LatestMessage
 
 /-- `InclusionListStore` (`consensus-specs/specs/heze/inclusion-list.md:28-38`): the
-fork-choice node's view of the inclusion lists it has seen. `inclusionLists` files each
-stored `InclusionList` under its committee root then its own hash-tree root
-(`DefaultDict[Root, Dict[Root, InclusionList]]`); `inclusionListTimeliness` records, per
-stored-list root, whether it arrived before `INCLUSION_LIST_DUE_BPS`; `equivocators` is the
-per-committee set of validator indices caught publishing two different lists. A `forkstruct`
-rather than a bare `structure`, so a later fork can `inherit` it, and so it carries the auto
-`[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+fork-choice node's view of the inclusion lists it has seen. The three fields:
 
-Declared here, above the fork-choice `Store` that carries it as a field, rather than in a
-separate feature file: the spec keeps `InclusionListStore` as a process-lifetime singleton reached
-through `get_inclusion_list_store()`, but this framework's fork choice is a pure `EStateM` over one
-`Store`, so the store is modeled as a field of that `Store`. It is fork-choice state, so it lives
-with fork choice, next to the handlers that drive it. -/
+* `inclusionLists`: every stored `InclusionList`, keyed first by its committee root, then by
+  the list's own hash-tree root (the spec's `DefaultDict[Root, Dict[Root, InclusionList]]`);
+* `inclusionListTimeliness`: per stored-list root, whether the list arrived before the
+  `INCLUSION_LIST_DUE_BPS` deadline;
+* `equivocators`: per committee root, the validators caught publishing two different lists.
+
+A `forkstruct` rather than a bare `structure`, so a later fork can `inherit` it, and so it
+carries the auto `[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+
+This declaration is the canonical home of the fold-in rationale. The spec keeps
+`InclusionListStore` as a process-lifetime singleton reached through
+`get_inclusion_list_store()`. This framework's fork choice threads one `Store` value through
+the generic `StoreTransition` monad (`SPEC_AUTHORING_MODEL.md` §4), with no ambient mutable
+singleton to hang the spec's store off, so the store is modeled as a `Store` field instead
+and moves with the rest of the state. Behavior is identical. It is fork-choice state, so it
+lives here, next to the handlers that drive it. -/
 forkstruct InclusionListStore (map : MapKind) [HasherTag] where
   inclusionLists          : map Root (map Root InclusionList)
   inclusionListTimeliness : map Root Bool
@@ -78,28 +93,32 @@ section
 
 variable [Preset] [HasherTag] [Config] {map : MapKind} [FcMap map]
 
-/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators. The seed
-`get_forkchoice_store` plants (`consensus-specs/specs/heze/fork-choice.md:165`) and the base
-every pin builds from, so the all-empty literal lives in one place. -/
+/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators.
+`getForkchoiceStore` seeds the folded-in `Store` field with it. The spec has no counterpart
+line: there the store is the lazily-created `get_inclusion_list_store()` singleton (see the
+`InclusionListStore` docstring above for the fold-in). Every pin below also builds from it,
+so the all-empty literal lives in one place. -/
 def InclusionListStore.empty : InclusionListStore map :=
   { inclusionLists := FcMap.empty, inclusionListTimeliness := FcMap.empty, equivocators := FcMap.empty }
 
 /-- The inner comprehension of `get_inclusion_list_transactions`
 (`consensus-specs/specs/heze/inclusion-list.md:105-114`): over the inclusion lists stored for
 one committee key, keep those from non-equivocating validators (and, when `onlyTimely`, only
-the timely ones), gather their transactions, and deduplicate. Factored out of the accessor so
-the equivocator / timeliness / dedup logic is unit-checkable without building a `BeaconState`
-for the committee key (the `cyclicSample` pattern). One pass with `FcMap.fold` over the stored
-map, which hands each `(ilRoot, il)` straight to the step (no second `lookup`, no dead `none`
-branch). `timeliness[ilRoot]` is a plain dict read in the spec (every stored list has a
-timeliness entry, written together in `process_inclusion_list`); the structurally-present key
-reads through `.getD false`, the default never reached on the spec path. The dedup is the house
-`arrayUnion #[] …` first-occurrence union: the spec's `list(set(transactions))` keeps each
-transaction once and calls the order irrelevant, so a deterministic first-occurrence
-representative lets the result be pinned by `#guard`. -/
+the timely ones), gather their transactions, and deduplicate.
+
+Factored out of the accessor so the equivocator / timeliness / dedup logic is unit-checkable
+without building a `BeaconState` for the committee key, the same reason `cyclicSample` is
+factored out in `Committees`. The dedup keeps each transaction's first occurrence
+(`arrayUnion`): the spec's `list(set(transactions))` keeps each transaction once and calls
+the order irrelevant, so a deterministic representative lets `#guard` pin the result.
+`timeliness[ilRoot]` is a plain dict read in the spec; the `.getD false` default here is
+unreachable on the spec path, because `process_inclusion_list` writes every stored list and
+its timeliness entry together. -/
 private def collectInclusionListTransactions (inclusionLists : map Root InclusionList)
     (equivocators : Array ValidatorIndex) (timeliness : map Root Bool) (onlyTimely : Bool) :
     Array Transaction :=
+  -- One `FcMap.fold` pass: each stored `(ilRoot, il)` goes straight to the filter, with no
+  -- second `lookup` and no dead `none` branch.
   let collected : Array Transaction :=
     FcMap.fold (fun acc ilRoot il =>
       let timely := FcMap.lookupD timeliness ilRoot
@@ -229,12 +248,13 @@ inherit payloadDataAvailability
 inherit isPreviousSlotPayloadDecision
 
 /-- `is_payload_inclusion_list_satisfied(store, root)`
-(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root` satisfied
-the inclusion-list constraints and is locally available. The spec opens with `assert root in
-store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so a missing
-key reads as `false` through `lookupD`, the same default-on-miss the sibling `payloadTimeliness`
-uses. That default sits off the spec path thanks to the `payloads`/satisfaction co-write; the
-INVARIANT note in `onExecutionPayloadEnvelope` is the canonical statement. -/
+(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root`
+satisfied the inclusion-list constraints and is locally available. The spec opens with
+`assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot
+throw, so a missing key reads as `false` through `lookupD` (the same default-on-miss the
+sibling `payloadTimeliness` uses). The default is unreachable on the spec path, because
+`onExecutionPayloadEnvelope` always writes `payloads` and the satisfaction entry together;
+the INVARIANT note there is the canonical statement of that argument. -/
 forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : Bool :=
   isPayloadVerified store root && FcMap.lookupD store.payloadInclusionListSatisfaction root
 
@@ -336,10 +356,11 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
   | .ok warm =>
     -- [New in Heze:EIP7805] record whether the payload satisfies the inclusion-list constraints
     let store := recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
-    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are co-written here
-    -- (the satisfaction key via `recordPayloadInclusionListSatisfaction` just above). Keep them
-    -- co-written: `isPayloadInclusionListSatisfied`'s default-false-on-miss is sound only because a
-    -- verified `root` (present in `payloads`) always carries a satisfaction entry.
+    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written
+    -- together here (the satisfaction key via `recordPayloadInclusionListSatisfaction` just
+    -- above). Keep it that way: `isPayloadInclusionListSatisfied`'s default-false-on-miss is
+    -- sound only because a verified `root` (present in `payloads`) always carries a
+    -- satisfaction entry.
     set { store with
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
@@ -353,9 +374,10 @@ inherit onAttesterSlashing
 
 /-- `get_forkchoice_store(anchor_state, anchor_block)` (Heze override,
 `consensus-specs/specs/heze/fork-choice.md:140-166`): the Gloas anchor store with the two
-`[New in Heze:EIP7805]` fields seeded empty, `payloadInclusionListSatisfaction` as an empty
-map and `inclusionListStore` as the empty `InclusionListStore` (`fork-choice.md:165`, decision
-A). The rest is Gloas verbatim. -/
+`[New in Heze:EIP7805]` fields seeded empty: `payloadInclusionListSatisfaction` as an empty
+map (`fork-choice.md:165`) and `inclusionListStore` as the empty `InclusionListStore` (no
+spec counterpart; the spec's store is a process-lifetime singleton, folded into `Store` here,
+see the `InclusionListStore` docstring). The rest is Gloas verbatim. -/
 forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
@@ -376,8 +398,8 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : S
     payloads := FcMap.empty
     payloadTimelinessVote := FcMap.empty
     payloadDataAvailabilityVote := FcMap.empty
-    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the co-write
-    -- INVARIANT in `onExecutionPayloadEnvelope`).
+    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the INVARIANT
+    -- note in `onExecutionPayloadEnvelope`: the two maps are always written together).
     payloadInclusionListSatisfaction := FcMap.empty
     inclusionListStore := InclusionListStore.empty }
 
@@ -405,20 +427,18 @@ end
 
 /-! ### Build-enforced pin (vectorless): the inclusion-list satisfaction gate
 
-`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload` reads
-to refuse a payload that failed its inclusion-list constraints. No conformance vector exercises it,
-and the no-regression sweep only runs the optimistic `is_inclusion_list_satisfied = true` mock, so
-the discriminating `false` branch is otherwise dead. This pin drives the predicate on a minimal
-`Store` directly, fixing its outcomes by hand: verified + recorded-`false` ⇒ `false` (the gate's
-whole point), verified + recorded-`true` ⇒ `true`, unverified ⇒ `false` even with the bit recorded
-`true` (the `is_payload_verified` membership gate dominates), and verified-but-absent ⇒ `false`
-through the `lookupD` default (off the spec path; the co-write INVARIANT in
-`onExecutionPayloadEnvelope`). Hash-free (`is_payload_verified` is a `payloads`
-membership test, no `htr`), so kernel `#guard`. The pin reaches the predicate end-to-end, including
-the `isPayloadVerified` composition; it fixes the recorded bit by hand rather than through the EL,
-so the `isInclusionListSatisfied` verdict is out of its reach. That verdict is the
-`[ExecutionEngine]` seam's job: `pinRecordRefuted` below drives its refuting branch through the
-record path into this gate. -/
+`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload`
+reads to refuse a payload that failed its inclusion-list constraints. No conformance vector
+exercises it, and the pyspec conformance runs answer every engine call through the optimistic
+`is_inclusion_list_satisfied = true` default, so the discriminating `false` branch is
+otherwise dead code. This pin drives the predicate on a minimal `Store` directly; the four
+verified/recorded combinations are enumerated one per `#guard` below, each with its expected
+verdict beside it. Everything is hash-free (`is_payload_verified` is a `payloads` membership
+test, no `htr`), so kernel `#guard` per the hash-tactic rule.
+
+The pin fixes the recorded bit by hand rather than through the engine, so the
+`isInclusionListSatisfied` verdict itself is out of its reach; `pinRecordRefuted` below
+drives that refuting branch through the record path into this gate. -/
 
 private def pinPilsRoot : Root := Vector.replicate 32 9
 
@@ -466,7 +486,8 @@ private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Bool :=
 #guard pinPils true (some true) = true
 -- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
 #guard pinPils false (some true) = false
--- verified but no recorded entry ⇒ `false` via the `lookupD` default (off the spec path).
+-- verified but no recorded entry ⇒ `false` via the `lookupD` default (a state the spec's
+-- own invariant rules out; the INVARIANT note in `onExecutionPayloadEnvelope`).
 #guard pinPils true none = false
 
 /-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
@@ -487,15 +508,17 @@ private def pinIlDueMs : UInt64 :=
   getInclusionListDueMs
 #guard pinIlDueMs = 4000
 
-/-- `record_payload_inclusion_list_satisfaction` records the EL verdict at `root`. With the
-optimistic `isInclusionListSatisfied = true` mock (the `ExecutionEngine` default) it writes
-`true`; the slot-0 `state` drives the underflow-guard branch (no previous slot ⇒ empty required
-set, `getInclusionListTransactions` never reached), though the pinned value alone does not
-discriminate the guard: with an empty store and the optimistic oracle the verdict is `true`
-either way. `state` is a `FastBox` of the default minimal `BeaconState`, the boxed `State` the
-forkdef wants (`State = SSZ.Box HasherTag.H BeaconState`); `FastBox` is FFI-backed, so this is a
-`native_decide` `example`
-(`Lean.ofReduceBool`). -/
+/-- `record_payload_inclusion_list_satisfaction` records the engine verdict at `root`: with
+the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. The slot-0
+`state` also sends execution down the underflow-guard branch (no previous slot, so the
+required set is empty and `getInclusionListTransactions` is never reached). Note the pinned
+value alone does not discriminate that guard: with an empty store and the optimistic oracle
+the verdict is `true` either way. What this pin fixes is the record path writing the verdict
+at the right key.
+
+Lean mechanics: the forkdef wants the boxed `State` (`State = SSZ.Box HasherTag.H
+BeaconState`), so `state` is a `FastBox` of the default minimal `BeaconState`. `FastBox` is
+FFI-backed, so this is a `native_decide` `example` (`Lean.ofReduceBool`). -/
 private def pinRecordSatisfied : Option Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
@@ -506,14 +529,14 @@ private def pinRecordSatisfied : Option Bool :=
   FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
 example : pinRecordSatisfied = some true := by native_decide
 
-/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path, now under a
-*refuting* `[ExecutionEngine]`. A local `letI` answering `false` overrides the global optimistic
-instance, the whole reason the seam exists. So the record path writes `false` at a *verified* `root`
-and `isPayloadInclusionListSatisfied` then refuses to extend it. This drives the
-`isInclusionListSatisfied = false` branch the optimistic default and every conformance vector leave
-dead, end-to-end: oracle → recorded verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`
-so the membership check passes and the recorded bit is what decides. `State` is FFI-backed
-(`FastBox`), so `native_decide`. -/
+/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path under a
+*refuting* engine, a local `letI` instance answering `false` in place of the optimistic
+default (`EthCLLib.Spec.Engine` documents the design). The record path writes `false` at a
+*verified* `root`, and `isPayloadInclusionListSatisfied` then refuses to extend it. That
+covers the branch every conformance vector leaves dead, end-to-end: oracle → recorded
+verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`, so the membership check
+passes and the recorded bit is what decides. `State` is FFI-backed (`FastBox`), so
+`native_decide`. -/
 private def pinRecordRefuted : Option Bool × Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
@@ -550,7 +573,8 @@ example : pinOnIlTimely 4 = some false := by native_decide
 
 /-! ### Build-enforced pins for the inclusion-list store (vectorless)
 
-FOCIL has no conformance vector, so these pin `process_inclusion_list`'s three branches and
+FOCIL has no conformance vector (the module docstring carries the coverage story), so these
+pin `process_inclusion_list`'s three branches and
 `get_inclusion_list_transactions`'s comprehension to hand-derived outcomes. They build a small
 `InclusionListStore treeMap` (deterministic key order) under the minimal preset and the FFI
 hasher. The branch-(A)/(B) pins and every `collectInclusionListTransactions` pin are

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -1,0 +1,669 @@
+import EthCLSpecs.Heze.Transition
+import EthCLSpecs.Gloas.ForkChoice
+import EthCLSpecs.Heze.Committees
+import EthCLLib.Spec.FiniteMap
+import EthCLLib.Spec.Engine
+
+/-!
+# `EthCLSpecs.Heze.ForkChoice`: the ePBS node-based fork choice with EIP-7805 (FOCIL)
+
+Heze inherits Gloas's whole ePBS node fork choice and adds the EIP-7805 inclusion-list layer
+on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` / `LatestMessage` are
+`inherit`ed unchanged; the `Store` is re-declared (a `forkstruct` rather than an `inherit`) to
+carry the two `[New in Heze:EIP7805]` fields, `payloadInclusionListSatisfaction` and the folded-in
+`inclusionListStore`. The spec keeps a separate process-lifetime `InclusionListStore`, but this
+framework's pure `EStateM` fork choice threads one `Store`, so the inclusion-list store rides inside
+it (see the `InclusionListStore` block below for the full rationale). Most handlers are
+inherited verbatim; the FOCIL touch points are re-declared here:
+
+* `get_forkchoice_store` seeds the two new store fields empty;
+* `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
+  `get_inclusion_list_due_ms` / `is_inclusion_list_satisfied` are the new helpers;
+* `should_extend_payload` gains the inclusion-list gate;
+* `on_execution_payload_envelope` records satisfaction before storing the payload;
+* `on_inclusion_list` is the new wire handler.
+
+EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it through
+`notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both are the production-side Engine-API
+surface a proposer drives to build its own payload, so they sit outside the modeled
+state-transition and fork-choice scope and stay unmodeled here, the same boundary every fork keeps.
+Only the consumption-side `is_inclusion_list_satisfied` is modeled, through the `[ExecutionEngine]`
+seam that `record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
+
+The `on_execution_payload_envelope` fork_choice vectors do drive the two overrides, but only the
+empty-inclusion-list, always-satisfied path they share with Gloas; the FOCIL-specific behavior (the
+discriminating satisfaction gate and `on_inclusion_list`) has no vector, so the pinned alpha.11 spec
+is its oracle. Each override mirrors its Python branch-for-branch, and the `InclusionListStore`
+`#guard`s below pin the inclusion-list store logic. The three node smart constructors and the `deriving` lines are
+plain declarations in Gloas (not captured), so they are restated here.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLLib.PySpecTests
+open SizzLean
+open SizzLean.Cache
+open SizzLean.Hasher
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit ForkChoiceNode
+deriving instance BEq, Inhabited for ForkChoiceNode
+
+inherit LatestMessage
+deriving instance Inhabited for LatestMessage
+
+/-- `InclusionListStore` (`consensus-specs/specs/heze/inclusion-list.md:28-38`): the
+fork-choice node's view of the inclusion lists it has seen. `inclusionLists` files each
+stored `InclusionList` under its committee root then its own hash-tree root
+(`DefaultDict[Root, Dict[Root, InclusionList]]`); `inclusionListTimeliness` records, per
+stored-list root, whether it arrived before `INCLUSION_LIST_DUE_BPS`; `equivocators` is the
+per-committee set of validator indices caught publishing two different lists. A `forkstruct`
+rather than a bare `structure`, so a later fork can `inherit` it, and so it carries the auto
+`[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+
+Declared here, above the fork-choice `Store` that carries it as a field, rather than in a
+separate feature file: the spec keeps `InclusionListStore` as a process-lifetime singleton reached
+through `get_inclusion_list_store()`, but this framework's fork choice is a pure `EStateM` over one
+`Store`, so the store is modeled as a field of that `Store`. It is fork-choice state, so it lives
+with fork choice, next to the handlers that drive it. -/
+forkstruct InclusionListStore (map : MapKind) [HasherTag] where
+  inclusionLists          : map Root (map Root InclusionList)
+  inclusionListTimeliness : map Root Bool
+  equivocators            : map Root (Array ValidatorIndex)
+
+section
+
+variable [Preset] [HasherTag] [Config] {map : MapKind} [FcMap map]
+
+/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators. The seed
+`get_forkchoice_store` plants (`consensus-specs/specs/heze/fork-choice.md:165`) and the base
+every pin builds from, so the all-empty literal lives in one place. -/
+def InclusionListStore.empty : InclusionListStore map :=
+  { inclusionLists := FcMap.empty, inclusionListTimeliness := FcMap.empty, equivocators := FcMap.empty }
+
+/-- The inner comprehension of `get_inclusion_list_transactions`
+(`consensus-specs/specs/heze/inclusion-list.md:105-114`): over the inclusion lists stored for
+one committee key, keep those from non-equivocating validators (and, when `onlyTimely`, only
+the timely ones), gather their transactions, and deduplicate. Factored out of the accessor so
+the equivocator / timeliness / dedup logic is unit-checkable without building a `BeaconState`
+for the committee key (the `cyclicSample` pattern). One pass with `FcMap.fold` over the stored
+map, which hands each `(ilRoot, il)` straight to the step (no second `lookup`, no dead `none`
+branch). `timeliness[ilRoot]` is a plain dict read in the spec (every stored list has a
+timeliness entry, written together in `process_inclusion_list`); the structurally-present key
+reads through `.getD false`, the default never reached on the spec path. The dedup is the house
+`arrayUnion #[] …` first-occurrence union: the spec's `list(set(transactions))` keeps each
+transaction once and calls the order irrelevant, so a deterministic first-occurrence
+representative lets the result be pinned by `#guard`. -/
+private def collectInclusionListTransactions (inclusionLists : map Root InclusionList)
+    (equivocators : Array ValidatorIndex) (timeliness : map Root Bool) (onlyTimely : Bool) :
+    Array Transaction :=
+  let collected : Array Transaction :=
+    FcMap.fold (fun acc ilRoot il =>
+      let timely := FcMap.lookupD timeliness ilRoot
+      if !equivocators.contains il.validatorIndex && (!onlyTimely || timely) then
+        acc ++ il.transactions.toArray
+      else acc) #[] inclusionLists
+  arrayUnion #[] collected
+
+/-- `process_inclusion_list(store, inclusion_list, is_timely)`
+(`consensus-specs/specs/heze/inclusion-list.md:57-82`): file a newly-received inclusion list,
+or record an equivocation. Pure here (returns the updated `InclusionListStore`); the spec
+mutates in place. The three branches mirror the Python:
+
+* (A) the list is from a known equivocator for this committee (`validator_index in
+  store.equivocators[key]`) → ignore it, return the store unchanged.
+* (B) we already hold a list from this validator for this committee → if the new list differs
+  from the stored one, add the validator to `equivocators[key]`; either way we have processed
+  it, so return (storing nothing new). At most one stored list per validator exists (a list is
+  filed only on branch (C), reached only when none matches), so the single `find?` match is
+  exactly the Python loop's first-and-only hit. The equivocator `push` is guarded by branch
+  (A) above, so it never duplicates.
+* (C) otherwise → store the list under its `hash_tree_root` and record its timeliness.
+
+`key` is the list's `inclusion_list_committee_root` (a field, no rehash). -/
+forkdef processInclusionList (store : InclusionListStore map) (inclusionList : InclusionList)
+    (isTimely : Bool) : InclusionListStore map :=
+  let key := inclusionList.inclusionListCommitteeRoot
+  let equivs := FcMap.lookupD store.equivocators key
+  -- (A) ignore inclusion lists from known equivocators for this committee
+  if equivs.contains inclusionList.validatorIndex then store
+  else
+    let stored := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
+    match (FcMap.values stored).find? (fun il => il.validatorIndex == inclusionList.validatorIndex) with
+    -- (B) already hold a list from this validator: equivocate iff it differs, then stop
+    | some existing =>
+      if existing == inclusionList then store
+      else
+        { store with
+            equivocators := FcMap.insert store.equivocators key (equivs.push inclusionList.validatorIndex) }
+    -- (C) first list from this validator: store it and its timeliness
+    | none =>
+      let inclusionListRoot := htr inclusionList
+      let stored' := FcMap.insert stored inclusionListRoot inclusionList
+      { store with
+          inclusionLists := FcMap.insert store.inclusionLists key stored',
+          inclusionListTimeliness := FcMap.insert store.inclusionListTimeliness inclusionListRoot isTimely }
+
+/-- `get_inclusion_list_transactions(store, state, slot, only_timely=True)`
+(`consensus-specs/specs/heze/inclusion-list.md:95-114`): the unique transactions from every
+valid, non-equivocating inclusion list whose committee root matches the one `state`/`slot`
+compute, optionally restricted to lists received before `INCLUSION_LIST_DUE_BPS`. Mirrors the
+Python: derive the committee, key it by `hash_tree_root`, read the `defaultdict` entries for
+that key, then run the comprehension (here `collectInclusionListTransactions`). Returns an
+`Array` for the spec's `Sequence[Transaction]`; the dedup leaves order unspecified, as the
+spec notes. -/
+forkdef getInclusionListTransactions (store : InclusionListStore map) (state : State)
+    (slot : Slot) (onlyTimely : Bool := true) : Array Transaction :=
+  let committee := getInclusionListCommittee state slot
+  let key := htr committee
+  let inclusionLists := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
+  let equivocators := FcMap.lookupD store.equivocators key
+  collectInclusionListTransactions inclusionLists equivocators store.inclusionListTimeliness onlyTimely
+
+end
+
+/-- The Heze fork-choice store: the Gloas store plus the EIP-7805 fields. Re-declared as a
+`forkstruct` rather than an `inherit Store`, so the two `[New in Heze:EIP7805]` fields can be added.
+`payloadInclusionListSatisfaction` tracks, per beacon-block root, whether the revealed payload
+satisfied the inclusion-list constraints (`consensus-specs/specs/heze/fork-choice.md:134`);
+`inclusionListStore` folds in the spec's separate `InclusionListStore` (see the module docstring).
+The seventeen Gloas fields are restated verbatim. -/
+forkstruct Store (map : MapKind) [HasherTag] where
+  time                          : UInt64
+  genesisTime                   : UInt64
+  justifiedCheckpoint           : Checkpoint
+  finalizedCheckpoint           : Checkpoint
+  unrealizedJustifiedCheckpoint : Checkpoint
+  unrealizedFinalizedCheckpoint : Checkpoint
+  proposerBoostRoot             : Root
+  equivocatingIndices           : Array ValidatorIndex
+  blocks                        : map Root BeaconBlock
+  blockStates                   : map Root State
+  blockTimeliness               : map Root (Array Bool)
+  checkpointStates              : map Checkpoint State
+  latestMessages                : map ValidatorIndex LatestMessage
+  unrealizedJustifications      : map Root Checkpoint
+  payloads                      : map Root ExecutionPayloadEnvelope
+  payloadTimelinessVote         : map Root (Array (Option Bool))
+  payloadDataAvailabilityVote   : map Root (Array (Option Bool))
+  -- [New in Heze:EIP7805] (consensus-specs/specs/heze/fork-choice.md:134)
+  payloadInclusionListSatisfaction : map Root Bool
+  -- [New in Heze:EIP7805] the spec's standalone `InclusionListStore`, folded in here as a field
+  inclusionListStore            : InclusionListStore map
+
+fork_choice_section map
+
+/-- A PENDING node at `root`: the undecided block, before either payload realisation is
+committed. -/
+def ForkChoiceNode.pending (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusPending }
+
+/-- An EMPTY node at `root`: the realisation in which the block's payload is absent. -/
+def ForkChoiceNode.empty (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusEmpty }
+
+/-- A FULL node at `root`: the realisation in which the block's payload is present. -/
+def ForkChoiceNode.full (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusFull }
+
+inherit fcZeroRoot
+inherit getSlotsSinceGenesis
+inherit getCurrentSlot
+inherit getCurrentStoreEpoch
+inherit timeIntoSlotMs
+inherit bpsDeadlineMs
+inherit getParentPayloadStatus
+inherit isParentNodeFull
+inherit getAncestor
+inherit isAncestor
+inherit getCheckpointBlock
+inherit getSupportedNode
+inherit getDependentRoot
+inherit isPayloadVerified
+inherit voteCount
+inherit payloadTimeliness
+inherit payloadDataAvailability
+inherit isPreviousSlotPayloadDecision
+
+/-- `is_payload_inclusion_list_satisfied(store, root)`
+(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root` satisfied
+the inclusion-list constraints and is locally available. The spec opens with `assert root in
+store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so a missing
+key reads as `false` through `lookupD`, the same default-on-miss the sibling `payloadTimeliness`
+uses. That default sits off the spec path thanks to the `payloads`/satisfaction co-write; the
+INVARIANT note in `onExecutionPayloadEnvelope` is the canonical statement. -/
+forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : Bool :=
+  isPayloadVerified store root && FcMap.lookupD store.payloadInclusionListSatisfaction root
+
+/-- `should_extend_payload(store, root)` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:221-236`): the Gloas body with the one new
+inclusion-list gate. After the `is_payload_verified` check, a payload that fails the
+inclusion-list constraints is not extended (`fork-choice.md:226`). The rest is Gloas verbatim.
+-/
+forkdef shouldExtendPayload (store : Store map) (root : Root) : Bool :=
+  if !isPayloadVerified store root then false
+  -- [New in Heze:EIP7805] do not extend a payload that fails the inclusion-list constraints
+  else if !isPayloadInclusionListSatisfied store root then false
+  else
+    let proposerRoot := store.proposerBoostRoot
+    let payloadIsTimely := payloadTimeliness store root true
+    let payloadDataIsAvailable := payloadDataAvailability store root true
+    (payloadIsTimely && payloadDataIsAvailable)
+      || proposerRoot == fcZeroRoot
+      || (match FcMap.lookup store.blocks proposerRoot with
+          | some pb => pb.parentRoot != root || isParentNodeFull store pb
+          | none    => true)
+
+inherit getPayloadStatusTiebreaker
+inherit committeeWeight
+inherit calculateCommitteeFraction
+inherit getProposerScore
+inherit getAttestationScore
+inherit isHeadWeak
+inherit isParentStrong
+inherit shouldApplyProposerBoost
+inherit getWeight
+inherit getVotingSource
+inherit filterBlockTree
+inherit getFilteredBlockTree
+inherit getNodeChildren
+inherit getHead
+inherit updateCheckpoints
+inherit updateUnrealizedCheckpoints
+inherit computePulledUpTip
+inherit onTickPerSlot
+inherit advanceStoreTime
+inherit onTick
+inherit recordBlockTimeliness
+inherit updateProposerBoostRoot
+inherit recordPtcVotes
+inherit notifyPtcMessages
+inherit onBlock
+inherit computeTimeAtSlot
+inherit verifyExecutionPayloadEnvelopeSignature
+inherit verifyExecutionPayloadEnvelope
+
+-- The `is_inclusion_list_satisfied` verdict comes from an external EL over the Engine API
+-- (`consensus-specs/specs/heze/fork-choice.md:54-62`), so it enters through the framework's
+-- `[ExecutionEngine]` seam (`EthCLLib.Spec.Engine`, the canonical home of the optimistic-mock
+-- rationale), instantiated at Heze's payload / transaction types.
+variable [ExecutionEngine ExecutionPayload Transaction]
+
+/-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
+(`consensus-specs/specs/heze/fork-choice.md:54-62`): the `ExecutionEngine` predicate deciding
+whether a payload includes the required inclusion-list transactions. Its verdict is
+EL-implementation-defined (the Engine API answers it against an external EL), so it reads the
+`[ExecutionEngine]` seam rather than a fixed value; the default and the trust boundary are
+documented on `EthCLLib.Spec.ExecutionEngine`. -/
+forkdef isInclusionListSatisfied (payload : ExecutionPayload) (ilTxs : Array Transaction) : Bool :=
+  ExecutionEngine.isInclusionListSatisfied payload ilTxs
+
+/-- `record_payload_inclusion_list_satisfaction(store, state, root, payload, execution_engine)`
+(`consensus-specs/specs/heze/fork-choice.md:180-193`): record whether `payload` satisfies the
+inclusion-list constraints for `root`. Pure here (returns the updated store); the spec mutates
+in place. `get_inclusion_list_store()` is `store.inclusionListStore`; the required
+transactions are read for the previous slot (`state.slot - 1`) at the default `only_timely =
+True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
+`[ExecutionEngine]` seam (the spec's `execution_engine` argument, modeled injectably). -/
+forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
+    (payload : ExecutionPayload) : Store map :=
+  -- The spec reads `Slot(state.slot - 1)`, which assumes `state.slot ≥ 1` (a genesis/slot-0 state
+  -- never reaches a payload envelope). Guard the `UInt64` underflow explicitly: at slot 0 there is
+  -- no previous slot, so no inclusion-list transactions are required.
+  let stateSlot := sszGet state slot
+  let ilTxs := if stateSlot == 0 then #[]
+               else getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
+  let satisfied := isInclusionListSatisfied payload ilTxs
+  { store with
+      payloadInclusionListSatisfaction := FcMap.insert store.payloadInclusionListSatisfaction root satisfied }
+
+/-- `on_execution_payload_envelope` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:273-300`): the Gloas body with one added step,
+`record_payload_inclusion_list_satisfaction` is called on the verified envelope *before* the
+payload is stored (`fork-choice.md:295`), so `should_extend_payload` can later read the
+recorded verdict. `state` is the pre-verify `block_states[root]`, as in the spec; the warm
+state from `verify_execution_payload_envelope` is kept only for `blockStates`. -/
+forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) : StoreTransition Unit := do
+  let store ← get
+  let envelope := signedEnv.message
+  let state ← FcMap.getOrThrow store.blockStates envelope.beaconBlockRoot
+
+  match verifyExecutionPayloadEnvelope state signedEnv with
+  | .error e => throw e
+  | .ok warm =>
+    -- [New in Heze:EIP7805] record whether the payload satisfies the inclusion-list constraints
+    let store := recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
+    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are co-written here
+    -- (the satisfaction key via `recordPayloadInclusionListSatisfaction` just above). Keep them
+    -- co-written: `isPayloadInclusionListSatisfied`'s default-false-on-miss is sound only because a
+    -- verified `root` (present in `payloads`) always carries a satisfaction entry.
+    set { store with
+      blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
+      payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
+
+inherit onPayloadAttestationMessage
+inherit storeTargetCheckpointState
+inherit validateOnAttestation
+inherit updateLatestMessages
+inherit onAttestation
+inherit onAttesterSlashing
+
+/-- `get_forkchoice_store(anchor_state, anchor_block)` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:140-166`): the Gloas anchor store with the two
+`[New in Heze:EIP7805]` fields seeded empty, `payloadInclusionListSatisfaction` as an empty
+map and `inclusionListStore` as the empty `InclusionListStore` (`fork-choice.md:165`, decision
+A). The rest is Gloas verbatim. -/
+forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
+  let anchorRoot := htr anchorBlock
+  let epoch := currentEpochOf anchorState
+  let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
+
+  { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+    genesisTime := sszGet anchorState genesisTime
+    justifiedCheckpoint := cp, finalizedCheckpoint := cp
+    unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
+    blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
+    blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
+    checkpointStates := FcMap.insert FcMap.empty cp anchorState
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
+    payloads := FcMap.empty
+    payloadTimelinessVote := FcMap.empty
+    payloadDataAvailabilityVote := FcMap.empty
+    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the co-write
+    -- INVARIANT in `onExecutionPayloadEnvelope`).
+    payloadInclusionListSatisfaction := FcMap.empty
+    inclusionListStore := InclusionListStore.empty }
+
+/-- `get_inclusion_list_due_ms()` (`consensus-specs/specs/heze/fork-choice.md:242-243`):
+`get_slot_component_duration_ms(INCLUSION_LIST_DUE_BPS)`. `bpsDeadlineMs` (inherited from Gloas)
+IS `get_slot_component_duration_ms`. A fork-choice deadline helper leaning on that inherited
+fork-choice function, so it lives here with the rest of the fork-choice layer. -/
+forkdef getInclusionListDueMs : UInt64 := bpsDeadlineMs Const.inclusionListDueBps
+
+/-- `on_inclusion_list(store, signed_inclusion_list)` (the new wire handler,
+`consensus-specs/specs/heze/fork-choice.md:256-267`): on receiving an inclusion list, judge its
+timeliness against `INCLUSION_LIST_DUE_BPS` and hand it to `process_inclusion_list`. The spec's
+`seconds_to_milliseconds(store.time - store.genesis_time) % SLOT_DURATION_MS` is exactly the
+inherited `timeIntoSlotMs`. `process_inclusion_list` is total, so the spec's "an invalid call
+MUST NOT modify the store" is automatic here. The inclusion-list store rides inside `Store`, so
+`get_inclusion_list_store()` is `store.inclusionListStore`. -/
+forkdef onInclusionList (signed : SignedInclusionList) : StoreTransition Unit := do
+  let store ← get
+  let inclusionList := signed.message
+  let isTimely := timeIntoSlotMs store < getInclusionListDueMs
+  set { store with
+    inclusionListStore := processInclusionList store.inclusionListStore inclusionList isTimely }
+
+end
+
+/-! ### Build-enforced pin (vectorless): the inclusion-list satisfaction gate
+
+`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload` reads
+to refuse a payload that failed its inclusion-list constraints. No conformance vector exercises it,
+and the no-regression sweep only runs the optimistic `is_inclusion_list_satisfied = true` mock, so
+the discriminating `false` branch is otherwise dead. This pin drives the predicate on a minimal
+`Store` directly, fixing its outcomes by hand: verified + recorded-`false` ⇒ `false` (the gate's
+whole point), verified + recorded-`true` ⇒ `true`, unverified ⇒ `false` even with the bit recorded
+`true` (the `is_payload_verified` membership gate dominates), and verified-but-absent ⇒ `false`
+through the `lookupD` default (off the spec path; the co-write INVARIANT in
+`onExecutionPayloadEnvelope`). Hash-free (`is_payload_verified` is a `payloads`
+membership test, no `htr`), so kernel `#guard`. The pin reaches the predicate end-to-end, including
+the `isPayloadVerified` composition; it fixes the recorded bit by hand rather than through the EL,
+so the `isInclusionListSatisfied` verdict is out of its reach. That verdict is the
+`[ExecutionEngine]` seam's job: `pinRecordRefuted` below drives its refuting branch through the
+record path into this gate. -/
+
+private def pinPilsRoot : Root := Vector.replicate 32 9
+
+/-- A minimal Heze `Store` exercising `isPayloadInclusionListSatisfied` at `pinPilsRoot`.
+`payloadPresent` controls whether `root ∈ payloads` (the `is_payload_verified` gate); `recorded` is
+the optional `payloadInclusionListSatisfaction[root]` entry. Every other field is empty/zero
+(`FcMap.empty`, default checkpoints, `fcZeroRoot`), mirroring the `getForkchoiceStore` literal. The
+`payloads` value is never read (the predicate tests membership only), so a `default` envelope
+serves. The `letI`s fix the preset / hasher so the anonymous `Store` constructor synthesizes them. -/
+private def pinPilsStore (payloadPresent : Bool) (recorded : Option Bool) :
+    @Store minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { time := 0, genesisTime := 0
+    justifiedCheckpoint := default, finalizedCheckpoint := default
+    unrealizedJustifiedCheckpoint := default, unrealizedFinalizedCheckpoint := default
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.empty
+    blockStates := FcMap.empty
+    blockTimeliness := FcMap.empty
+    checkpointStates := FcMap.empty
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.empty
+    payloads := if payloadPresent then FcMap.insert FcMap.empty pinPilsRoot default else FcMap.empty
+    payloadTimelinessVote := FcMap.empty
+    payloadDataAvailabilityVote := FcMap.empty
+    payloadInclusionListSatisfaction :=
+      match recorded with
+      | some b => FcMap.insert FcMap.empty pinPilsRoot b
+      | none   => FcMap.empty
+    inclusionListStore := InclusionListStore.empty }
+
+/-- The predicate's verdict on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
+preset / hasher the `forkdef` parameters want (Lean re-synthesizes them rather than reading the
+store's fixed type), the same pattern the `InclusionListStore` pins in this file use. -/
+private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Bool :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  isPayloadInclusionListSatisfied (pinPilsStore payloadPresent recorded) pinPilsRoot
+
+-- verified + recorded `false` ⇒ `false` (do not extend this payload).
+#guard pinPils true (some false) = false
+-- verified + recorded `true` ⇒ `true`.
+#guard pinPils true (some true) = true
+-- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
+#guard pinPils false (some true) = false
+-- verified but no recorded entry ⇒ `false` via the `lookupD` default (off the spec path).
+#guard pinPils true none = false
+
+/-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
+
+`get_inclusion_list_due_ms`, `record_payload_inclusion_list_satisfaction`, and `on_inclusion_list`
+ship no conformance vector either. These drive them end-to-end so a future edit can't regress them
+silently: the deadline constant, the recorded EL verdict, and the timeliness bit `on_inclusion_list`
+threads into `process_inclusion_list`. -/
+
+/-- `get_inclusion_list_due_ms = INCLUSION_LIST_DUE_BPS * SLOT_DURATION_MS // BASIS_POINTS`. Under
+the minimal config that is `6667 * 6000 / 10000 = 4000` (truncating divide), pinning both the
+`INCLUSION_LIST_DUE_BPS = 6667` constant and the inherited `bpsDeadlineMs` composition. Arithmetic
+only (no hash), so kernel `#guard`. -/
+private def pinIlDueMs : UInt64 :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  getInclusionListDueMs
+#guard pinIlDueMs = 4000
+
+/-- `record_payload_inclusion_list_satisfaction` records the EL verdict at `root`. With the
+optimistic `isInclusionListSatisfied = true` mock (the `ExecutionEngine` default) it writes
+`true`; the slot-0 `state` drives the underflow-guard branch (no previous slot ⇒ empty required
+set, `getInclusionListTransactions` never reached), though the pinned value alone does not
+discriminate the guard: with an empty store and the optimistic oracle the verdict is `true`
+either way. `state` is a `FastBox` of the default minimal `BeaconState`, the boxed `State` the
+forkdef wants (`State = SSZ.Box HasherTag.H BeaconState`); `FastBox` is FFI-backed, so this is a
+`native_decide` `example`
+(`Lean.ofReduceBool`). -/
+private def pinRecordSatisfied : Option Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
+  let after := recordPayloadInclusionListSatisfaction (pinPilsStore false none) state pinPilsRoot
+    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
+  FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
+example : pinRecordSatisfied = some true := by native_decide
+
+/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path, now under a
+*refuting* `[ExecutionEngine]`. A local `letI` answering `false` overrides the global optimistic
+instance, the whole reason the seam exists. So the record path writes `false` at a *verified* `root`
+and `isPayloadInclusionListSatisfied` then refuses to extend it. This drives the
+`isInclusionListSatisfied = false` branch the optimistic default and every conformance vector leave
+dead, end-to-end: oracle → recorded verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`
+so the membership check passes and the recorded bit is what decides. `State` is FFI-backed
+(`FastBox`), so `native_decide`. -/
+private def pinRecordRefuted : Option Bool × Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  letI : ExecutionEngine (@EthCLSpecs.Heze.ExecutionPayload minimal) Transaction :=
+    { isInclusionListSatisfied := fun _ _ => false }
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
+  let after := recordPayloadInclusionListSatisfaction (pinPilsStore true none) state pinPilsRoot
+    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
+  (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot,
+   isPayloadInclusionListSatisfied after pinPilsRoot)
+-- refuting oracle ⇒ recorded `false`, and the gate rejects the verified payload.
+example : pinRecordRefuted = (some false, false) := by native_decide
+
+/-- `on_inclusion_list` threads the slot-timeliness bit into `process_inclusion_list`: a list
+received before `INCLUSION_LIST_DUE_BPS` is filed timely, one at/after the deadline untimely. Runs
+the handler end-to-end on a minimal store whose `time` puts `timeIntoSlotMs` below vs at the
+`getInclusionListDueMs = 4000` deadline, then reads the stored timeliness bit back at `htr il`.
+`process_inclusion_list` files the default list on branch (C), computing `htr` (FFI `Sha256`), so
+this is a `native_decide` `example` (`Lean.ofReduceBool`). -/
+private def pinOnIlTimely (time : UInt64) : Option Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let signed : @SignedInclusionList minimal := default
+  match runOn { pinPilsStore false none with time := time }
+      (onInclusionList (map := treeMap) signed : EStateM StoreTransitionError (Store treeMap) Unit) with
+  | .ok after => FcMap.lookup after.inclusionListStore.inclusionListTimeliness (htr signed.message)
+  | .error _  => none
+-- time 0: timeIntoSlotMs = 0 < 4000 ⇒ timely.
+example : pinOnIlTimely 0 = some true := by native_decide
+-- time 4: timeIntoSlotMs = 4000, not < 4000 ⇒ untimely.
+example : pinOnIlTimely 4 = some false := by native_decide
+
+/-! ### Build-enforced pins for the inclusion-list store (vectorless)
+
+FOCIL has no conformance vector, so these pin `process_inclusion_list`'s three branches and
+`get_inclusion_list_transactions`'s comprehension to hand-derived outcomes. They build a small
+`InclusionListStore treeMap` (deterministic key order) under the minimal preset and the FFI
+hasher. The branch-(A)/(B) pins and every `collectInclusionListTransactions` pin are
+hash-free, so kernel `#guard`; the branch-(C) pin computes `htr` (FFI `Sha256`), so it is a
+`native_decide` `example` (`Lean.ofReduceBool`), per the project's hash-tactic rule. -/
+
+private def pinKey : Root := Vector.replicate 32 7
+private def pinDummyRoot : Root := Vector.replicate 32 1
+private def pinAltRoot : Root := Vector.replicate 32 2
+
+/-- A transaction holding the single byte `b` (enough to make two transactions compare
+unequal for the dedup pins). -/
+private def pinTx (b : UInt8) : Transaction := sszOfArray #[b]
+
+/-- An inclusion list from validator `v` over committee `pinKey`, carrying `txs`. The `letI`
+fixes the preset so the anonymous constructor can synthesize it (a return-type annotation alone
+does not flow into instance resolution for `{ … }`). -/
+private def pinIL (v : ValidatorIndex) (txs : Array Transaction) : @InclusionList minimal :=
+  letI : Preset := minimal
+  { slot := 0, validatorIndex := v, inclusionListCommitteeRoot := pinKey, transactions := sszOfArray txs }
+
+/-- Number of inclusion lists stored under `pinKey`. The `letI`s supply the store's preset /
+hasher for the field projection (Lean re-synthesizes them rather than reading the argument's
+fixed type). -/
+private def pinNumStored (s : @InclusionListStore minimal treeMap fastHasherTag) : Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  ((FcMap.lookup s.inclusionLists pinKey).getD FcMap.empty |> FcMap.keys).length
+/-- The equivocator set recorded under `pinKey`. -/
+private def pinEquivs (s : @InclusionListStore minimal treeMap fastHasherTag) : Array ValidatorIndex :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  FcMap.lookupD s.equivocators pinKey
+
+/-- A store already holding one inclusion list from validator 5, filed under an arbitrary root
+(branch (B) never rehashes the stored list, so the key is free). Shared by the two branch-(B)
+pins. -/
+private def pinStoreB : @InclusionListStore minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { inclusionLists := FcMap.insert FcMap.empty pinKey (FcMap.insert FcMap.empty pinDummyRoot (pinIL 5 #[pinTx 0xAA])),
+    inclusionListTimeliness := FcMap.insert FcMap.empty pinDummyRoot true,
+    equivocators := FcMap.empty }
+
+-- Branch (A): a list from a validator already in `equivocators[key]` is ignored; nothing is
+-- stored and the equivocator set is untouched. Hash-free, so kernel `#guard`. Returns
+-- (stored count, equivocator count); expected (0, 1).
+private def pinResA : Nat × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let store : InclusionListStore treeMap :=
+    { InclusionListStore.empty with equivocators := FcMap.insert FcMap.empty pinKey #[5] }
+  let after := processInclusionList store (pinIL 5 #[pinTx 0xAA]) true
+  (pinNumStored after, (pinEquivs after).size)
+#guard pinResA = (0, 1)
+
+-- Branch (B), conflict: a second, differing list from validator 5 adds 5 to `equivocators[key]`
+-- and stores nothing new. Returns (equivocators, stored count); expected (#[5], 1).
+private def pinResBConflict : Array ValidatorIndex × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let after := processInclusionList pinStoreB (pinIL 5 #[pinTx 0xBB]) true
+  (pinEquivs after, pinNumStored after)
+#guard pinResBConflict = (#[5], 1)
+
+-- Branch (B), match: re-receiving the *same* list is a no-op. Returns (equivocator count,
+-- stored count); expected (0, 1).
+private def pinResBMatch : Nat × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let after := processInclusionList pinStoreB (pinIL 5 #[pinTx 0xAA]) true
+  ((pinEquivs after).size, pinNumStored after)
+#guard pinResBMatch = (0, 1)
+
+-- Branch (C): the first list from a validator is stored (one entry under `key`) with its
+-- timeliness recorded under `htr inclusion_list`. Reads the bit back at the actual `htr il` key
+-- (not just its presence), so a flipped `insert … (!isTimely)` fails; the stored-count half pins
+-- that branch (C) filed exactly one list. Computes `htr` (FFI `Sha256`), so `native_decide`
+-- `example`s. Returns (stored count, timeliness at `htr il`); expected (1, some isTimely).
+private def pinResC (isTimely : Bool) : Nat × Option Bool :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let store : InclusionListStore treeMap := InclusionListStore.empty
+  let il := pinIL 5 #[pinTx 0xAA]
+  let after := processInclusionList store il isTimely
+  (pinNumStored after, FcMap.lookup after.inclusionListTimeliness (htr il))
+example : pinResC true = (1, some true) := by native_decide
+example : pinResC false = (1, some false) := by native_decide
+
+-- `collectInclusionListTransactions` (the `get_inclusion_list_transactions` comprehension).
+-- Two stored lists: validator 5 → [0xAA], validator 6 → [0xAA, 0xBB], timeliness 5=true /
+-- 6=false. Pins worked out by hand from the comprehension. All hash-free, kernel `#guard`.
+private def pinLists : treeMap Root (@InclusionList minimal) :=
+  FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot (pinIL 5 #[pinTx 0xAA]))
+    pinAltRoot (pinIL 6 #[pinTx 0xAA, pinTx 0xBB])
+private def pinTimeliness : treeMap Root Bool :=
+  FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot true) pinAltRoot false
+
+/-- Run the comprehension over `pinLists` / `pinTimeliness` under the minimal preset, so the
+hash-free `#guard`s below need no ambient instance. -/
+private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) : Array Transaction :=
+  letI : Preset := minimal
+  collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely
+
+-- No equivocators, timeliness ignored: union of {0xAA} and {0xAA, 0xBB}, deduped to two.
+#guard (pinCollect #[] false).size = 2
+#guard (pinCollect #[] false).contains (pinTx 0xAA)
+#guard (pinCollect #[] false).contains (pinTx 0xBB)
+-- only_timely drops validator 6's untimely list, leaving just {0xAA}.
+#guard (pinCollect #[] true).size = 1
+#guard (pinCollect #[] true).contains (pinTx 0xAA)
+-- Equivocator 6 is filtered out regardless of timeliness, leaving just {0xAA}.
+#guard (pinCollect #[6] false).size = 1
+#guard (pinCollect #[6] false).contains (pinTx 0xAA)
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
@@ -5,10 +5,11 @@ import EthCLSpecs.Gloas.Containers
 # `EthCLSpecs.Heze.Inherited`: the inherited containers (everything but the new IL family)
 
 At alpha.11 EIP-7805 adds only the `InclusionList` family; every other Heze container is
-byte-identical to Gloas, so each is `inherit`ed (the capture replays the ancestor's
-field block in `EthCLSpecs.Heze`, giving a fresh twin with the same SSZ encoding). The
-bid, `ExecutionRequests`, and the ePBS containers are Gloas's; the component containers
-walk the lineage to Fulu's captures. `BeaconState` / `BeaconBlock*` are inherited in
+byte-identical to Gloas, so each is `inherit`ed: the ancestor's field block is re-declared
+in `EthCLSpecs.Heze`, giving a distinct type with the same SSZ encoding (the inheritance
+mechanism, `SPEC_AUTHORING_MODEL.md` §8). The bid, `ExecutionRequests`, and the ePBS
+containers come from Gloas; the component containers resolve through Gloas back to the
+definitions captured in Fulu. `BeaconState` / `BeaconBlock*` are inherited in
 `State` / `Block` (they need the `state_preamble` / signed-wrapper steps).
 -/
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
@@ -1,0 +1,68 @@
+import EthCLSpecs.Heze.Constants
+import EthCLSpecs.Gloas.Containers
+
+/-!
+# `EthCLSpecs.Heze.Inherited`: the inherited containers (everything but the new IL family)
+
+At alpha.11 EIP-7805 adds only the `InclusionList` family; every other Heze container is
+byte-identical to Gloas, so each is `inherit`ed (the capture replays the ancestor's
+field block in `EthCLSpecs.Heze`, giving a fresh twin with the same SSZ encoding). The
+bid, `ExecutionRequests`, and the ePBS containers are Gloas's; the component containers
+walk the lineage to Fulu's captures. `BeaconState` / `BeaconBlock*` are inherited in
+`State` / `Block` (they need the `state_preamble` / signed-wrapper steps).
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+-- Component containers (walk to Fulu's captures).
+inherit Checkpoint
+inherit AttestationData
+inherit Attestation
+inherit IndexedAttestation
+inherit AttesterSlashing
+inherit BLSToExecutionChange
+inherit BeaconBlockHeader
+inherit ConsolidationRequest
+inherit DepositData
+inherit Deposit
+inherit DepositRequest
+inherit Eth1Data
+inherit WithdrawalRequest
+inherit Fork
+inherit HistoricalSummary
+inherit PendingConsolidation
+inherit PendingDeposit
+inherit PendingPartialWithdrawal
+inherit SignedBeaconBlockHeader
+inherit ProposerSlashing
+inherit SignedBLSToExecutionChange
+inherit VoluntaryExit
+inherit SignedVoluntaryExit
+inherit SyncAggregate
+inherit SyncCommittee
+inherit Validator
+inherit Withdrawal
+
+-- ePBS + EIP-8282 containers (declared in Gloas; FOCIL leaves them untouched at alpha.11).
+inherit Builder
+inherit BuilderDepositRequest
+inherit BuilderExitRequest
+inherit BuilderPendingWithdrawal
+inherit BuilderPendingPayment
+inherit ExecutionRequests
+inherit PayloadAttestationData
+inherit PayloadAttestation
+inherit IndexedPayloadAttestation
+inherit PayloadAttestationMessage
+inherit ExecutionPayload
+inherit ExecutionPayloadBid
+inherit SignedExecutionPayloadBid
+inherit ExecutionPayloadEnvelope
+inherit SignedExecutionPayloadEnvelope
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -8,15 +8,18 @@ import EthCLSpecs.Heze.ForkChoice
 /-!
 # `EthCLSpecs.Heze.Interface`: the Heze fork-interface instance
 
-Heze's implementation of `ForkInterface`. At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state
-transition and no *vector-tested* fork-choice change: its overrides run on the existing fork_choice
-vectors but stay Gloas-equivalent (empty inclusion-list store), and the FOCIL-specific behavior
-ships no vector, so every dynamic runner reuses the Gloas spine re-instantiated over Heze types
-(`Heze.EpochProcessing` / `Operations` / `Withdrawals` /
-`Transition` / `ForkChoice`). `runUpgrade` is the Gloas→Heze `fork` format (a pure field
-copy, no onboarding); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
-Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model are
-`outOfScope` (reported `skip` rather than counted as xfail work), matching Fulu / Gloas. Pinned to
+Heze's implementation of `ForkInterface`, the entry points the pyspec runner drives
+(`SPEC_AUTHORING_MODEL.md` §11). At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state transition
+and no vector-tested fork-choice change. Its fork-choice overrides do run on the existing
+fork_choice vectors, but only on the path where the inclusion-list store stays empty, which
+behaves exactly like Gloas; the FOCIL-specific behavior ships no vector. So every dynamic
+runner reuses the Gloas spine re-instantiated over Heze types (`Heze.EpochProcessing` /
+`Operations` / `Withdrawals` / `Transition` / `ForkChoice`).
+
+The Heze-specific entries: `runUpgrade` is the Gloas→Heze `fork` format (a pure field copy,
+see `upgradeToHeze`); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
+Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model report
+`outOfScope`, a deliberate skip rather than xfail work, matching Fulu / Gloas. Pinned to
 v1.7.0-alpha.11.
 -/
 
@@ -45,8 +48,7 @@ private def stateRootImpl (P : Preset) (bytes : ByteArray) :
 
 /-- `runUpgrade` (the `fork` format, Gloas→Heze): decode the Gloas pre-state at preset `P`,
 apply `upgradeToHeze` with the config's `HEZE_FORK_VERSION`, return the Heze post root. A
-pure field copy; no onboarding / PTC recompute (builders are already onboarded in the Gloas
-state). -/
+pure field copy; `upgradeToHeze`'s docstring carries the why. -/
 private def runUpgradeImpl (P : Preset) (forkVersion : Version) (preBytes : ByteArray) :
     Except (RunError StateTransitionError) ByteArray :=
   letI : Preset := P
@@ -187,8 +189,8 @@ private def runBlocksImpl (P : Preset) (C : Config) (preBytes : ByteArray)
 
 /-- `runTransition` (the `transition` format, Gloas→Heze): fold the pre-fork blocks under
 Gloas `state_transition`, advance the Gloas state to the fork-epoch boundary, apply
-`upgradeToHeze` (pure copy, no onboarding), then fold the post-fork blocks under the Heze
-spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
+`upgradeToHeze` (a pure copy, see its docstring), then fold the post-fork blocks under the
+Heze spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
 qualified. -/
 private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
     (preBytes : ByteArray) (blocks : Array ByteArray) (cmeta : CaseMeta) :

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -1,0 +1,402 @@
+import EthCLSpecs.Heze.Upgrade
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Heze.Operations
+import EthCLSpecs.Heze.Withdrawals
+import EthCLSpecs.Heze.Transition
+import EthCLSpecs.Heze.ForkChoice
+
+/-!
+# `EthCLSpecs.Heze.Interface`: the Heze fork-interface instance
+
+Heze's implementation of `ForkInterface`. At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state
+transition and no *vector-tested* fork-choice change: its overrides run on the existing fork_choice
+vectors but stay Gloas-equivalent (empty inclusion-list store), and the FOCIL-specific behavior
+ships no vector, so every dynamic runner reuses the Gloas spine re-instantiated over Heze types
+(`Heze.EpochProcessing` / `Operations` / `Withdrawals` /
+`Transition` / `ForkChoice`). `runUpgrade` is the Gloas→Heze `fork` format (a pure field
+copy, no onboarding); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
+Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model are
+`outOfScope` (reported `skip` rather than counted as xfail work), matching Fulu / Gloas. Pinned to
+v1.7.0-alpha.11.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLLib.PySpecTests
+open EthCLSpecs.Fulu
+open SizzLean
+open SizzLean.Cache
+open SizzLean.Hasher
+
+namespace EthCLSpecs.Heze.Interface
+
+/-- Pinned upstream release; Heze tracks the same tag as Fulu / Gloas. -/
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
+
+/-- `stateRoot`: decode a Heze `BeaconState` at preset `P` and take its root. -/
+private def stateRootImpl (P : Preset) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := @Heze.BeaconState P) bytes with
+  | .ok v    => .ok (htr v)
+  | .error _ => .error (.decode "BeaconState")
+
+/-- `runUpgrade` (the `fork` format, Gloas→Heze): decode the Gloas pre-state at preset `P`,
+apply `upgradeToHeze` with the config's `HEZE_FORK_VERSION`, return the Heze post root. A
+pure field copy; no onboarding / PTC recompute (builders are already onboarded in the Gloas
+state). -/
+private def runUpgradeImpl (P : Preset) (forkVersion : Version) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := @Gloas.BeaconState P) preBytes with
+  | .ok pre  => .ok (htr (upgradeToHeze forkVersion pre))
+  | .error _ => .error (.decode "Gloas BeaconState")
+
+/-- Decode a Heze `BeaconState` into a `FastBox`, or the runner's `decode` error. -/
+private def decodeState (P : Preset) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (SSZ.Box Sha256 (@Heze.BeaconState P)) :=
+  letI : Preset := P
+  match SSZ.FastBox.deserialize (T := @Heze.BeaconState P) bytes with
+  | .ok box  => .ok box
+  | .error _ => .error (.decode "BeaconState")
+
+/-- `runEpochSubstep`: dispatch the `epoch_processing/<handler>` name to its Heze substep,
+run it over the decoded Heze pre-state, return the post root. Every substep is the Gloas
+one re-instantiated over Heze. -/
+private def runEpochSubstepImpl (P : Preset) (C : Config) (step : EpochStep) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit :=
+    match step with
+    | .slashingsReset               => processSlashingsReset
+    | .randaoMixesReset             => processRandaoMixesReset
+    | .eth1DataReset                => processEth1DataReset
+    | .historicalSummariesUpdate    => processHistoricalSummariesUpdate
+    | .participationFlagUpdates     => processParticipationFlagUpdates
+    | .justificationAndFinalization => processJustificationAndFinalization
+    | .inactivityUpdates            => processInactivityUpdates
+    | .rewardsAndPenalties          => processRewardsAndPenalties
+    | .registryUpdates              => processRegistryUpdates
+    | .slashings                    => processSlashings
+    | .effectiveBalanceUpdates      => processEffectiveBalanceUpdates
+    | .pendingDeposits              => processPendingDeposits
+    | .pendingDepositsChurn         => processPendingDeposits
+    | .pendingConsolidations        => processPendingConsolidations
+    | .builderPendingPayments       => processBuilderPendingPayments
+    | .syncCommitteeUpdates         => processSyncCommitteeUpdates
+    | .proposerLookahead            => processProposerLookahead
+    | .ptcWindow                    => processPtcWindow
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runRewards`: the four reward-delta blobs computed by the inherited Heze delta
+functions. The `Deltas` container is Fulu's (fork-agnostic). -/
+private def runRewardsImpl (P : Preset) (C : Config) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) (Array ByteArray) := do
+  let state ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  let mkDeltas : Array Gwei × Array Gwei → ByteArray := fun rp =>
+    SSZ.serialize ({ rewards := sszOfArray rp.1, penalties := sszOfArray rp.2 } : Fulu.Deltas)
+  let n := (sszGet state validators).size
+  let zeros := Array.replicate n (0 : Gwei)
+  RunError.ofSpec do
+    let d0 ← liftErr (getFlagIndexDeltas state 0)
+    let d1 ← liftErr (getFlagIndexDeltas state 1)
+    let d2 ← liftErr (getFlagIndexDeltas state 2)
+    pure #[mkDeltas d0, mkDeltas d1, mkDeltas d2, mkDeltas (zeros, getInactivityPenaltyDeltas state)]
+
+/-- Decode a plain (non-boxed) SSZ operation value. -/
+private def decodeOp (T : Type) [SizzLean.SSZRepr T] (b : ByteArray) :
+    Except (RunError StateTransitionError) T :=
+  match SSZ.deserialize (T := T) b with
+  | .ok v    => .ok v
+  | .error _ => .error (.decode "operation")
+
+/-- `runOperation`: dispatch every operation handler over the decoded Heze pre-state. Each
+handler is the Gloas one re-instantiated over Heze. -/
+private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
+    (preBytes opBytes : ByteArray) (cmeta : CaseMeta) : Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let dispatch : Except (RunError StateTransitionError) (EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit) :=
+    match kind with
+    | .proposerSlashing       => (decodeOp (@ProposerSlashing P) opBytes).map processProposerSlashing
+    | .attesterSlashing       => (decodeOp (@AttesterSlashing P) opBytes).map processAttesterSlashing
+    | .attestation            => (decodeOp (@Attestation P) opBytes).map processAttestation
+    | .payloadAttestation     => (decodeOp (@PayloadAttestation P) opBytes).map processPayloadAttestation
+    | .executionPayloadBid    => (decodeOp (@SignedExecutionPayloadBid P) opBytes).map processExecutionPayloadBid
+    | .parentExecutionPayload => (decodeOp (@BeaconBlock P) opBytes).map processParentExecutionPayload
+    | .blockHeader            => (decodeOp (@BeaconBlock P) opBytes).map processBlockHeader
+    | .withdrawals            => .ok processWithdrawals
+    | .voluntaryExit          => (decodeOp (@SignedVoluntaryExit P) opBytes).map processVoluntaryExit
+    | .voluntaryExitChurn     => (decodeOp (@SignedVoluntaryExit P) opBytes).map processVoluntaryExit
+    | .blsToExecutionChange   => (decodeOp (@SignedBLSToExecutionChange P) opBytes).map processBlsToExecutionChange
+    | .depositRequest         => (decodeOp (@DepositRequest P) opBytes).map processDepositRequest
+    | .withdrawalRequest      => (decodeOp (@WithdrawalRequest P) opBytes).map processWithdrawalRequest
+    | .consolidationRequest   => (decodeOp (@ConsolidationRequest P) opBytes).map processConsolidationRequest
+    | .builderDepositRequest  => (decodeOp (@Heze.BuilderDepositRequest P) opBytes).map processBuilderDepositRequest
+    | .builderExitRequest     => (decodeOp (@Heze.BuilderExitRequest P) opBytes).map processBuilderExitRequest
+    | .syncAggregate          => (decodeOp (@SyncAggregate P) opBytes).map processSyncAggregate
+    | .deposit | .executionPayload =>
+        .error (.spec (.todo s!"heze operations/{reprStr kind}: not a standalone ePBS operation"))
+  match dispatch with
+  | .error e   => .error e
+  | .ok action =>
+    RunError.ofSpec (runToRoot box0 action)
+
+/-- `runSlots`: advance the decoded Heze pre-state by `n` empty slots. -/
+private def runSlotsImpl (P : Preset) (C : Config) (preBytes : ByteArray) (n : Nat) :
+    Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+    let state ← get
+    processSlots ((sszGet state slot) + UInt64.ofNat n)
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runBlocks` (`sanity/blocks`, `finality`, `random`): fold the Heze `state_transition`
+over the decoded signed blocks. -/
+private def runBlocksImpl (P : Preset) (C : Config) (preBytes : ByteArray)
+    (blocks : Array ByteArray) (cmeta : CaseMeta) : Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  let signedBlocks ← blocks.mapM (fun bb =>
+    match SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bb with
+    | .ok sb   => .ok sb
+    | .error _ => .error (RunError.decode "Heze SignedBeaconBlock"))
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+    for sb in signedBlocks do stateTransition sb
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runTransition` (the `transition` format, Gloas→Heze): fold the pre-fork blocks under
+Gloas `state_transition`, advance the Gloas state to the fork-epoch boundary, apply
+`upgradeToHeze` (pure copy, no onboarding), then fold the post-fork blocks under the Heze
+spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
+qualified. -/
+private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
+    (preBytes : ByteArray) (blocks : Array ByteArray) (cmeta : CaseMeta) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let forkEpoch := cmeta.forkEpoch.getD 0
+  let boundary : Slot := UInt64.ofNat (forkEpoch * Const.slotsPerEpoch)
+  let nPre := match cmeta.forkBlock with | some n => n + 1 | none => 0
+  match SSZ.deserialize (T := @Gloas.BeaconState P) preBytes with
+  | .error _ => .error (.decode "Gloas BeaconState")
+  | .ok preGloas => do
+    let preBlocks ← (List.range nPre).toArray.mapM (fun i =>
+      match blocks[i]? with
+      | none    => Except.error (RunError.spec (.outOfBounds i blocks.size))
+      | some bb => match SSZ.deserialize (T := @Gloas.SignedBeaconBlock P) bb with
+        | .ok sb   => Except.ok sb
+        | .error _ => Except.error (RunError.decode "Gloas SignedBeaconBlock"))
+    let postBlocks ← (blocks.extract nPre blocks.size).mapM (fun bb =>
+      match SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bb with
+      | .ok sb   => Except.ok sb
+      | .error _ => Except.error (RunError.decode "Heze SignedBeaconBlock"))
+    let gloasBox0 : SSZ.Box Sha256 (@Gloas.BeaconState P) := SSZ.FastBox preGloas
+    let gloasAction : EStateM StateTransitionError (SSZ.Box Sha256 (@Gloas.BeaconState P)) Unit := do
+      for sb in preBlocks do Gloas.stateTransition sb
+      if (sszGet (← get) slot) < boundary then Gloas.processSlots boundary
+    match gloasAction.run gloasBox0 with
+    | .error e _ => Except.error (RunError.spec e)
+    | .ok _ gloasSt =>
+      let hezeBox0 : SSZ.Box Sha256 (@Heze.BeaconState P) := SSZ.FastBox (upgradeToHeze forkVersion gloasSt.view)
+      let hezeAction : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+        for sb in postBlocks do
+          if (sszGet (← get) slot) < sb.message.slot then processSlots sb.message.slot
+          if cmeta.blsSetting != 2 then assert (verifyBlockSignature (← get) sb)
+          processBlock sb.message
+          let root ← getStateRoot
+          assert (sb.message.stateRoot == bytesToRoot root)
+      RunError.ofSpec (runToRoot hezeBox0 hezeAction)
+
+/-- Fold the decoded fork-choice `steps` over the Heze store. Identical shape to Gloas's
+interpreter, re-instantiated over Heze types: a `block` step runs `on_block` then replays
+the block's own attestations / attester-slashings; `execution_payload` /
+`payload_attestation_message` drive the two ePBS handlers; the checks read the head node's
+payload status and the per-block PTC vote arrays. -/
+private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
+    (P : Preset) (store0 : Store hashMap) (steps : Array FcStep) : Except StoreTransitionError Unit := do
+  let mut store : Store hashMap := store0
+  for step in steps do
+    match step with
+    | .tick t =>
+      store := (← checkStepValidity store true
+        (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
+    | .block bytes _columns valid =>
+      let outcome := decodeStepOr (α := @Heze.SignedBeaconBlock P) bytes "block" fun sb =>
+        let action : EStateM StoreTransitionError (Store hashMap) Unit := do
+          onBlock (map := hashMap) sb
+          for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+          for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+        runOn store action
+      store := (← checkStepValidity store valid outcome)
+    | .attestation bytes valid =>
+      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" fun a =>
+        runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .attesterSlashing bytes valid =>
+      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" fun a =>
+        runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .executionPayload bytes valid =>
+      let outcome := decodeStepOr (α := @Heze.SignedExecutionPayloadEnvelope P) bytes "envelope" fun env =>
+        runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .payloadAttestationMessage bytes valid =>
+      let outcome := decodeStepOr (α := @Heze.PayloadAttestationMessage P) bytes "ptc message" fun msg =>
+        runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .checkHead root slot =>
+      let head := getHead store
+      assert (head.root == root)
+      let headSlot := match FcMap.lookup store.blocks head.root with | some b => b.slot.toNat | none => 0
+      assert (headSlot == slot)
+    | .checkHeadPayloadStatus status =>
+      assert ((getHead store).payloadStatus.toNat == status)
+    | .checkPayloadTimelinessVote blockRoot votes =>
+      assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
+    | .checkPayloadDataAvailabilityVote blockRoot votes =>
+      assert (FcMap.lookupD store.payloadDataAvailabilityVote (bytesToRoot blockRoot) == votes)
+    | .checkJustified epoch root =>
+      assert (store.justifiedCheckpoint.epoch.toNat == epoch)
+      assert (store.justifiedCheckpoint.root == root)
+    | .checkFinalized epoch root =>
+      assert (store.finalizedCheckpoint.epoch.toNat == epoch)
+      assert (store.finalizedCheckpoint.root == root)
+    | .checkBoost root =>
+      assert (store.proposerBoostRoot == root)
+    | .checkTime t => assert (store.time.toNat == t)
+    | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
+    | .unsupported reason => throw (StoreTransitionError.todo reason)
+    -- `get_proposer_head` is Gloas-Modified but not ported, and no alpha.11 vector exercises it;
+    -- surface it as unmodeled (a `todo` xfail) rather than passing it vacuously. This arm makes
+    -- the match exhaustive over `FcStep`, so a newly added constructor becomes a build error rather
+    -- than a silent pass through a catch-all.
+    | .checkProposerHead _ => throw (StoreTransitionError.todo "get_proposer_head check: not modeled")
+  pure ()
+
+/-- `runForkChoice` (Heze): decode the anchor state / block, build the ePBS store, and run
+the step interpreter. -/
+private def runForkChoiceImpl (P : Preset) (C : Config) (anchorStateBytes anchorBlockBytes : ByteArray)
+    (steps : Array FcStep) : Except (RunError StoreTransitionError) Unit :=
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  match SSZ.FastBox.deserialize (T := @Heze.BeaconState P) anchorStateBytes,
+        SSZ.deserialize (T := @Heze.BeaconBlock P) anchorBlockBytes with
+  | .error _, _ => .error (.decode "fork_choice anchor state")
+  | _, .error _ => .error (.decode "fork_choice anchor block")
+  | .ok anchorState, .ok anchorBlock =>
+    RunError.ofSpec (fcInterpretHeze P (getForkchoiceStore anchorState anchorBlock) steps)
+
+/-- The `ssz_static` per-type kernel: decode `bytes` as `T`, return its root paired with
+the round-trip check (`reserialize == bytes`). -/
+private def runStatic (T : Type) [SizzLean.SSZRepr T] (typeName : String) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (ByteArray × Bool) :=
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := T) bytes with
+  | .ok v    => .ok ((htr v : ByteArray), SSZ.serialize v == bytes)
+  | .error _ => .error (.decode typeName)
+
+/-- `sszStatic`: the Gloas set retargeted to the Heze namespace, plus the FOCIL-new
+`InclusionList` / `SignedInclusionList`. Types Heze does not model report `.outOfScope`
+(skip), matching Fulu / Gloas. -/
+private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (ByteArray × Bool) :=
+  match typeName with
+  | "AttestationData"            => runStatic (@Heze.AttestationData P) typeName bytes
+  | "Attestation"                => runStatic (@Heze.Attestation P) typeName bytes
+  | "AttesterSlashing"           => runStatic (@Heze.AttesterSlashing P) typeName bytes
+  | "BeaconBlock"                => runStatic (@Heze.BeaconBlock P) typeName bytes
+  | "BeaconBlockBody"            => runStatic (@Heze.BeaconBlockBody P) typeName bytes
+  | "BeaconBlockHeader"          => runStatic (@Heze.BeaconBlockHeader P) typeName bytes
+  | "BeaconState"                => runStatic (@Heze.BeaconState P) typeName bytes
+  | "BLSToExecutionChange"       => runStatic (@Heze.BLSToExecutionChange P) typeName bytes
+  | "Builder"                    => runStatic (@Heze.Builder P) typeName bytes
+  | "BuilderDepositRequest"      => runStatic (@Heze.BuilderDepositRequest P) typeName bytes
+  | "BuilderExitRequest"         => runStatic (@Heze.BuilderExitRequest P) typeName bytes
+  | "BuilderPendingPayment"      => runStatic (@Heze.BuilderPendingPayment P) typeName bytes
+  | "BuilderPendingWithdrawal"   => runStatic (@Heze.BuilderPendingWithdrawal P) typeName bytes
+  | "Checkpoint"                 => runStatic (@Heze.Checkpoint P) typeName bytes
+  | "ConsolidationRequest"       => runStatic (@Heze.ConsolidationRequest P) typeName bytes
+  | "Deposit"                    => runStatic (@Heze.Deposit P) typeName bytes
+  | "DepositData"                => runStatic (@Heze.DepositData P) typeName bytes
+  | "DepositRequest"             => runStatic (@Heze.DepositRequest P) typeName bytes
+  | "Eth1Data"                   => runStatic (@Heze.Eth1Data P) typeName bytes
+  | "ExecutionPayload"           => runStatic (@Heze.ExecutionPayload P) typeName bytes
+  | "ExecutionPayloadBid"        => runStatic (@Heze.ExecutionPayloadBid P) typeName bytes
+  | "ExecutionPayloadEnvelope"   => runStatic (@Heze.ExecutionPayloadEnvelope P) typeName bytes
+  | "ExecutionRequests"          => runStatic (@Heze.ExecutionRequests P) typeName bytes
+  | "Fork"                       => runStatic (@Heze.Fork P) typeName bytes
+  | "HistoricalSummary"          => runStatic (@Heze.HistoricalSummary P) typeName bytes
+  | "InclusionList"              => runStatic (@Heze.InclusionList P) typeName bytes
+  | "IndexedAttestation"         => runStatic (@Heze.IndexedAttestation P) typeName bytes
+  | "IndexedPayloadAttestation"  => runStatic (@Heze.IndexedPayloadAttestation P) typeName bytes
+  | "PayloadAttestation"         => runStatic (@Heze.PayloadAttestation P) typeName bytes
+  | "PayloadAttestationData"     => runStatic (@Heze.PayloadAttestationData P) typeName bytes
+  | "PayloadAttestationMessage"  => runStatic (@Heze.PayloadAttestationMessage P) typeName bytes
+  | "PendingConsolidation"       => runStatic (@Heze.PendingConsolidation P) typeName bytes
+  | "PendingDeposit"             => runStatic (@Heze.PendingDeposit P) typeName bytes
+  | "PendingPartialWithdrawal"   => runStatic (@Heze.PendingPartialWithdrawal P) typeName bytes
+  | "ProposerSlashing"           => runStatic (@Heze.ProposerSlashing P) typeName bytes
+  | "SyncAggregate"              => runStatic (@Heze.SyncAggregate P) typeName bytes
+  | "SyncCommittee"              => runStatic (@Heze.SyncCommittee P) typeName bytes
+  | "Validator"                  => runStatic (@Heze.Validator P) typeName bytes
+  | "VoluntaryExit"              => runStatic (@Heze.VoluntaryExit P) typeName bytes
+  | "Withdrawal"                 => runStatic (@Heze.Withdrawal P) typeName bytes
+  | "WithdrawalRequest"          => runStatic (@Heze.WithdrawalRequest P) typeName bytes
+  | "SignedBeaconBlock"          => runStatic (@Heze.SignedBeaconBlock P) typeName bytes
+  | "SignedBeaconBlockHeader"    => runStatic (@Heze.SignedBeaconBlockHeader P) typeName bytes
+  | "SignedBLSToExecutionChange" => runStatic (@Heze.SignedBLSToExecutionChange P) typeName bytes
+  | "SignedExecutionPayloadBid"      => runStatic (@Heze.SignedExecutionPayloadBid P) typeName bytes
+  | "SignedExecutionPayloadEnvelope" => runStatic (@Heze.SignedExecutionPayloadEnvelope P) typeName bytes
+  | "SignedInclusionList"        => runStatic (@Heze.SignedInclusionList P) typeName bytes
+  | "SignedVoluntaryExit"        => runStatic (@Heze.SignedVoluntaryExit P) typeName bytes
+  | _ => .error (.spec (.outOfScope s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Heze"))
+
+/-- Heze's fork-interface instance at preset `P` / config `C` with `HEZE_FORK_VERSION`.
+Every in-scope entry is driven via the inherited Gloas spine over Heze state; `runUpgrade`
+is the pure Gloas→Heze copy and `runTransition` the Gloas→Heze boundary. `runGenesis` is
+`outOfScope` (not modeled; no genesis vectors at the pin), as in Fulu / Gloas. -/
+@[reducible] def hezeInterfaceFor (P : Preset) (C : Config) (forkVersion : Version) : ForkInterface where
+  stateRoot       := stateRootImpl P
+  sszStatic       := sszStaticImpl P
+  runUpgrade      := runUpgradeImpl P forkVersion
+  runEpochSubstep := runEpochSubstepImpl P C
+  runRewards      := runRewardsImpl P C
+  runForkChoice   := runForkChoiceImpl P C
+  runOperation    := runOperationImpl P C
+  runBlocks       := runBlocksImpl P C
+  runSlots        := runSlotsImpl P C
+  runGenesis      := fun _ _   => .error (.spec (.outOfScope "heze genesis: out of scope (not modeled)"))
+  runTransition   := runTransitionImpl P C forkVersion
+
+/-- The `minimal`-preset / config Heze interface. -/
+@[reducible] def hezeInterface : ForkInterface := hezeInterfaceFor minimal minimalConfig hezeForkVersionMinimal
+
+/-- The `mainnet`-preset / config Heze interface (on demand). -/
+@[reducible] def hezeInterfaceMainnet : ForkInterface := hezeInterfaceFor mainnet mainnetConfig hezeForkVersionMainnet
+
+end EthCLSpecs.Heze.Interface

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
@@ -1,0 +1,71 @@
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Gloas.Operations
+
+/-!
+# `EthCLSpecs.Heze.Operations`: the inherited operation handlers (Gloas over Heze state)
+
+EIP-7805 changes no block operation. Every Gloas operation handler (the inherited
+non-ePBS ones and the ePBS-modified / EIP-8282 builder ones) is `inherit`ed over Heze
+state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas (not captured by
+`forkdef`), so it is restated here before its first use.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+/-- `withdrawal_credentials[12:]` as a 20-byte execution address. Restated from Gloas
+(a plain `def` rather than an inheritable `forkdef`). -/
+private def addressOfCred (wc : Bytes32) : ExecutionAddress := Vector.ofFn (fun i : Fin 20 => wc[12 + i.val])
+
+inherit isSlashableAttestationData
+inherit isValidIndexedAttestation
+inherit isValidSwitchToCompoundingRequest
+inherit getAttestingIndices
+inherit processAttesterSlashing
+inherit processBlockHeader
+inherit processBlsToExecutionChange
+inherit processWithdrawalRequest
+inherit processConsolidationRequest
+inherit processDepositRequest
+inherit processVoluntaryExit
+inherit processSyncAggregate
+inherit isBuilderIndex
+inherit toBuilderIndex
+inherit isActiveBuilder
+inherit getPendingBalanceToWithdrawForBuilder
+inherit builderPaymentIndex
+inherit isBuilderWithdrawalCredential
+inherit isPendingValidator
+inherit initiateBuilderExit
+inherit getIndexForNewBuilder
+inherit addBuilderToRegistry
+inherit applyDepositForBuilder
+inherit onboardBuildersFromPendingDeposits
+inherit isValidBuilderDepositSignature
+inherit processBuilderDepositRequest
+inherit processBuilderExitRequest
+inherit processProposerSlashing
+inherit isAttestationSameSlot
+inherit getAttestationParticipationFlagIndices
+inherit processAttestation
+inherit getPtc
+inherit getIndexedPayloadAttestation
+inherit isValidIndexedPayloadAttestation
+inherit processPayloadAttestation
+inherit convertBuilderIndexToValidatorIndex
+inherit canBuilderCoverBid
+inherit verifyExecutionPayloadBidSignature
+inherit settleBuilderPayment
+inherit processExecutionPayloadBid
+inherit applyParentExecutionPayload
+inherit processParentExecutionPayload
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
@@ -6,8 +6,9 @@ import EthCLSpecs.Gloas.Operations
 
 EIP-7805 changes no block operation. Every Gloas operation handler (the inherited
 non-ePBS ones and the ePBS-modified / EIP-8282 builder ones) is `inherit`ed over Heze
-state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas (not captured by
-`forkdef`), so it is restated here before its first use.
+state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas, and only the capturing
+declaration forms (`forkdef` / `forkcontainer` / `forkstruct`, `SPEC_AUTHORING_MODEL.md`
+§8.5) are stored for `inherit` to replay, so it is restated here before its first use.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -26,11 +26,15 @@ state_section
 signature by its committee member's key under `DOMAIN_INCLUSION_LIST_COMMITTEE` at the
 message's epoch. Mirrors the Python step-for-step: read `message`, the validator `pubkey` at
 `validator_index`, the domain, `compute_signing_root(message, domain)`, then `bls.Verify`.
-`blsVerify` is the residual trust boundary (the `[CryptoBackend]` seam): no pure assertion
-pins it, the same treatment Gloas gives `verify_execution_payload_bid_signature` and the
-builder-deposit signature predicate. It has no in-model caller by design. The spec's sole
-consumer is the p2p `inclusion_list` gossip `[REJECT]` (`p2p-interface.md:100`), and EthCLSpecs
-models the state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
+
+The signature check itself, `blsVerifySigned`, goes through the `[CryptoBackend]` seam
+(`FRAMEWORK_ARCHITECTURE.md` §1), and no build-enforced pin fixes its verdict. That is the
+same trust boundary every signature predicate keeps (Gloas's bid and builder-deposit
+signatures included).
+
+The predicate has no in-model caller, by design. Its sole consumer in the spec is the p2p
+`inclusion_list` gossip `[REJECT]` rule (`p2p-interface.md:100`), and EthCLSpecs models the
+state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
 conformance scope). `on_inclusion_list` carries no signature check of its own
 (`fork-choice.md:256-267`), so the fork-choice path mirrors the spec faithfully. Kept as the
 beacon-chain surface for spec-completeness. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -1,0 +1,53 @@
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Heze.Containers
+
+/-!
+# `EthCLSpecs.Heze.Signing`: the EIP-7805 (FOCIL) inclusion-list signature predicate
+
+Heze inherits the domain accessor and the rest of the signing surface from Fulu; this file adds
+the one new predicate EIP-7805 introduces. `is_valid_inclusion_list_signature` (the "Predicates"
+section, `consensus-specs/specs/heze/beacon-chain.md:76-87`) checks a `SignedInclusionList`'s BLS
+signature under `DOMAIN_INCLUSION_LIST_COMMITTEE`. `blsVerifySigned` is the residual trust
+boundary (the `[CryptoBackend]` seam), as for every other signature predicate; no pure assertion
+pins it. FOCIL adds no state transition, so this is a pure predicate rather than a transition step.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+/-- `is_valid_inclusion_list_signature(state, signed_inclusion_list)` (EIP-7805,
+`consensus-specs/specs/heze/beacon-chain.md:76-87`): the `InclusionList` carries a valid BLS
+signature by its committee member's key under `DOMAIN_INCLUSION_LIST_COMMITTEE` at the
+message's epoch. Mirrors the Python step-for-step: read `message`, the validator `pubkey` at
+`validator_index`, the domain, `compute_signing_root(message, domain)`, then `bls.Verify`.
+`blsVerify` is the residual trust boundary (the `[CryptoBackend]` seam): no pure assertion
+pins it, the same treatment Gloas gives `verify_execution_payload_bid_signature` and the
+builder-deposit signature predicate. It has no in-model caller by design. The spec's sole
+consumer is the p2p `inclusion_list` gossip `[REJECT]` (`p2p-interface.md:100`), and EthCLSpecs
+models the state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
+conformance scope). `on_inclusion_list` carries no signature check of its own
+(`fork-choice.md:256-267`), so the fork-choice path mirrors the spec faithfully. Kept as the
+beacon-chain surface for spec-completeness. -/
+forkdef isValidInclusionListSignature (state : State) (signed : SignedInclusionList) : Bool :=
+  let message := signed.message
+  let index := message.validatorIndex
+  let vs := sszGet state validators
+  -- `validator_index` arrives off the wire, so bound it: the spec's `state.validators[index]`
+  -- raises `IndexError` for an out-of-range index, rejecting the list. Reject explicitly rather
+  -- than reading the `Inhabited` default (zero-pubkey) validator through `[…]!`.
+  if index.toNat < vs.size then
+    let pubkey := (vs[index.toNat]!).pubkey
+    let domain := getDomain state Const.domainInclusionListCommittee (computeEpochAtSlot message.slot)
+    blsVerifySigned pubkey message domain signed.signature
+  else
+    false
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
@@ -1,0 +1,25 @@
+import EthCLSpecs.Heze.Containers.InclusionList
+
+/-!
+# `EthCLSpecs.Heze.State`: the Heze `BeaconState` (inherited from Gloas)
+
+At alpha.11 Heze does not change `BeaconState`, so `inherit BeaconState` replays Gloas's
+field block here unchanged. `state_preamble` declares the boxed `State` and `modifyState`.
+The `Containers.InclusionList` import is the load-order entry: it transitively pulls
+`Heze.Inherited` (the inherited containers) and the `fork Heze from Gloas` lineage that
+`inherit` resolves against. It is load-bearing; do not drop it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit BeaconState
+
+-- The once-per-fork preamble: declares `State` (the boxed `BeaconState`) and `modifyState`.
+state_preamble BeaconState
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
@@ -7,8 +7,9 @@ import EthCLSpecs.Gloas.Transition
 EIP-7805 (FOCIL) leaves the EIP-7732 block spine unchanged. `process_slot` /
 `process_epoch` / `process_slots` / `process_operations` / `process_block` /
 `state_transition` (and the unchanged `process_randao` / `process_eth1_data` /
-`verify_block_signature`) are all `inherit`ed over Heze state; their sub-calls late-bind
-to the Heze copies from the earlier spine files.
+`verify_block_signature`) are all `inherit`ed over Heze state. When `inherit` replays each
+definition here, its unqualified callee names resolve to the Heze versions declared in the
+files above, the transition "spine", and never to the Gloas originals.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
@@ -1,0 +1,35 @@
+import EthCLSpecs.Heze.Withdrawals
+import EthCLSpecs.Gloas.Transition
+
+/-!
+# `EthCLSpecs.Heze.Transition`: the inherited state-transition spine (Gloas over Heze)
+
+EIP-7805 (FOCIL) leaves the EIP-7732 block spine unchanged. `process_slot` /
+`process_epoch` / `process_slots` / `process_operations` / `process_block` /
+`state_transition` (and the unchanged `process_randao` / `process_eth1_data` /
+`verify_block_signature`) are all `inherit`ed over Heze state; their sub-calls late-bind
+to the Heze copies from the earlier spine files.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit processRandao
+inherit processEth1Data
+inherit verifyBlockSignature
+inherit processSlot
+inherit processEpoch
+inherit processSlots
+inherit processOperations
+inherit processBlock
+inherit stateTransition
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
@@ -1,0 +1,126 @@
+import EthCLSpecs.Heze.Containers
+
+/-!
+# `EthCLSpecs.Heze.Upgrade`: the Gloas → Heze fork upgrade (EIP-7805)
+
+`upgradeToHeze` reads a finished Gloas state and constructs the Heze one, the single
+sanctioned cross-fork reference. At alpha.11 it is a near-passthrough: every
+`BeaconState` field carries across and only the fork version bumps. Because Heze's
+containers are fresh namespace twins of Gloas's, each container field is copied through
+a field-by-field `cv*` converter, the mechanical price of the flat namespace. No builder
+onboarding / PTC recompute (the upgrade is a pure copy).
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-! ## Component-container conversion at the fork boundary -/
+
+private def cvBeaconBlockHeader [Preset] (v : Gloas.BeaconBlockHeader) : BeaconBlockHeader :=
+  { slot := v.slot, proposerIndex := v.proposerIndex, parentRoot := v.parentRoot,
+    stateRoot := v.stateRoot, bodyRoot := v.bodyRoot }
+private def cvEth1Data [Preset] (v : Gloas.Eth1Data) : Eth1Data :=
+  { depositRoot := v.depositRoot, depositCount := v.depositCount, blockHash := v.blockHash }
+private def cvCheckpoint [Preset] (v : Gloas.Checkpoint) : Checkpoint :=
+  { epoch := v.epoch, root := v.root }
+private def cvValidator [Preset] (v : Gloas.Validator) : Validator :=
+  { pubkey := v.pubkey, withdrawalCredentials := v.withdrawalCredentials,
+    effectiveBalance := v.effectiveBalance, slashed := v.slashed,
+    activationEligibilityEpoch := v.activationEligibilityEpoch,
+    activationEpoch := v.activationEpoch, exitEpoch := v.exitEpoch,
+    withdrawableEpoch := v.withdrawableEpoch }
+private def cvSyncCommittee [Preset] (v : Gloas.SyncCommittee) : SyncCommittee :=
+  { pubkeys := v.pubkeys, aggregatePubkey := v.aggregatePubkey }
+private def cvHistoricalSummary [Preset] (v : Gloas.HistoricalSummary) : HistoricalSummary :=
+  { blockSummaryRoot := v.blockSummaryRoot, stateSummaryRoot := v.stateSummaryRoot }
+private def cvPendingDeposit [Preset] (v : Gloas.PendingDeposit) : PendingDeposit :=
+  { pubkey := v.pubkey, withdrawalCredentials := v.withdrawalCredentials, amount := v.amount,
+    signature := v.signature, slot := v.slot }
+private def cvPendingPartialWithdrawal [Preset] (v : Gloas.PendingPartialWithdrawal) :
+    PendingPartialWithdrawal :=
+  { validatorIndex := v.validatorIndex, amount := v.amount, withdrawableEpoch := v.withdrawableEpoch }
+private def cvPendingConsolidation [Preset] (v : Gloas.PendingConsolidation) : PendingConsolidation :=
+  { sourceIndex := v.sourceIndex, targetIndex := v.targetIndex }
+private def cvBuilder [Preset] (v : Gloas.Builder) : Builder :=
+  { pubkey := v.pubkey, version := v.version, executionAddress := v.executionAddress,
+    balance := v.balance, depositEpoch := v.depositEpoch, withdrawableEpoch := v.withdrawableEpoch }
+private def cvBuilderPendingWithdrawal [Preset] (v : Gloas.BuilderPendingWithdrawal) :
+    BuilderPendingWithdrawal :=
+  { feeRecipient := v.feeRecipient, amount := v.amount, builderIndex := v.builderIndex }
+private def cvBuilderPendingPayment [Preset] (v : Gloas.BuilderPendingPayment) : BuilderPendingPayment :=
+  { weight := v.weight, withdrawal := cvBuilderPendingWithdrawal v.withdrawal,
+    proposerIndex := v.proposerIndex }
+private def cvWithdrawal [Preset] (v : Gloas.Withdrawal) : Withdrawal :=
+  { index := v.index, validatorIndex := v.validatorIndex, address := v.address, amount := v.amount }
+
+/-- Convert the Gloas bid to the Heze bid. At alpha.11 the bid is unchanged, so this is a
+plain 12-field copy. -/
+private def cvExecutionPayloadBid [Preset] (v : Gloas.ExecutionPayloadBid) : ExecutionPayloadBid :=
+  { parentBlockHash := v.parentBlockHash, parentBlockRoot := v.parentBlockRoot,
+    blockHash := v.blockHash, prevRandao := v.prevRandao, feeRecipient := v.feeRecipient,
+    gasLimit := v.gasLimit, builderIndex := v.builderIndex, slot := v.slot, value := v.value,
+    executionPayment := v.executionPayment, blobKzgCommitments := v.blobKzgCommitments,
+    executionRequestsRoot := v.executionRequestsRoot }
+
+/-- The fork upgrade `upgrade_to_heze(pre)`: builds the Heze state from a finished Gloas
+one. At alpha.11 every field carries across; only the fork version changes
+(`previous := pre.fork.current`, `current := HEZE_FORK_VERSION`, `epoch := get_current_epoch(pre)`).
+`hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by the runner. -/
+def upgradeToHeze [Preset] (hezeForkVersion : Version) (pre : Gloas.BeaconState) :
+    Heze.BeaconState :=
+  let epoch : Epoch := pre.slot / UInt64.ofNat Const.slotsPerEpoch
+  { genesisTime                   := pre.genesisTime
+    genesisValidatorsRoot         := pre.genesisValidatorsRoot
+    slot                          := pre.slot
+    forkData                      :=
+      { previousVersion := pre.forkData.currentVersion
+        currentVersion  := hezeForkVersion
+        epoch           := epoch }
+    latestBlockHeader             := cvBeaconBlockHeader pre.latestBlockHeader
+    blockRoots                    := pre.blockRoots
+    stateRoots                    := pre.stateRoots
+    historicalRoots               := pre.historicalRoots
+    eth1Data                      := cvEth1Data pre.eth1Data
+    eth1DataVotes                 := pre.eth1DataVotes.mapCap cvEth1Data
+    eth1DepositIndex              := pre.eth1DepositIndex
+    validators                    := pre.validators.mapCap cvValidator
+    balances                      := pre.balances
+    randaoMixes                   := pre.randaoMixes
+    slashings                     := pre.slashings
+    previousEpochParticipation    := pre.previousEpochParticipation
+    currentEpochParticipation     := pre.currentEpochParticipation
+    justificationBits             := pre.justificationBits
+    previousJustifiedCheckpoint   := cvCheckpoint pre.previousJustifiedCheckpoint
+    currentJustifiedCheckpoint    := cvCheckpoint pre.currentJustifiedCheckpoint
+    finalizedCheckpoint           := cvCheckpoint pre.finalizedCheckpoint
+    inactivityScores              := pre.inactivityScores
+    currentSyncCommittee          := cvSyncCommittee pre.currentSyncCommittee
+    nextSyncCommittee             := cvSyncCommittee pre.nextSyncCommittee
+    latestBlockHash               := pre.latestBlockHash
+    nextWithdrawalIndex           := pre.nextWithdrawalIndex
+    nextWithdrawalValidatorIndex  := pre.nextWithdrawalValidatorIndex
+    historicalSummaries           := pre.historicalSummaries.mapCap cvHistoricalSummary
+    depositRequestsStartIndex     := pre.depositRequestsStartIndex
+    depositBalanceToConsume       := pre.depositBalanceToConsume
+    exitBalanceToConsume          := pre.exitBalanceToConsume
+    earliestExitEpoch             := pre.earliestExitEpoch
+    consolidationBalanceToConsume := pre.consolidationBalanceToConsume
+    earliestConsolidationEpoch    := pre.earliestConsolidationEpoch
+    pendingDeposits               := pre.pendingDeposits.mapCap cvPendingDeposit
+    pendingPartialWithdrawals     := pre.pendingPartialWithdrawals.mapCap cvPendingPartialWithdrawal
+    pendingConsolidations         := pre.pendingConsolidations.mapCap cvPendingConsolidation
+    proposerLookahead             := pre.proposerLookahead
+    builders                      := pre.builders.mapCap cvBuilder
+    nextWithdrawalBuilderIndex    := pre.nextWithdrawalBuilderIndex
+    executionPayloadAvailability  := pre.executionPayloadAvailability
+    builderPendingPayments        := pre.builderPendingPayments.map cvBuilderPendingPayment
+    builderPendingWithdrawals     := pre.builderPendingWithdrawals.mapCap cvBuilderPendingWithdrawal
+    latestExecutionPayloadBid     := cvExecutionPayloadBid pre.latestExecutionPayloadBid
+    payloadExpectedWithdrawals    := pre.payloadExpectedWithdrawals.mapCap cvWithdrawal
+    ptcWindow                     := pre.ptcWindow }
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
@@ -8,7 +8,8 @@ sanctioned cross-fork reference. At alpha.11 it is a near-passthrough: every
 `BeaconState` field carries across and only the fork version bumps. Because Heze's
 containers are fresh namespace twins of Gloas's, each container field is copied through
 a field-by-field `cv*` converter, the mechanical price of the flat namespace. No builder
-onboarding / PTC recompute (the upgrade is a pure copy).
+onboarding and no PTC recompute: builders were onboarded and the PTC window built at the
+Gloas fork, and EIP-7805 adds no `BeaconState` field, so the upgrade is a pure copy.
 -/
 
 set_option autoImplicit false
@@ -69,7 +70,9 @@ private def cvExecutionPayloadBid [Preset] (v : Gloas.ExecutionPayloadBid) : Exe
 /-- The fork upgrade `upgrade_to_heze(pre)`: builds the Heze state from a finished Gloas
 one. At alpha.11 every field carries across; only the fork version changes
 (`previous := pre.fork.current`, `current := HEZE_FORK_VERSION`, `epoch := get_current_epoch(pre)`).
-`hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by the runner. -/
+No builder onboarding or PTC recompute is needed: both already happened at the Gloas fork
+and live in the pre-state. `hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by
+the runner. -/
 def upgradeToHeze [Preset] (hezeForkVersion : Version) (pre : Gloas.BeaconState) :
     Heze.BeaconState :=
   let epoch : Epoch := pre.slot / UInt64.ofNat Const.slotsPerEpoch

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -1,0 +1,48 @@
+import EthCLSpecs.Heze.Operations
+import EthCLSpecs.Gloas.Withdrawals
+
+/-!
+# `EthCLSpecs.Heze.Withdrawals`: the inherited builder-aware withdrawal sweep
+
+EIP-7805 changes no withdrawal logic. Gloas's `process_withdrawals` and its sweep helpers
+are `inherit`ed over Heze state. `addressOf` / `balanceAfterWithdrawals` are plain `def`s
+in Gloas (not captured `forkdef`s), so they are restated for the Heze validator / state
+before the sweep helpers that use them.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit isFullyWithdrawable
+inherit isPartiallyWithdrawable
+inherit isEligibleForPartialWithdrawals
+
+/-- `addressOf` over `Heze.Validator`: the 20-byte execution address in the validator's
+withdrawal credentials. Restated (a plain `def` rather than an inheritable `forkdef`). -/
+def addressOf (v : Validator) : ExecutionAddress :=
+  Vector.ofFn (fun i : Fin 20 => vget v.withdrawalCredentials (12 + i.val))
+
+/-- `get_balance_after_withdrawals` over `Heze.State`: the balance net of any
+already-queued withdrawals for `vi`. Restated (a plain `def` rather than a `forkdef`). -/
+def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) : Gwei :=
+  let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
+  let bal := sszGet state balances[vi.toNat]!
+  if withdrawn > bal then 0 else bal - withdrawn
+
+inherit getBuilderWithdrawals
+inherit getPendingPartialWithdrawals
+inherit getBuildersSweepWithdrawals
+inherit getValidatorsSweepWithdrawals
+inherit getExpectedWithdrawals
+inherit applyWithdrawals
+inherit processWithdrawals
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -6,8 +6,9 @@ import EthCLSpecs.Gloas.Withdrawals
 
 EIP-7805 changes no withdrawal logic. Gloas's `process_withdrawals` and its sweep helpers
 are `inherit`ed over Heze state. `addressOf` / `balanceAfterWithdrawals` are plain `def`s
-in Gloas (not captured `forkdef`s), so they are restated for the Heze validator / state
-before the sweep helpers that use them.
+in Gloas, which the capture does not cover (only `forkdef` / `forkcontainer` / `forkstruct`
+replay, `SPEC_AUTHORING_MODEL.md` §8.5), so they are restated for the Heze validator /
+state before the sweep helpers that use them.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -165,13 +165,21 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
       | "boost"             => steps := steps.push (.checkBoost (hexToBytes parts[1]!))
       | "time"              => steps := steps.push (.checkTime parts[1]!.toNat!)
       | "genesis_time"      => steps := steps.push (.checkGenesisTime parts[1]!.toNat!)
-      | "unsupported"       => steps := steps.push (.unsupported "get_proposer_head / should_override check")
-      | _                   => pure ()
+      | "unsupported"       =>
+        -- `harness.py` passes the specific descriptor (`should_override_forkchoice_update`, or an
+        -- unrecognized step key like `on_inclusion_list`), so the xfail reason is accurate.
+        let reason := if parts.size > 1 then String.intercalate " " (parts.toList.drop 1) else "unmodeled step"
+        steps := steps.push (.unsupported s!"unsupported fork-choice step: {reason}")
+      -- An unrecognized token surfaces as `unsupported` (a `todo` xfail) rather than silently
+      -- dropping the step; `harness.py` already maps unknown steps.yaml keys to `unsupported`,
+      -- so this is the second line of defense.
+      | other               => steps := steps.push (.unsupported s!"unrecognized fork-choice step: {other}")
 
   match iface.runForkChoice anchorState anchorBlock steps with
   | .ok ()   => return "pass\tpassing\t"
   | .error e =>
-    -- Classify the runner error: a `spec todo` is out-of-scope, everything else (a
+    -- Classify the runner error: a `spec todo` is the xfail work-queue, a `spec
+    -- outOfScope` a deliberate skip, everything else (a
     -- decode failure, a check mismatch, an unexpected rejection, a missing store key) is
     -- a bug on the fork-choice path (per-step `valid:false` rejections are resolved inside
     -- the interpreter and never reach here).
@@ -211,7 +219,7 @@ partial def serve (iface : ForkInterface) : IO UInt32 := do
   let stdin ← IO.getStdin
   let stdout ← IO.getStdout
   let rec loop : IO UInt32 := do
-    -- Strip only the line ending, not interior / trailing tabs (the final
+    -- Strip the line ending while keeping interior / trailing tabs (the final
     -- `inputPaths` field is empty, hence a trailing tab, when a case has no inputs).
     let line := ((← stdin.getLine).dropEndWhile (fun c => c == '\n' || c == '\r')).toString
     if line.isEmpty then
@@ -228,32 +236,71 @@ def toHex (b : ByteArray) : String :=
     let s := String.ofList (Nat.toDigits 16 x.toNat)
     if s.length == 1 then "0" ++ s else s)
 
+/-- Resolve a fork name to its minimal-preset interface; `none` for an unknown name.
+`main` uses this to error on a bad fork argument instead of inheriting
+`pickInterface`'s silent Fulu default (kept only for the documented no-argument
+invocation). -/
+def forkInterface? (forkName : String) : Option ForkInterface :=
+  match forkName with
+  | "fulu"  => some EthCLSpecs.Fulu.Interface.fuluInterface
+  | "gloas" => some EthCLSpecs.Gloas.Interface.gloasInterface
+  | "heze"  => some EthCLSpecs.Heze.Interface.hezeInterface
+  | _       => none
+
 /-- Select a fork's interface at a preset. -/
 @[reducible] def pickInterface (forkName preset : String) : ForkInterface :=
   match forkName, preset with
   | "gloas", "mainnet" => EthCLSpecs.Gloas.Interface.gloasInterfaceMainnet
   | "gloas", _         => EthCLSpecs.Gloas.Interface.gloasInterface
+  | "heze",  "mainnet" => EthCLSpecs.Heze.Interface.hezeInterfaceMainnet
+  | "heze",  _         => EthCLSpecs.Heze.Interface.hezeInterface
   | _,       "mainnet" => EthCLSpecs.Fulu.Interface.fuluInterfaceMainnet
   | _,       _         => EthCLSpecs.Fulu.Interface.fuluInterface
+
+/-- Serve at a named fork/preset, erroring on the names `pickInterface` would silently
+default. An unknown fork or preset here is a typo'd invocation (the pytest harness passes
+exact names), and silently decoding another fork's SSZ shows up as a wall of opaque decode
+failures instead of one clear message. -/
+def serveKnown (forkName preset : String) : IO UInt32 := do
+  if (forkInterface? forkName).isNone then
+    IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2
+  else if preset != "minimal" && preset != "mainnet" then
+    IO.eprintln s!"unknown preset: {preset} (expected minimal / mainnet)"; return 2
+  else
+    serve (pickInterface forkName preset)
 
 end EthCLSpecs.PySpecTests
 
 /-- The exe entry point. `pyspec_server [fork [preset]]` runs the server loop at
-the named fork's interface and preset (`fulu` / `minimal` defaults). The
-`stateroot [fork] <path>` mode decodes a `BeaconState` and prints its root (a
-decode / container-layer sanity check). -/
+the named fork's interface and preset; the no-argument invocation defaults to
+`fulu` / `minimal`, and a named-but-unknown fork or preset is an error rather
+than a silent Fulu fallback. The `stateroot [fork] <path>` mode decodes a
+`BeaconState` and prints its root (a decode / container-layer sanity check). -/
 def main (args : List String) : IO UInt32 := do
   match args with
   | ["stateroot", path] =>
-    let bytes ← IO.FS.readBinFile path
-    match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
-    | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
-    | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  | ["stateroot", "gloas", path] =>
-    let bytes ← IO.FS.readBinFile path
-    match EthCLSpecs.Gloas.Interface.gloasInterface.stateRoot bytes with
-    | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
-    | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  | [forkName, preset] => EthCLSpecs.PySpecTests.serve (EthCLSpecs.PySpecTests.pickInterface forkName preset)
-  | [forkName]         => EthCLSpecs.PySpecTests.serve (EthCLSpecs.PySpecTests.pickInterface forkName "minimal")
-  | _                  => EthCLSpecs.PySpecTests.serve EthCLSpecs.Fulu.Interface.fuluInterface
+    -- `stateroot <fork>` with the path forgotten lands here with `path` bound to the
+    -- fork name (and would decode a file of that name as Fulu); catch it explicitly.
+    if (EthCLSpecs.PySpecTests.forkInterface? path).isSome then
+      IO.eprintln s!"stateroot: missing <path> after fork name {path}"; return 2
+    else
+      let bytes ← IO.FS.readBinFile path
+      match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
+      | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
+      | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
+  -- `fork` is a registered token of the spec DSL (the `forkstruct` family), so the
+  -- binder is `forkName`, matching the serve arms below.
+  | ["stateroot", forkName, path] =>
+    match EthCLSpecs.PySpecTests.forkInterface? forkName with
+    | none => IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2
+    | some iface =>
+      let bytes ← IO.FS.readBinFile path
+      match iface.stateRoot bytes with
+      | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
+      | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
+  | [forkName, preset] => EthCLSpecs.PySpecTests.serveKnown forkName preset
+  | [forkName]         => EthCLSpecs.PySpecTests.serveKnown forkName "minimal"
+  | []                 => EthCLSpecs.PySpecTests.serve EthCLSpecs.Fulu.Interface.fuluInterface
+  | _ =>
+    IO.eprintln "usage: pyspec_server [fork [preset]] | pyspec_server stateroot [fork] <path>"
+    return 2

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -178,8 +178,8 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
   match iface.runForkChoice anchorState anchorBlock steps with
   | .ok ()   => return "pass\tpassing\t"
   | .error e =>
-    -- Classify the runner error: a `spec todo` is the xfail work-queue, a `spec
-    -- outOfScope` a deliberate skip, everything else (a
+    -- Classify the runner error: a `spec todo` means unfinished work (reported `xfail`), a
+    -- `spec outOfScope` means deliberately unmodeled (reported `skip`); everything else (a
     -- decode failure, a check mismatch, an unexpected rejection, a missing store key) is
     -- a bug on the fork-choice path (per-step `valid:false` rejections are resolved inside
     -- the interpreter and never reach here).
@@ -288,8 +288,8 @@ def main (args : List String) : IO UInt32 := do
       match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
       | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
       | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  -- `fork` is a registered token of the spec DSL (the `forkstruct` family), so the
-  -- binder is `forkName`, matching the serve arms below.
+  -- The pattern binder cannot be named `fork`, because `fork` is a keyword of the spec
+  -- DSL; use `forkName`, as in the serve arms below.
   | ["stateroot", forkName, path] =>
     match EthCLSpecs.PySpecTests.forkInterface? forkName with
     | none => IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -33,8 +33,25 @@ From this directory, with the repo venv:
 caching backend for the plain FFI (caching is on by default). Useful for comparing
 cache-on against cache-off timings.
 
-The pin (`--tag`, default `v1.7.0-alpha.10`) selects the release; the archive is
+The pin (`--tag`, default `v1.7.0-alpha.11`) selects the release; the archive is
 downloaded once and cached.
+
+### Re-pinning checklist
+
+Bumping the pin touches more than the constant. In one pass:
+
+1. Bump `PINNED_VERSION` (`harness.py`) and each fork's `pyspecPinnedVersion`
+   (`Interface.lean`) together.
+2. Re-run the full sweep (`just ethcl-pyspec-full`) at both presets.
+3. Revalidate the spec-markdown line anchors (`<file>.md:NN`) in
+   `../docs/DISCREPANCIES.md` and the fork `.lean` docstrings against the new tag,
+   along with the recorded divergences themselves (the spec text may have moved
+   or fixed the branch a divergence pins).
+4. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
+   alpha.10→alpha.11 bump left six behind.
+5. Diff the corpus for new runners or handlers (new directories under
+   `tests/<preset>/<fork>/`); either collect them or name the exclusion in the
+   `IN_SCOPE_RUNNERS` allowlist comment, never leave one silently uncollected.
 
 ## Status
 

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -44,12 +44,14 @@ Bumping the pin touches more than the constant. In one pass:
    (`Interface.lean`) together.
 2. Re-run the full sweep (`just ethcl-pyspec-full`) at both presets.
 3. Revalidate the spec-markdown line anchors (`<file>.md:NN`) in
-   `../docs/DISCREPANCIES.md` and the fork `.lean` docstrings against the new tag,
-   along with the recorded divergences themselves (the spec text may have moved
-   or fixed the branch a divergence pins).
-4. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
+   `../docs/IMPLEMENTATION_NOTES.md`, `../docs/DISCREPANCIES.md`, and the fork
+   `.lean` docstrings against the new tag.
+4. Re-check each recorded divergence itself (`IMPLEMENTATION_NOTES.md`, the
+   per-fork divergence entries): the new spec text may have moved, or may have
+   fixed the branch a divergence pins.
+5. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
    alpha.10→alpha.11 bump left six behind.
-5. Diff the corpus for new runners or handlers (new directories under
+6. Diff the corpus for new runners or handlers (new directories under
    `tests/<preset>/<fork>/`); either collect them or name the exclusion in the
    `IN_SCOPE_RUNNERS` allowlist comment, never leave one silently uncollected.
 

--- a/packages/EthCLSpecs/PySpecTests/conftest.py
+++ b/packages/EthCLSpecs/PySpecTests/conftest.py
@@ -10,6 +10,7 @@ Run:
     pytest -n auto               # sharded across cores via xdist
     pytest --subset=0            # the full in-scope suite
     pytest --fork=gloas          # the Gloas vectors
+    pytest --fork=heze           # the Heze vectors
 """
 
 import pytest
@@ -20,7 +21,7 @@ from harness import ServerClient, ensure_archive, walk_cases, PINNED_VERSION
 def pytest_addoption(parser):
     parser.addoption("--preset", default="minimal",
                      help="consensus-spec-tests preset (minimal / mainnet)")
-    parser.addoption("--fork", default="fulu", help="fork to run (fulu / gloas)")
+    parser.addoption("--fork", default="fulu", help="fork to run (fulu / gloas / heze)")
     parser.addoption("--subset", type=int, default=2,
                      help="cases per (runner,handler); 0 = the full suite")
     parser.addoption("--tag", default=PINNED_VERSION,

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -24,21 +24,43 @@ import cramjam
 import yaml
 
 # The pinned release: the latest consensus-specs release, confirmed to
-# carry both Fulu and Gloas minimal vectors (matches
+# carry the Fulu, Gloas, and Heze minimal vectors (matches
 # EthCLSpecs.Fulu.Interface.pyspecPinnedVersion).
 PINNED_VERSION = "v1.7.0-alpha.11"
 CACHE_DIR = Path.home() / ".cache" / "sizzlean"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# In-scope (runner, handler-is-path-segment) formats for Fulu and Gloas.
+# In-scope (runner, handler-is-path-segment) formats for Fulu, Gloas, and Heze.
 # `ssz_static` runs the per-fork consensus-container vectors (decode →
 # hash-tree-root → round-trip) against the container types EthCLSpecs declares;
 # the fork-agnostic `ssz_generic` primitive vectors live in SizzLean instead.
 # `bls`, `kzg`, `light_client`, `merkle_proof`, `networking`, `sync` are out of
-# scope (they exercise primitives a dependency owns).
+# scope (they exercise primitives a dependency owns). `fast_confirmation` (the
+# confirmation-rule fork-choice format, minimal-only) is a runner we have not
+# implemented yet: deliberately uncollected, a named future work item rather
+# than a silent omission.
 IN_SCOPE_RUNNERS = {
     "sanity", "finality", "random", "epoch_processing", "operations",
     "rewards", "genesis", "fork", "transition", "fork_choice", "ssz_static",
+}
+
+# The `checks` keys `_build_fork_choice_request` models (its emitter chain) and,
+# for nested check objects, the subkeys each emitter reads. Keep both in lockstep
+# with the emitter chain: a key handled there but missing here emits a spurious
+# `unsupported <key>` line and silently demotes a fully-checked case to the
+# todo/xfail bucket.
+KNOWN_CHECK_KEYS = {
+    "get_proposer_head", "should_override_forkchoice_update", "head",
+    "payload_timeliness_vote", "payload_data_availability_vote",
+    "justified_checkpoint", "finalized_checkpoint", "proposer_boost_root",
+    "time", "genesis_time",
+}
+KNOWN_CHECK_SUBKEYS = {
+    "head": {"root", "slot", "payload_status"},
+    "payload_timeliness_vote": {"block_root", "votes"},
+    "payload_data_availability_vote": {"block_root", "votes"},
+    "justified_checkpoint": {"epoch", "root"},
+    "finalized_checkpoint": {"epoch", "root"},
 }
 
 
@@ -100,7 +122,8 @@ def walk_cases(extract_root: Path, preset: str, fork: str,
         # Fulu `fork` (Electra->Fulu upgrade) and `transition` (Electra->Fulu
         # boundary) require a full Electra parent fork the library never builds, so
         # they are permanently out of scope: not collected, not counted, not even as
-        # xfail. (The Gloas `fork` / `transition` are Fulu->Gloas, fully in scope.)
+        # xfail. (The Gloas `fork` / `transition` are Fulu->Gloas and the Heze ones
+        # Gloas->Heze, both fully in scope.)
         if fork == "fulu" and runner in ("fork", "transition"):
             continue
         for handler_dir in sorted(p for p in runner_dir.iterdir() if p.is_dir()):
@@ -136,8 +159,12 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
     `inputs` pair `anchorBlockPath,scriptPath`. The script is one line per
     `steps.yaml` entry, with `block` / `attestation` / `attester_slashing` steps
     referencing decompressed SSZ files by path, and `checks` split into one line
-    per supported key (`get_proposer_head` / `should_override_forkchoice_update`
-    checks become a single `unsupported` line, so the case reports out-of-scope)."""
+    per key. `get_proposer_head` emits a dedicated `get_proposer_head <root>`
+    step; `should_override_forkchoice_update` emits `unsupported
+    should_override_forkchoice_update`, so that case reports `todo` (an xfail).
+    Sibling keys in the same checks entry still emit their own lines. Any key or
+    nested subkey we don't model becomes `unsupported <key>`, keeping the xfail
+    reason accurate instead of silently dropping the check."""
     anchor_state = _decompress_to(tmpdir, case.path / "anchor_state.ssz_snappy")
     anchor_block = _decompress_to(tmpdir, case.path / "anchor_block.ssz_snappy")
     steps = yaml.safe_load((case.path / "steps.yaml").read_text())
@@ -171,10 +198,8 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
             c = s["checks"]
             if "get_proposer_head" in c:
                 lines.append(f"get_proposer_head {c['get_proposer_head']}")
-                continue
             if "should_override_forkchoice_update" in c:
-                lines.append("unsupported")
-                continue
+                lines.append("unsupported should_override_forkchoice_update")
             if "head" in c:
                 lines.append(f"head {c['head']['root']} {int(c['head']['slot'])}")
                 if "payload_status" in c["head"]:
@@ -197,6 +222,28 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
                 lines.append(f"time {int(c['time'])}")
             if "genesis_time" in c:
                 lines.append(f"genesis_time {int(c['genesis_time'])}")
+            # A check key we don't model (e.g. a future inclusion_list_satisfied) reports as
+            # `unsupported <key>`, so the case lands in the `todo`/xfail bucket rather than
+            # passing with the check silently dropped. The same guard runs one level down: an
+            # unmodeled subkey of a nested check object (e.g. a new field on `head` past
+            # root/slot/payload_status) surfaces as `unsupported <key>.<subkey>`, so the
+            # unmodeled-key promise covers nested shapes as well as top-level keys. `str(k)`
+            # keeps the join total if YAML 1.1 ever parses an unquoted key as a non-string.
+            # No alpha.11 vector hits either path.
+            unknown = [str(k) for k in c if k not in KNOWN_CHECK_KEYS]
+            for parent, known_sub in KNOWN_CHECK_SUBKEYS.items():
+                sub = c.get(parent)
+                if isinstance(sub, dict):
+                    unknown += [f"{parent}.{k}" for k in sub if k not in known_sub]
+            if unknown:
+                lines.append(f"unsupported {'/'.join(sorted(unknown))}")
+        else:
+            # An unrecognized step key (e.g. a future on_inclusion_list fork-choice step) reports
+            # as `unsupported <key>`, so the case lands `todo`/xfail with an accurate reason rather
+            # than silently dropping the step. Drop the auxiliary flags (valid / columns) and sort,
+            # so the reason names the step rather than its flags. No alpha.11 vector hits this.
+            keys = sorted(str(k) for k in s if k not in ("valid", "columns"))
+            lines.append(f"unsupported {'/'.join(keys) or 'unknown-step'}")
     script_path = tmpdir / "fc_script.txt"
     script_path.write_text("\n".join(lines))
     return "\t".join(["fork_choice", case.handler, str(anchor_state), "-", "1", "0", "-",

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -44,11 +44,13 @@ IN_SCOPE_RUNNERS = {
     "rewards", "genesis", "fork", "transition", "fork_choice", "ssz_static",
 }
 
-# The `checks` keys `_build_fork_choice_request` models (its emitter chain) and,
-# for nested check objects, the subkeys each emitter reads. Keep both in lockstep
-# with the emitter chain: a key handled there but missing here emits a spurious
-# `unsupported <key>` line and silently demotes a fully-checked case to the
-# todo/xfail bucket.
+# The `checks` keys `_build_fork_choice_request` recognizes. Most are modeled by
+# its emitter chain; `should_override_forkchoice_update` is recognized but
+# deliberately emitted as `unsupported` (the case lands todo/xfail).
+# KNOWN_CHECK_SUBKEYS below lists, for the nested check objects, the subkeys
+# each emitter reads. Keep both sets in lockstep with the emitter chain: a key
+# the chain handles but this set omits emits a spurious `unsupported <key>`
+# line and silently demotes a fully-checked case to the todo/xfail bucket.
 KNOWN_CHECK_KEYS = {
     "get_proposer_head", "should_override_forkchoice_update", "head",
     "payload_timeliness_vote", "payload_data_availability_vote",

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -25,12 +25,14 @@ Three forks are in scope:
 - **Fulu** is the base, authored whole. It carries the accumulated
   beacon-chain spec from Phase 0 through Electra, plus Fulu's PeerDAS
   data-availability additions (EIP-7594).
-- **Gloas** is a diff over Fulu. It adds enshrined proposer-builder separation
-  (EIP-7732): a builder registry, execution payload bids, the
+- **Gloas** is a diff over Fulu. It adds ePBS (EIP-7732): a builder
+  registry, execution payload bids, the
   payload-timeliness committee, and a reordered block pipeline.
 - **Heze** is a thin diff over Gloas. It adds fork-choice inclusion lists
-  (EIP-7805 FOCIL): the `InclusionList` container family, the inclusion-list
-  committee helpers, and the fork-choice store and satisfaction gate.
+  (EIP-7805 FOCIL): the `InclusionList` container family, the
+  inclusion-list committee helpers, an inclusion-list store folded into the
+  fork-choice store, and the payload satisfaction gate
+  (`is_payload_inclusion_list_satisfied`).
 
 For each fork the library implements the SSZ containers, the state transition
 (slots, blocks, epochs, and every operation), the fork upgrade, and a second

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -1,11 +1,11 @@
 # EthCLSpecs
 
 > **Status: experimental, single-developer; personal project, not an EF
-> release. Validated against the pyspec test vectors for two
-> forks (Fulu, Gloas); machine-checked proofs are future work.**
+> release. Validated against the pyspec test vectors for three
+> forks (Fulu, Gloas, Heze); machine-checked proofs are future work.**
 
-A Lean 4 implementation of the Ethereum consensus specification for the Fulu
-and Gloas forks. It is executable. The SSZ container types, the full
+A Lean 4 implementation of the Ethereum consensus specification for the Fulu,
+Gloas, and Heze forks. It is executable. The SSZ container types, the full
 beacon-chain state transition, the fork upgrade, and fork choice all run, and
 they are checked against Ethereum's pyspec
 [`consensus-spec-tests`](https://github.com/ethereum/consensus-spec-tests)
@@ -20,7 +20,7 @@ packages, through `EthCLLib`, to `EthCLSpecs`.
 
 ## What it covers
 
-Two forks are in scope:
+Three forks are in scope:
 
 - **Fulu** is the base, authored whole. It carries the accumulated
   beacon-chain spec from Phase 0 through Electra, plus Fulu's PeerDAS
@@ -28,6 +28,9 @@ Two forks are in scope:
 - **Gloas** is a diff over Fulu. It adds enshrined proposer-builder separation
   (EIP-7732): a builder registry, execution payload bids, the
   payload-timeliness committee, and a reordered block pipeline.
+- **Heze** is a thin diff over Gloas. It adds fork-choice inclusion lists
+  (EIP-7805 FOCIL): the `InclusionList` container family, the inclusion-list
+  committee helpers, and the fork-choice store and satisfaction gate.
 
 For each fork the library implements the SSZ containers, the state transition
 (slots, blocks, epochs, and every operation), the fork upgrade, and a second
@@ -80,8 +83,8 @@ inherit processRandao     -- a transition step it leaves unchanged
 ```
 
 **Validated against the real vectors.** The full in-scope suite passes at both
-the `minimal` and `mainnet` presets, for both forks, pinned to release
-`v1.7.0-alpha.10`. The verdict model is honest. An out-of-range read or a crash
+the `minimal` and `mainnet` presets, for all three forks (Fulu, Gloas, Heze),
+pinned to release `v1.7.0-alpha.11`. The verdict model is honest. An out-of-range read or a crash
 is a hard failure, and an unimplemented branch is a visible `xfail`. Every
 passing vector reflects a real match or a faithful rejection.
 
@@ -92,9 +95,9 @@ lake build EthCLLib EthCLSpecs       # build the framework and the fork bodies
 just ethcl-test                       # build everything plus the Lean self-tests
 
 # Pyspec against upstream vectors (downloads and caches the archive):
-just ethcl-pyspec-smoke          # dev subset, both forks
+just ethcl-pyspec-smoke          # dev subset, all three forks
 just ethcl-pyspec "--subset=0 --fork=gloas"   # one fork, full in-scope suite
-just ethcl-pyspec-full                # the full sweep: both presets, both forks
+just ethcl-pyspec-full                # the full sweep: both presets, all three forks
 ```
 
 CI runs the dev-subset smoke gate. The full multi-preset sweep runs on demand.

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -10,12 +10,17 @@ and the divergence is **recorded here** rather than papered over by bending Lean
 to a wrong vector.
 
 Each entry carries the vector id, the spec-text citation, and the upstream issue
-link, so the audit trail is one grep away.
+link, so the audit trail is one grep away. Resolved Lean-versus-vector divergences
+stay logged here for the audit trail even when the fix landed in Lean.
+
+Deliberate implementation divergences that no vector observes live in
+`IMPLEMENTATION_NOTES.md`, catalogued per fork; the FOCIL set is under "Heze diff".
 
 Pin: `v1.7.0-alpha.11` (all forks).
 
-Spec-markdown line citations (`<file>.md:NN`) are valid at this pin; every re-pin
-re-checks them alongside the divergences they anchor.
+Spec-markdown line citations (`<file>.md:NN`) resolve under `specs/` in
+`ethereum/consensus-specs` at the pinned version (also a git tag there) and are valid
+at this pin; every re-pin re-checks them alongside the divergences they anchor.
 
 ## Fulu
 
@@ -24,99 +29,38 @@ by root or rejects faithfully (`epoch_processing`, `operations` incl. standalone
 `execution_payload`, `sanity/blocks`, `sanity/slots`, `finality`, `random`,
 `rewards`, `fork_choice` incl. the PeerDAS data-availability `on_block` cases and
 `get_proposer_head`), with zero `xfail`. The only Fulu vectors not run are the
-deselected out-of-scope ones (`IMPLEMENTATION_NOTES.md` §2.x): the Fulu `fork` /
+deselected out-of-scope ones (`IMPLEMENTATION_NOTES.md`, "Scope and conformance"): the Fulu `fork` /
 `transition` formats (the Electra→Fulu upgrade / boundary, needing an Electra parent
 fork) and the `ssz_static` / `light_client` / `networking` / `merkle_proof` / `sync`
 runners.
 
 | Vector id | Spec citation | Upstream issue | Resolution |
 |---|---|---|---|
-| — | — | — | — |
+| `epoch_processing/registry_updates/pyspec_tests/invalid_large_withdrawable_epoch` | `electra/beacon-chain.md`, `initiate_validator_exit` | none (Lean-side gap) | Fixed in Lean |
 
-**Resolved.** `epoch_processing/registry_updates/.../invalid_large_withdrawable_epoch`
-was an open Lean-side gap (Lean's `UInt64` wrapped where the pyspec raises a
-`ValueError` serializing the overflowed `withdrawable_epoch`). Closed by asserting
-the `exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY` bound in
-`initiateValidatorExit`, so the case now rejects faithfully.
+The one resolved entry was a Lean-side gap: Lean's `UInt64`
+wrapped where the pyspec raises a `ValueError` serializing the overflowed
+`withdrawable_epoch`. Closed by asserting the `exit_epoch +
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY` bound in `initiateValidatorExit`, so the case
+now rejects faithfully.
 
 ## Gloas
 
-_No open discrepancies._ Gloas is fully ported (the EIP-7732 ePBS spine, operations,
-fork choice, and the Fulu→Gloas transition); every in-scope minimal and mainnet
-vector passes by root or rejects faithfully, with no `xfail`. Gloas inherits the Fulu
-`registry_updates` substep (`forkdef` replay), so the overflow fix above propagated to
-Gloas with no Gloas-side change.
-
-| Vector id | Spec citation | Upstream issue | Resolution |
-|---|---|---|---|
-| — | — | — | — |
+_No open discrepancies._ Gloas is fully ported (the EIP-7732 ePBS spine, that is the
+state-transition pipeline, plus operations, fork choice, and the Fulu→Gloas
+transition); every in-scope minimal and mainnet vector passes by root or rejects
+faithfully, with no `xfail`. Gloas inherits the Fulu `registry_updates` substep (the
+DSL re-elaborates the captured `forkdef` in the Gloas namespace), so the overflow fix
+above propagated to Gloas with no Gloas-side change. Two spec asserts dropped as
+total-function shapes are catalogued in `IMPLEMENTATION_NOTES.md`, "Fork choice" and
+"Heze diff" (the anchor-root one is shared with Fulu; Heze inherits both).
 
 ## Heze
 
-_No open vector discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
-`v1.7.0-alpha.11` (the two new containers do get full `ssz_static` suites, which pass), so there
-is no Lean-versus-vector divergence to record: the inherited Gloas spine and fork choice pass
-every in-scope Heze vector by root or reject faithfully, with no `xfail`. The vectorless FOCIL
-layer does carry deliberate divergences from the spec *text*, each pinned by the `Heze/*.lean`
-`#guard`s rather than exercised by a runner, and each recorded here so the audit trail is one
-grep away.
-
-`is_inclusion_list_satisfied` (`heze/fork-choice.md:54-62`) defers its verdict to
-`ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external EL. This
-harness has no execution layer, so the call routes through the `[ExecutionEngine]` seam
-(`EthCLLib.Spec.Engine`), whose default instance answers the constant `true`, the same treatment
-Gloas gives `verify_and_notify_new_payload` and `is_data_available`. That default is the residual
-EL trust boundary of the FOCIL gate; no conformance vector reaches the discriminating `false`
-branch, which the `pinRecordRefuted` pin drives end-to-end under a local refuting instance instead.
-The sibling `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with `assert
-root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so the Lean
-reads a missing key as `false` through `lookupD`. That default sits off the spec path, since the
-`payloads` / `payload_inclusion_list_satisfaction` co-write in `on_execution_payload_envelope` keeps
-the key present whenever `root ∈ payloads`. The `timeliness` read in
-`get_inclusion_list_transactions` is the same shape one store over: a plain dict read in the spec,
-`lookupD false` in Lean, off-path through `process_inclusion_list`'s own co-write
-(`Heze/ForkChoice.lean`).
-
-The other two are representational. `cyclicSample` (`heze/beacon-chain.md:95-110`) resamples the
-committee as `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation;
-the Lean read is total (`i % 0 = i`, then the `getD` default), and a real beacon chain never reaches a
-zero-active-validator slot, so the branch is unreachable (`Heze/Committees.lean`). The
-`InclusionListStore` is folded into the fork-choice `Store` as a field: the spec keeps it as a
-process-lifetime singleton (`heze/inclusion-list.md:28-38`, reached through
-`get_inclusion_list_store()`), but this framework's pure `EStateM` fork choice has no ambient
-mutable singleton to hang it off, so it rides inside `Store` and threads like every other piece of
-state, behavior-complete at zero coverage cost (`Heze/ForkChoice.lean`).
-
-The rest are total-function elisions of a spec `assert`/raise, the same class as
-`is_payload_inclusion_list_satisfied` above: latent (no alpha.11 vector reaches the branch) and
-each guarded or bounded at its call site. `record_payload_inclusion_list_satisfaction`
-(`heze/fork-choice.md`) reads `Slot(state.slot - 1)`; on a slot-0 state the pyspec raises the
-uint64 underflow, invalidating the whole `on_execution_payload_envelope` call with the store
-unmodified, while the Lean guards the underflow, records the verdict over an empty required set,
-and proceeds (`Heze/ForkChoice.lean`, `recordPayloadInclusionListSatisfaction`). Only an envelope
-whose target block state sits at slot 0 (the genesis anchor) could tell the difference, and no
-vector produces one. `should_extend_payload` (`heze/fork-choice.md`) opens with `assert
-store.blocks[root].slot + 1 == get_current_slot(store)`; a pure `Bool` forkdef cannot throw, so
-the Lean elides the assert, and its one caller (`get_payload_status_tiebreaker`) is gated by
-`is_previous_slot_payload_decision`, which enforces the same slot equation. The Gloas
-`should_extend_payload` carries the identical elision, so this is inherited shape, recorded here
-with the Heze layer that restates the body. Inside the same function, the spec also reads
-`store.blocks[proposer_root]` unguarded (a `KeyError` on a boost root absent from `blocks`); the
-Lean's `| none => true` extends instead, a miss-default in the *accepting* direction, unreachable
-while the boost root is always a stored block (`on_block` sets it).
-`is_valid_inclusion_list_signature`
-(`heze/beacon-chain.md:76-87`) reads `state.validators[message.validator_index]`, which raises
-`IndexError` on an out-of-range wire index; the Lean bounds the index and returns `false` instead
-(`Heze/Signing.lean`). Same rejection, different mechanism, and no in-model caller by design.
-`get_forkchoice_store` (`heze/fork-choice.md:140-166`) opens with `assert anchor_block.state_root
-== hash_tree_root(anchor_state)`; the Lean restatement elides it (a pure constructor), so an
-inconsistent anchor pair would seed a store instead of raising. Every fork_choice vector runs
-through this constructor, but the harness always derives the anchor block and state from the same
-vector's files, so the branch is unreachable in conformance; the Gloas and Fulu constructors carry
-the identical elision. Below this threshold, one framework-wide note: the inherited time
-arithmetic (`timeIntoSlotMs`, the store-time seed) wraps `UInt64` where the pyspec saturates or
-raises, observable only at astronomically unreachable uptimes.
-
-| Vector id | Spec citation | Upstream issue | Resolution |
-|---|---|---|---|
-| — | — | — | — |
+_No open discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
+`v1.7.0-alpha.11`; the two new containers pass their full `ssz_static` suites, and the
+inherited Gloas spine and fork choice pass every in-scope Heze vector by root or reject
+faithfully, with no `xfail`. The vectorless FOCIL layer carries deliberate divergences
+from the spec text; those are implementation choices no vector observes, catalogued in
+`IMPLEMENTATION_NOTES.md`, "Heze diff". Where a build-enforced pin covers one, the
+entry names it.

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -12,7 +12,10 @@ to a wrong vector.
 Each entry carries the vector id, the spec-text citation, and the upstream issue
 link, so the audit trail is one grep away.
 
-Pin: `v1.7.0-alpha.10` (both forks).
+Pin: `v1.7.0-alpha.11` (all forks).
+
+Spec-markdown line citations (`<file>.md:NN`) are valid at this pin; every re-pin
+re-checks them alongside the divergences they anchor.
 
 ## Fulu
 
@@ -43,6 +46,76 @@ fork choice, and the Fulu→Gloas transition); every in-scope minimal and mainne
 vector passes by root or rejects faithfully, with no `xfail`. Gloas inherits the Fulu
 `registry_updates` substep (`forkdef` replay), so the overflow fix above propagated to
 Gloas with no Gloas-side change.
+
+| Vector id | Spec citation | Upstream issue | Resolution |
+|---|---|---|---|
+| — | — | — | — |
+
+## Heze
+
+_No open vector discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
+`v1.7.0-alpha.11` (the two new containers do get full `ssz_static` suites, which pass), so there
+is no Lean-versus-vector divergence to record: the inherited Gloas spine and fork choice pass
+every in-scope Heze vector by root or reject faithfully, with no `xfail`. The vectorless FOCIL
+layer does carry deliberate divergences from the spec *text*, each pinned by the `Heze/*.lean`
+`#guard`s rather than exercised by a runner, and each recorded here so the audit trail is one
+grep away.
+
+`is_inclusion_list_satisfied` (`heze/fork-choice.md:54-62`) defers its verdict to
+`ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external EL. This
+harness has no execution layer, so the call routes through the `[ExecutionEngine]` seam
+(`EthCLLib.Spec.Engine`), whose default instance answers the constant `true`, the same treatment
+Gloas gives `verify_and_notify_new_payload` and `is_data_available`. That default is the residual
+EL trust boundary of the FOCIL gate; no conformance vector reaches the discriminating `false`
+branch, which the `pinRecordRefuted` pin drives end-to-end under a local refuting instance instead.
+The sibling `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with `assert
+root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so the Lean
+reads a missing key as `false` through `lookupD`. That default sits off the spec path, since the
+`payloads` / `payload_inclusion_list_satisfaction` co-write in `on_execution_payload_envelope` keeps
+the key present whenever `root ∈ payloads`. The `timeliness` read in
+`get_inclusion_list_transactions` is the same shape one store over: a plain dict read in the spec,
+`lookupD false` in Lean, off-path through `process_inclusion_list`'s own co-write
+(`Heze/ForkChoice.lean`).
+
+The other two are representational. `cyclicSample` (`heze/beacon-chain.md:95-110`) resamples the
+committee as `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation;
+the Lean read is total (`i % 0 = i`, then the `getD` default), and a real beacon chain never reaches a
+zero-active-validator slot, so the branch is unreachable (`Heze/Committees.lean`). The
+`InclusionListStore` is folded into the fork-choice `Store` as a field: the spec keeps it as a
+process-lifetime singleton (`heze/inclusion-list.md:28-38`, reached through
+`get_inclusion_list_store()`), but this framework's pure `EStateM` fork choice has no ambient
+mutable singleton to hang it off, so it rides inside `Store` and threads like every other piece of
+state, behavior-complete at zero coverage cost (`Heze/ForkChoice.lean`).
+
+The rest are total-function elisions of a spec `assert`/raise, the same class as
+`is_payload_inclusion_list_satisfied` above: latent (no alpha.11 vector reaches the branch) and
+each guarded or bounded at its call site. `record_payload_inclusion_list_satisfaction`
+(`heze/fork-choice.md`) reads `Slot(state.slot - 1)`; on a slot-0 state the pyspec raises the
+uint64 underflow, invalidating the whole `on_execution_payload_envelope` call with the store
+unmodified, while the Lean guards the underflow, records the verdict over an empty required set,
+and proceeds (`Heze/ForkChoice.lean`, `recordPayloadInclusionListSatisfaction`). Only an envelope
+whose target block state sits at slot 0 (the genesis anchor) could tell the difference, and no
+vector produces one. `should_extend_payload` (`heze/fork-choice.md`) opens with `assert
+store.blocks[root].slot + 1 == get_current_slot(store)`; a pure `Bool` forkdef cannot throw, so
+the Lean elides the assert, and its one caller (`get_payload_status_tiebreaker`) is gated by
+`is_previous_slot_payload_decision`, which enforces the same slot equation. The Gloas
+`should_extend_payload` carries the identical elision, so this is inherited shape, recorded here
+with the Heze layer that restates the body. Inside the same function, the spec also reads
+`store.blocks[proposer_root]` unguarded (a `KeyError` on a boost root absent from `blocks`); the
+Lean's `| none => true` extends instead, a miss-default in the *accepting* direction, unreachable
+while the boost root is always a stored block (`on_block` sets it).
+`is_valid_inclusion_list_signature`
+(`heze/beacon-chain.md:76-87`) reads `state.validators[message.validator_index]`, which raises
+`IndexError` on an out-of-range wire index; the Lean bounds the index and returns `false` instead
+(`Heze/Signing.lean`). Same rejection, different mechanism, and no in-model caller by design.
+`get_forkchoice_store` (`heze/fork-choice.md:140-166`) opens with `assert anchor_block.state_root
+== hash_tree_root(anchor_state)`; the Lean restatement elides it (a pure constructor), so an
+inconsistent anchor pair would seed a store instead of raising. Every fork_choice vector runs
+through this constructor, but the harness always derives the anchor block and state from the same
+vector's files, so the branch is unreachable in conformance; the Gloas and Fulu constructors carry
+the identical elision. Below this threshold, one framework-wide note: the inherited time
+arithmetic (`timeIntoSlotMs`, the store-time seed) wraps `UInt64` where the pyspec saturates or
+raises, observable only at astronomically unreachable uptimes.
 
 | Vector id | Spec citation | Upstream issue | Resolution |
 |---|---|---|---|

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -43,7 +43,7 @@ instance-implicit class, and a consumer, the test runner, a proof, or a future
 production client, picks the concrete instance at the call boundary. The spec
 body commits to none of them.
 
-Six seams carry the design.
+These seams carry the design.
 
 | Seam | Class / variable | What it abstracts | Fast instance | Pure instance |
 |---|---|---|---|---|
@@ -51,11 +51,12 @@ Six seams carry the design.
 | Config values | `[Config]` | config-tier values (fork versions, genesis delay) | the test config | a fixed config |
 | Merkleization hasher | `[HasherTag]` | the SSZ hash backend, carried as `HasherTag.H` | `Sha256` (FFI, opaque) | `Sha256Spec` (pure-Lean) |
 | Crypto backend | `[CryptoBackend]` | BLS verify/aggregate, KZG | caching FFI | symbolic (abstract `verify`) |
+| Execution engine | `[ExecutionEngine Payload Tx]` | EL-answered predicates (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
 | Finite-map backing | `{map : MapKind} [FcMap map]` | the fork-choice store's maps | `hashMap` | `treeMap` |
 | Box flavour | smart constructor at the anchor | cache strategy of the boxed state | `FastBox` (cached, `= CachedBox Sha256`) | `UncachedBox Sha256Spec` (uncached) |
 | Effect monad | `{StateTransition : Type → Type}` | the state-threading effect | `EStateM` | `StateT ∘ Except` |
 
-Five of these hide completely behind instance resolution or a constructor choice
+Most of these hide completely behind instance resolution or a constructor choice
 at the anchor, so the author never names them. The fork-choice map is the one
 exception, and it cannot hide: `map` lands in the `Store` type itself, so
 `Store hashMap` and `Store treeMap` are genuinely distinct types. A fork-choice

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -43,7 +43,7 @@ instance-implicit class, and a consumer, the test runner, a proof, or a future
 production client, picks the concrete instance at the call boundary. The spec
 body commits to none of them.
 
-These seams carry the design.
+Eight seams carry the design.
 
 | Seam | Class / variable | What it abstracts | Fast instance | Pure instance |
 |---|---|---|---|---|
@@ -51,13 +51,16 @@ These seams carry the design.
 | Config values | `[Config]` | config-tier values (fork versions, genesis delay) | the test config | a fixed config |
 | Merkleization hasher | `[HasherTag]` | the SSZ hash backend, carried as `HasherTag.H` | `Sha256` (FFI, opaque) | `Sha256Spec` (pure-Lean) |
 | Crypto backend | `[CryptoBackend]` | BLS verify/aggregate, KZG | caching FFI | symbolic (abstract `verify`) |
-| Execution engine | `[ExecutionEngine Payload Tx]` | EL-answered predicates (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
+| Execution engine | `[ExecutionEngine Payload Tx]` | predicates answered by the execution layer (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
 | Finite-map backing | `{map : MapKind} [FcMap map]` | the fork-choice store's maps | `hashMap` | `treeMap` |
 | Box flavour | smart constructor at the anchor | cache strategy of the boxed state | `FastBox` (cached, `= CachedBox Sha256`) | `UncachedBox Sha256Spec` (uncached) |
 | Effect monad | `{StateTransition : Type → Type}` | the state-threading effect | `EStateM` | `StateT ∘ Except` |
 
-Most of these hide completely behind instance resolution or a constructor choice
-at the anchor, so the author never names them. The fork-choice map is the one
+Seven of the eight hide completely behind instance resolution or a constructor
+choice at the anchor, so the author never names them. (The execution-engine pair
+is a trust axis rather than a speed one: the optimistic default answers `true`
+everywhere, and a local instance replaces it where a test or proof needs a real
+or refuting verdict.) The fork-choice map is the one
 exception, and it cannot hide: `map` lands in the `Store` type itself, so
 `Store hashMap` and `Store treeMap` are genuinely distinct types. A fork-choice
 section takes `map` as an explicit type variable for that reason. The finite-map

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -6,20 +6,21 @@ the glossary). Those four are the design of record. This file records how
 `EthCLSpecs` / `EthCLLib` realize them: the current architecture, the places the code
 deviates from a doc (with the reason), and the spec-faithfulness decisions worth
 knowing. Everything here describes the tree as it stands against the
-`v1.7.0-alpha.10` pin.
+`v1.7.0-alpha.11` pin.
 
 ## Scope and conformance
 
-Two forks, **Fulu** and **Gloas**, against the `consensus-spec-tests` minimal and
-mainnet archives at `v1.7.0-alpha.10` (the latest release with cut vectors; it is
+Three forks, **Fulu**, **Gloas**, and **Heze**, against the `consensus-spec-tests` minimal and
+mainnet archives at `v1.7.0-alpha.11` (the latest release with cut vectors; it is
 flagged pre-release, so the harness pins the tag explicitly rather than reading `gh
-release latest`). The full in-scope suite is green at both presets for both forks,
-`--subset=0`, zero failures and zero `xfail`:
+release latest`). The full in-scope suite is green at both presets for all three
+forks, `--subset=0`, zero failures and zero `xfail`:
 
-|       | minimal        | mainnet        |
-| ----- | -------------- | -------------- |
-| Fulu  | **760 passed** | **667 passed** |
-| Gloas | **903 passed** | **792 passed** |
+| | minimal | mainnet |
+|---|---|---|
+| Fulu  | **5188 passed** | **847 passed** |
+| Gloas | **6573 passed** | **1034 passed** |
+| Heze  | **6770 passed** | **997 passed** |
 
 Fulu's collected formats: `epoch_processing`, `operations` (including the standalone
 `execution_payload`), `rewards`, `sanity/blocks`, `sanity/slots`, `finality`,
@@ -33,15 +34,16 @@ implemented formats reach matches by root or rejects faithfully.
 - **Fulu `fork` / `transition`** (Electra→Fulu): the upgrade and the pre-fork Electra
   blocks both need a complete Electra parent fork the library never builds. The
   **Gloas** `fork` / `transition` (Fulu→Gloas) are in scope and green.
-- **`ssz_static`**: covered by SizzLean's own tests and the build-time `deriving
-SSZRepr` gates.
+- **Fulu `ssz_static`**: reports `skip` (covered by SizzLean's own tests and the
+  build-time `deriving SSZRepr` gates). Gloas and Heze run their per-fork
+  container vectors for real.
 - **`light_client`, `networking`, `merkle_proof`, `sync`**: not state-transition or
   fork-choice formats; outside `IN_SCOPE_RUNNERS`.
 - **`genesis`**: no vectors at the pin (see Genesis below).
 
 **CI.** The `ethcl` job in `lean_action_ci.yml` runs `just ethcl-test` (builds all
 four libraries, firing the framework and spec self-tests) and `just
-ethcl-pyspec-smoke` (the `pytest-xdist` dev subset at minimal for both forks
+ethcl-pyspec-smoke` (the `pytest-xdist` dev subset at minimal for all three forks
 through the per-worker `pyspec_server`). It is green iff no in-scope vector hits a
 bug-smell or a real mismatch. Mainnet and the full sweep run on demand
 (`--preset=mainnet`, `--subset=0`).
@@ -602,7 +604,7 @@ desynced or dead server, so the parallel run is deterministic.
 
 `SPECS_ARCHITECTURE.md` §10.1 marks `genesis` in scope and §6.1 names
 `initializeBeaconStateFromEth1` / `isValidGenesisState`. The pytest corpus carries no
-`genesis` vectors for Fulu or Gloas at the `v1.7.0-alpha.10` pin, so there is nothing to
+`genesis` vectors for Fulu, Gloas, or Heze at the `v1.7.0-alpha.11` pin, so there is nothing to
 drive; both stay a `todo` stub in `Interface.lean`.
 
 ## Proofs

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -26,8 +26,10 @@ Fulu's collected formats: `epoch_processing`, `operations` (including the standa
 `execution_payload`), `rewards`, `sanity/blocks`, `sanity/slots`, `finality`,
 `random`, `fork_choice` (including the PeerDAS data-availability `on_block` cases and
 `get_proposer_head`). Gloas adds `fork`, `transition`, and the full ePBS
-`fork_choice`. `DISCREPANCIES.md` is empty of open discrepancies: every vector the
-implemented formats reach matches by root or rejects faithfully.
+`fork_choice`. `DISCREPANCIES.md` records no open vector discrepancy: every vector the
+implemented formats reach matches by root or rejects faithfully. Deliberate divergences
+from the spec *text* that no vector observes are catalogued per fork in this file (see
+the Heze diff), not there.
 
 **Out of scope** (deselected in `walk_cases`, not collected):
 
@@ -164,6 +166,23 @@ pubkeys are passed to `ethFastAggregateVerify`, which aggregates whatever list i
 given. This matches the spec result for all three of its cases (all-participate,
 majority-subtract, full list) and keeps the seam to `ethFastAggregateVerify` alone,
 with no G1 add/neg and no precomputed-aggregate dependency.
+
+## Engine seam
+
+`EthCLLib.Spec.Engine` defines `[ExecutionEngine]`, the execution-layer sibling of the
+crypto seam: a spec function whose verdict belongs to an external execution client
+routes through the typeclass instead of hard-coding an answer. `CryptoBackend` ships
+no global instance; every call site injects one. `ExecutionEngine`, by contrast,
+ships a default: the optimistic global instance answering the constant `true` (the
+seam table in `FRAMEWORK_ARCHITECTURE.md` §1), which matches how the conformance
+harness treats engine verdicts. A local `letI` substitutes a different instance per
+proof or per pin; the `pinRecordRefuted` example in `EthCLSpecs/Heze/ForkChoice.lean`
+refutes Heze's inclusion-list gate end-to-end this way.
+
+Heze's `is_inclusion_list_satisfied` is the seam's first user. Gloas's engine
+predicates (`verify_and_notify_new_payload`, `is_data_available`) share the
+constant-`true` verdict but are still modeled as inline constants; their migration
+onto the seam is a named follow-up in `EthCLLib.Spec.Engine`'s module docstring.
 
 ## State, presets, and the header macro
 
@@ -442,6 +461,11 @@ through the framework's pure `fuelIterate` (§12). The one tree walk, `filterBlo
 recurses over every child inside a fold, which a linear combinator cannot express, so it
 keeps a local fuel-bounded `where` helper. The totality the doc wants is met either way.
 
+One framework-wide caveat, shared by all three forks: the inherited time arithmetic
+(`timeIntoSlotMs`, the store-time seed in `get_forkchoice_store`) wraps on `UInt64`
+where the pyspec saturates or raises. The difference is observable only at
+astronomically unreachable uptimes.
+
 The Gloas fork choice is the node-based (`ForkChoiceNode = (root, payload_status)`)
 ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children` /
 `get_head` thread the payload status, with the ePBS handlers
@@ -450,6 +474,10 @@ ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children
 checks; the `FcStep` protocol grows the envelope / PTC-message steps. EIP-7732 genuinely
 differs here, so Gloas overrides most handlers rather than inheriting them, and the
 `forkstruct` / `inherit` reuse pays off less than it does for the state transition.
+Two spec asserts are dropped there as total-function shapes: `should_extend_payload`'s
+slot assert (its one caller enforces the same equation) and `get_forkchoice_store`'s
+anchor-root assert (Fulu's constructor drops it too). Heze inherits both shapes
+unchanged; the Heze diff below carries the detailed entries.
 
 ## Fulu state transition
 
@@ -567,6 +595,96 @@ phases. `Gloas/Transition.lean` reshapes `process_block` (drop
 payload-availability bit), and `process_epoch` (builder-pending-payments and
 `process_ptc_window` last). The `transition` format folds pre-fork Fulu blocks, applies
 `upgradeToGloas` plus onboarding at the boundary, then folds post-fork Gloas blocks.
+
+## Heze diff
+
+`EthCLSpecs.Heze` is `fork Heze from Gloas` plus EIP-7805 (FOCIL). At alpha.11
+the fork is a thin diff. EIP-7805 changes no state-transition substep, so the whole
+spine is the Gloas spine re-elaborated over Heze types, and the additions are two
+containers (`InclusionList`, `SignedInclusionList`), one committee accessor
+(`get_inclusion_list_committee`), one signature predicate
+(`is_valid_inclusion_list_signature`), and the fork-choice inclusion-list layer (the
+`InclusionListStore`, the satisfaction gate, and the `on_inclusion_list` handler).
+
+**Vector coverage.** FOCIL ships no behavioral conformance vector at the alpha.11 pin.
+The two new containers pass their full `ssz_static` suites, and the
+`on_execution_payload_envelope` fork_choice vectors do drive the Heze overrides, but
+only on the empty-inclusion-list, always-satisfied path they share with Gloas. For
+everything FOCIL-specific the pinned spec text is the oracle, backed by the
+build-enforced pins in `EthCLSpecs/Heze/ForkChoice.lean`: kernel `#guard`s (the
+kernel evaluates the check at build time) where the expected value needs no hashing,
+and `native_decide` examples (compiled evaluation, needed once a hash-tree-root calls
+the FFI hasher the kernel cannot reduce) where it does. Not every divergence below
+carries a discriminating pin; where one exists the entry names it, and the rest stand
+on unreachability arguments at their call sites.
+
+Deliberate divergences from the spec text follow. None is observable by any alpha.11
+vector. Spec citations resolve under `specs/` in `ethereum/consensus-specs` at the
+pinned version, which is also a git tag there.
+
+- **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
+  `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
+  execution client. This harness has no execution layer, so the call goes through the
+  `[ExecutionEngine]` typeclass (the Engine seam above), whose default instance answers
+  the constant `true`. That default is the residual execution-layer trust boundary of
+  the FOCIL gate. No conformance vector reaches the discriminating `false` branch; the
+  `pinRecordRefuted` `native_decide` example drives it end-to-end under a locally
+  substituted refuting engine instance.
+- **Two map reads default to `false` where the spec assumes the key present.**
+  `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with
+  `assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` function
+  cannot throw, so the Lean reads a missing key as `false` (`lookupD`). A missing key
+  is unreachable when the spec's own invariant holds: `on_execution_payload_envelope`
+  writes `payloads` and `payload_inclusion_list_satisfaction` together, so the key is
+  present whenever `root ∈ payloads`. The `timeliness` read in
+  `get_inclusion_list_transactions` (`heze/inclusion-list.md:105-114`) is the same
+  pattern, with `process_inclusion_list` writing the stored list and its timeliness
+  entry together.
+- **`record_payload_inclusion_list_satisfaction`** (`heze/fork-choice.md:180-193`)
+  reads `Slot(state.slot - 1)`. On a slot-0 state the pyspec raises the uint64
+  underflow, which invalidates the whole `on_execution_payload_envelope` call with the
+  store unmodified; the Lean guards the underflow, records the verdict over an empty
+  required set, and proceeds. Only an envelope whose target block state sits at slot 0
+  (the genesis anchor) could tell the difference, and no vector produces one.
+- **`should_extend_payload`** (`heze/fork-choice.md:221-236`) opens with
+  `assert store.blocks[root].slot + 1 == get_current_slot(store)`; the Lean is a total
+  `Bool` function, so the assert is dropped. Its one caller
+  (`get_payload_status_tiebreaker`) is gated by `is_previous_slot_payload_decision`,
+  which enforces the same slot equation. Gloas drops the identical assert (see the Fork
+  choice section); Heze restates the body for the inclusion-list gate. In the same
+  function, the spec reads `store.blocks[proposer_root]` unguarded (a `KeyError` on a
+  boost root absent from `blocks`); the Lean's `| none => true` arm extends instead, a
+  default in the accepting direction, unreachable while the boost root is always a
+  stored block (`on_block` sets it).
+- **`is_valid_inclusion_list_signature`** (`heze/beacon-chain.md:76-87`) reads
+  `state.validators[message.validator_index]`, which raises `IndexError` on an
+  out-of-range wire index; the Lean bounds the index and returns `false` instead
+  (`EthCLSpecs/Heze/Signing.lean`). Same rejection, different mechanism; the predicate
+  has no in-model caller by design.
+- **`get_forkchoice_store`** (`heze/fork-choice.md:140-166`) opens with
+  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean
+  restatement is a pure constructor and drops it, so an inconsistent anchor pair would
+  seed a store instead of raising. Every fork_choice vector runs through this
+  constructor, but the harness always derives the anchor block and state from the same
+  vector's files, so the branch is unreachable in conformance. The Gloas and Fulu
+  constructors drop the identical assert.
+
+Two model-structure choices carry no behavioral difference on any reachable input:
+
+- **`cyclicSample`** (`heze/beacon-chain.md:95-110`) resamples the committee as
+  `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty
+  concatenation. The Lean read is total (`i % 0 = i`, then the `getD` default), and a
+  real beacon chain never reaches a zero-active-validator slot, so the branch is
+  unreachable (`EthCLSpecs/Heze/Committees.lean`).
+- **The `InclusionListStore` rides inside the fork-choice `Store` as a field.** The
+  spec keeps it as a process-lifetime singleton reached through
+  `get_inclusion_list_store()` (`heze/inclusion-list.md:28-38`); this framework's fork
+  choice threads one `Store` value through the generic `StoreTransition` monad
+  (`SPEC_AUTHORING_MODEL.md` §4), with no ambient singleton to hang the spec's store
+  off, so it rides as a field and moves with the rest of the state. Behavior is
+  identical.
+  The full rationale lives on the `InclusionListStore` declaration
+  (`EthCLSpecs/Heze/ForkChoice.lean`).
 
 ## Config-tier values that bite
 

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -77,7 +77,7 @@ wraps both behind the `[CryptoBackend]` seam.
 **The vectors and the spec source.** Conformance runs against the upstream
 `consensus-spec-tests`, downloaded per `pyspecPinnedVersion`. The
 `PINNED_VERSION` in `packages/EthCLSpecs/PySpecTests/harness.py` pins
-`v1.7.0-alpha.10`; the implementation bumps
+`v1.7.0-alpha.11`; the implementation bumps
 to the current latest release at start and confirms the tag carries Gloas vectors.
 The archive layout is `tests/<preset>/<fork>/<runner>/<handler>/<suite>/<case>/`; the
 preset and fork live in the path, and each case carries a `meta.yaml`

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -78,7 +78,8 @@ wraps both behind the `[CryptoBackend]` seam.
 `consensus-spec-tests`, downloaded per `pyspecPinnedVersion`. The
 `PINNED_VERSION` in `packages/EthCLSpecs/PySpecTests/harness.py` pins
 `v1.7.0-alpha.11`; the implementation bumps
-to the current latest release at start and confirms the tag carries Gloas vectors.
+to the current latest release at start and confirms the tag carries vectors for the
+newest ported fork (Heze at this writing).
 The archive layout is `tests/<preset>/<fork>/<runner>/<handler>/<suite>/<case>/`; the
 preset and fork live in the path, and each case carries a `meta.yaml`
 (`bls_setting`, `blocks_count`, the `transition` format's `fork_epoch`). The spec

--- a/packages/EthCLSpecs/docs/README.md
+++ b/packages/EthCLSpecs/docs/README.md
@@ -1,7 +1,7 @@
 # EthCLSpecs, architecture documents
 
 EthCLSpecs is a Lean 4 library for Ethereum consensus-spec types, SSZ, the
-state-transition function, and fork choice, covering the Fulu and Gloas forks.
+state-transition function, and fork choice, covering the Fulu, Gloas, and Heze forks.
 
 Three documents define the design. Read them in order.
 
@@ -10,8 +10,8 @@ Three documents define the design. Read them in order.
    canonical glossary. Start here.
 2. [FRAMEWORK_ARCHITECTURE.md](FRAMEWORK_ARCHITECTURE.md), the framework and DSL that
    implement the contract.
-3. [SPECS_ARCHITECTURE.md](SPECS_ARCHITECTURE.md), how the Fulu and Gloas specs are
-   organized, ported, and tested.
+3. [SPECS_ARCHITECTURE.md](SPECS_ARCHITECTURE.md), how the fork specs (Fulu, Gloas,
+   Heze) are organized, ported, and tested.
 
 The glossary in the first document is the single source of truth for shared
 vocabulary; the other two quote it.
@@ -21,6 +21,12 @@ vocabulary; the other two quote it.
 implementor needs. During implementation, deviations and notable findings go in
 `IMPLEMENTATION_NOTES.md` (created then), not into these four documents, which stay
 the design of record.
+
+[DISCREPANCIES.md](DISCREPANCIES.md) is the narrow spec-vs-vector ledger: it records
+only cases where a released vector contradicts the spec text (upstream pyspec bugs)
+and resolved vector-level gaps, keyed by vector id. Deliberate implementation
+divergences that no vector observes belong in `IMPLEMENTATION_NOTES.md` instead,
+catalogued per fork.
 
 [FUTURE_WORK.md](FUTURE_WORK.md) records deferred changes: what is left, why it waits,
 and the shape it will take, so a later pass picks each one up whole. The current entry is

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -922,20 +922,20 @@ The pinned version per fork is the `pyspecPinnedVersion` constant of the contrac
 spec-revision-pin section: the latest upstream tag carrying that fork's vectors,
 stable or pre-release. Fulu pins a stable release. Gloas tracks the consensus-specs
 main branch, so it pins a pre-release or alpha tag, or a dev commit, while it is
-unreleased. The two forks sit at different pins at the same time.
+unreleased. Forks can sit at different pins at the same time.
 
 The values below are illustrative and are bumped to the current latest release at
-implementation time (the pytest harnesses pin `v1.7.0-alpha.10` at this writing);
+implementation time (the pytest harnesses pin `v1.7.0-alpha.11` at this writing);
 the implementation also confirms the chosen tag
 actually carries Gloas vectors, falling back to a dev commit if not.
 
 ```lean
 namespace EthCLSpecs.Fulu
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"   -- latest release at writing
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"   -- latest release at writing
 end EthCLSpecs.Fulu
 
 namespace EthCLSpecs.Gloas
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"   -- same tag while Gloas is unreleased
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"   -- same tag while Gloas is unreleased
 end EthCLSpecs.Gloas
 ```
 

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -6,7 +6,7 @@ it, for the Lean 4 consensus-spec library. It sits above its two siblings.
 author writes and what the framework supplies, carries the canonical glossary,
 and states the author/framework boundary table. `FRAMEWORK_ARCHITECTURE.md`
 builds each "framework generates" cell of that table from below. This document
-uses both from the author's side: it shows how the Fulu and Gloas specs are
+uses both from the author's side: it shows how the Fulu, Gloas, and Heze specs are
 organized, ported, tested, and eventually proved, written against the contract
 and on top of the machinery. Read `SPEC_AUTHORING_MODEL.md` first. This document
 quotes its glossary rather than re-coining terms, and cross-references both
@@ -64,7 +64,7 @@ Both `minimal` and `mainnet` presets are supported from the start, through the
 preset tier system that `FRAMEWORK_ARCHITECTURE.md` builds in its
 preset-constant-config-tier-system section. Minimal comes first for fast
 iteration: its smaller vector widths and shorter epochs make a failing vector
-quick to reproduce. Mainnet vectors exist for both forks and run on demand rather
+quick to reproduce. Mainnet vectors exist for all three forks and run on demand rather
 than on every push, since they are slower. The preset machinery carries both from
 day one, so mainnet is a CI-schedule choice, never a missing capability.
 
@@ -833,15 +833,15 @@ interface and `PySpecTests`, written once and fork-agnostic, runs every format.
 | `rewards/*` | a single delta function | yes |
 | `fork_choice` | the `on_*` handlers | yes |
 | `genesis` | `initializeBeaconStateFromEth1` | yes |
-| `fork` | `upgradeToGloas` | yes (Fulu to Gloas only) |
-| `transition` | `stateTransition` with `upgradeToGloas` mid-fold | yes (Fulu to Gloas only) |
-| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Fulu + Gloas) |
+| `fork` | `upgradeToGloas` / `upgradeToHeze` | yes (Fulu→Gloas, Gloas→Heze) |
+| `transition` | `stateTransition` with the upgrade mid-fold | yes (Fulu→Gloas, Gloas→Heze) |
+| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Gloas + Heze; Fulu via SizzLean) |
 | `bls`, `kzg` | n/a | no (crypto-backend concern) |
 
 The `rewards/*` format is in scope and drives a single delta function in isolation,
 the reward and penalty deltas of the `Rewards` concern file (row 29). `fork` and
-`transition` run only the Fulu-to-Gloas upgrade, since Electra is not built. Both
-presets run; mainnet runs on demand rather than on every CI pass.
+`transition` run the Fulu-to-Gloas and Gloas-to-Heze upgrades only, since Electra is
+not built. Both presets run; mainnet runs on demand rather than on every CI pass.
 
 ### 10.2 The reject-faithfulness audit
 
@@ -927,7 +927,7 @@ unreleased. Forks can sit at different pins at the same time.
 The values below are illustrative and are bumped to the current latest release at
 implementation time (the pytest harnesses pin `v1.7.0-alpha.11` at this writing);
 the implementation also confirms the chosen tag
-actually carries Gloas vectors, falling back to a dev commit if not.
+actually carries the newest ported fork's vectors, falling back to a dev commit if not.
 
 ```lean
 namespace EthCLSpecs.Fulu

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -629,7 +629,8 @@ fork must provide, with fixed signatures, expressed as a typeclass the fork
 instantiates. The entry points are `stateTransition`, `processSlots`, the
 individual `process_*` steps and operation handlers, the reward and penalty
 delta functions, the `on_*` fork-choice handlers,
-`initializeBeaconStateFromEth1`, and `upgradeToGloas`. Each entry point is
+`initializeBeaconStateFromEth1`, and the fork upgrade (`upgradeToGloas`,
+`upgradeToHeze`). Each entry point is
 independently invocable, so a single-operation vector can drive a single handler
 without running a whole block.
 

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -598,7 +598,7 @@ implementation passes the full pyspec suite. It is recorded as a constant in
 the fork:
 
 ```lean
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
 ```
 
 The name is lowerCamelCase, per the Lean convention; the value is the release

--- a/packages/SizzLean/PySpecTests/harness.py
+++ b/packages/SizzLean/PySpecTests/harness.py
@@ -29,7 +29,7 @@ import yaml
 
 # The pinned release (matches EthCLSpecs.Fulu.Interface.pyspecPinnedVersion and
 # the EthCLSpecs harness). `ssz_generic` ships in the `general` archive.
-PINNED_VERSION = "v1.7.0-alpha.10"
+PINNED_VERSION = "v1.7.0-alpha.11"
 CACHE_DIR = Path.home() / ".cache" / "sizzlean"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 


### PR DESCRIPTION
Adds the Heze fork layer (EIP-7805 FOCIL) at consensus-specs v1.7.0-alpha.11. Heze at this
pin is a thin diff over Gloas: ethereum/consensus-specs#5371 reverted the inclusion-list
bitlist back out of the bid, so the consensus delta is the `InclusionList` container family
plus the FOCIL fork-choice machinery.

## Conformance

heze minimal: 6770 passed, 3198 skipped, 0 failed, 0 xfail. heze mainnet: 997 passed, 130
skipped, 0 failed, 0 xfail. Every heze `fork_choice` case passes (84 minimal + 53 mainnet),
including through the two FOCIL overrides with behavioral deltas on the vector path
(`should_extend_payload`, `on_execution_payload_envelope`; the re-declared store constructor
also runs everywhere, its delta is seeding the two new fields empty). fulu and gloas are
unchanged. Deliberately excluded categories stay visible: the
`ssz_static` types Heze doesn't model and the `genesis` runner report `skip`, and the
harness now names its one never-collected runner (`fast_confirmation`) in the allowlist
comment instead of leaving the omission silent.

## What's in the layer

- The Gloas spine re-instantiated over Heze's byte-identical twin types (EpochProcessing /
  Operations / Withdrawals / Transition / ForkChoice, each inheriting its Gloas counterpart).
  EIP-7805 adds no new state-transition step at alpha.11.
- The two new containers, `InclusionList` / `SignedInclusionList`, the passthrough
  `upgradeToHeze`, and the beacon-chain helpers `get_inclusion_list_committee` /
  `is_valid_inclusion_list_signature`.
- The FOCIL fork-choice layer: the `InclusionListStore`, `process_inclusion_list` /
  `get_inclusion_list_transactions`, `on_inclusion_list`, the satisfaction record/gate pair,
  `get_inclusion_list_due_ms`, and the two overrides above.

Alpha.11 ships `ssz_static` vectors for the two new containers (full suites, passing) but no
vector driving FOCIL behavior: no `on_inclusion_list` fork-choice step, no operation, nothing
feeding the inclusion-list store. So everything past the two overrides runs on no behavioral
conformance input yet. I mirrored that layer branch-for-branch from the pinned spec text and
pinned it with build-enforced `#guard`s / `native_decide` examples (expected values worked out
by hand), so a later edit can't regress it silently. `is_inclusion_list_satisfied` is an
Engine-API verdict with no EL in this harness; it enters through a framework-level
`[ExecutionEngine]` seam (a generic class in EthCLLib, its own commit) whose default
instance answers `true` (the treatment Gloas gives `verify_and_notify_new_payload` /
`is_data_available`), and a refuting-oracle pin drives the `false` branch no vector can
reach. The vectorless layer's deliberate spec-text divergences are recorded in
`packages/EthCLSpecs/docs/DISCREPANCIES.md`.

## One supporting fix (touches Fulu and Gloas)

The fork-choice step interpreters silently passed unmodeled steps through a `| _ => pure ()`
catch-all, so a `checks.get_proposer_head` entry scored a vacuous pass. All three
interpreters now match `FcStep` exhaustively: unmodeled steps surface as `todo` (an xfail)
and a newly added constructor is a build error. The two step decoders (harness and server)
report an unrecognized step or check key as `unsupported` instead of dropping it, which
pre-wires a future `on_inclusion_list` vector. No alpha.11 vector hits any of these paths,
so conformance is unchanged. The `pyspec_server` CLI got the same treatment: an unknown
fork or preset name errors with the expected-names list instead of silently serving Fulu.
Two housekeeping commits ride along: a `PYTEST_JOBS` override for the full-sweep recipes
(default unchanged) and a docs sweep of the pin citations the alpha.11 re-pin left stale.

## Known limitation

`fcInterpretHeze` is a near-verbatim copy of `fcInterpretGloas`, differing only in the
fork-namespaced decode types. The state-transition spine inherits across forks; the step
interpreter has no equivalent seam yet, so each fork clones the whole match and keeps it in
lockstep by hand. The natural fix is a parametric interpreter over a fork's decode bundle; I
queued that as a follow-up rather than folding it into a fork-addition PR, and the same goes
for migrating Gloas's two inline engine constants onto the new `[ExecutionEngine]` seam.

<details>
<summary><b>Deferred follow-ups</b> (tracked on my side; none block this PR). Tick anything you'd like filed as an upstream issue (or pulled into this PR) and I'll take it from there.</summary>

- [ ] **`fast_confirmation` runner**: the corpus ships a whole fork-choice format we don't collect yet.
  <details><summary>details</summary>

  The alpha.11 corpus carries `fast_confirmation` (the confirmation-rule format) for
  fulu/gloas/heze, minimal-only, ~1530 yaml files across 9 handlers. It is deliberately
  uncollected and now named in the
  [`IN_SCOPE_RUNNERS` allowlist comment](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLSpecs/PySpecTests/harness.py).
  Implementing it is real fork-choice work: a steps script plus the confirmation-rule store
  fields (`previous_slot_head`, observed-justified / greatest-unrealized checkpoints), and
  upstream is still growing the format (~870 new lines of phase0 tests post-alpha.11).
  </details>
- [ ] **Parametric fork-choice interpreter**: the clone family from the Known-limitation section.
  <details><summary>details</summary>

  Beyond `fcInterpretHeze` ≈ `fcInterpretGloas`: `runStatic` and `decodeOp` are fully
  fork-agnostic yet exist as three identical copies per
  [fork `Interface.lean`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean),
  and the ~45-arm `ssz_static` name dispatch is restated per fork, where a missed arm doesn't
  fail, it silently reports skip. A parametric interpreter over a fork's decode bundle plus a
  delta-based dispatch table fixes the class; kept out of here so the diff stays on the Heze layer.
  </details>
- [ ] **Gloas engine predicates onto `[ExecutionEngine]`**: finish what the seam commit starts.
  <details><summary>details</summary>

  [`EthCLLib/Spec/Engine.lean`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLLib/EthCLLib/Spec/Engine.lean)
  now owns the generic engine seam and Heze's `is_inclusion_list_satisfied` reads it;
  `verify_and_notify_new_payload` / `is_data_available` in
  [`Gloas/ForkChoice.lean`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean)
  are still inline constants. Migrating them gives one EL trust boundary and makes
  refuting-instance pins possible for both.
  </details>
- [ ] **Harness check-emitter registry**: make the known-key drift impossible, not just commented.
  <details><summary>details</summary>

  `KNOWN_CHECK_KEYS` / `KNOWN_CHECK_SUBKEYS` in
  [`harness.py`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLSpecs/PySpecTests/harness.py)
  hand-mirror the emitter chain in `_build_fork_choice_request`; a handler added without the
  set-update silently demotes a fully-checked case to xfail. One key→(emitter, subkeys) table
  driving both ends the failure mode.
  </details>
- [ ] **`checkHead` missing-block fallback**: replace a vacuous-pass-shaped default with a thrown error.
  <details><summary>details</summary>

  All three interpreters read the head block's slot as
  `match FcMap.lookup store.blocks head.root with | some b => b.slot.toNat | none => 0`. A store
  corrupt enough to make `getHead` return an unstored root (unreachable today; pyspec would
  KeyError loudly) could then pass a `head <root> 0` check vacuously. Cross-fork one-arm change.
  </details>
- [ ] **`should_override_forkchoice_update` bucket**: xfail today, arguably skip.
  <details><summary>details</summary>

  It routes `unsupported` → `todo` (the work-queue xfail bucket), but nothing intends to model
  it (it needs an EL head/safe-block signal), so by the
  [`Errors.lean`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLLib/EthCLLib/Spec/Errors.lean)
  taxonomy it may belong in `outOfScope` (skip). Vector-dead either way at alpha.11; a one-arm
  decision plus a comment.
  </details>
- [ ] **Preset watch: `INCLUSION_LIST_COMMITTEE_SIZE`**: nothing to do until presets diverge.
  <details><summary>details</summary>

  A preset-file value modeled as a universal-tier `abbrev` because both presets say `2**4` at
  this pin (and still on master). The comment in
  [`Fulu/Constants.lean`](https://github.com/IvanAnishchuk/etheorem/blob/feat/heze-focil-alpha11/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean)
  records the promotion path (a `Preset` field like `ptcSize`) for the day a re-pin diverges them.
  </details>
</details>
