### PR TITLE
test(ethcl): split deliberately out-of-scope vectors into skip, not xfail

### DIFF
--- a/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
@@ -128,6 +128,7 @@ def runCase [ForkInterface] (req : CaseRequest) : CaseResult :=
       else { passed := false, bucket := .likelyBug, detail := "rewards deltas mismatch" }
     | .error e =>
       match e.classify with
+      | .todo       => { passed := false, bucket := .todo, detail := reprStr e }
       | .outOfScope => { passed := false, bucket := .outOfScope, detail := reprStr e }
       | _           => { passed := false, bucket := .likelyBug, detail := reprStr e }
   else
@@ -151,11 +152,12 @@ def runCase [ForkInterface] (req : CaseRequest) : CaseResult :=
     { passed := false, bucket := e.classify, detail := reprStr e }
   | .error e, none =>
     -- Invalid vector that rejected: faithful iff it was an `assert`. A bug-smell
-    -- reject still counts as rejected but is flagged; a `todo` fails (not a
-    -- validation).
+    -- reject still counts as rejected but is flagged; a `todo` / `outOfScope` fails
+    -- (not a validation) and reports as its own bucket (xfail / skip respectively).
     match e.classify with
     | .expectedRejection => { passed := true,  bucket := .expectedRejection, detail := reprStr e }
     | .likelyBug         => { passed := true,  bucket := .likelyBug, detail := reprStr e, flagged := true }
+    | .todo              => { passed := false, bucket := .todo, detail := reprStr e }
     | .outOfScope        => { passed := false, bucket := .outOfScope, detail := reprStr e }
     | .passing           => { passed := false, bucket := .likelyBug, detail := "unreachable classify" }
 

--- a/packages/EthCLLib/EthCLLib/Spec/Assert.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Assert.lean
@@ -29,11 +29,20 @@ namespace EthCLLib.Spec
 universe u
 
 /-- The typed deferral, throwing the section's `todo` reject (resolved through
-`SpecReject` from the monad's error type). Classified out-of-scope by the harness.
-Polymorphic in the result so it stubs any step or helper. -/
+`SpecReject` from the monad's error type). A work-queue item the harness reports
+as `xfail`; it is expected to pass once the branch is filled. Polymorphic in the
+result so it stubs any step or helper. -/
 @[inline] def todo {m : Type → Type u} {α E : Type} [MonadExcept E m] [SpecReject E]
     (what : String) : m α :=
   throw (SpecReject.todo what)
+
+/-- The typed out-of-scope reject (resolved through `SpecReject` from the monad's
+error type). For a branch we deliberately do not model, a runner or type chosen
+not to implement, so the harness reports it as `skip` rather than counting it in
+the `xfail` work-queue. Polymorphic in the result, like `todo`. -/
+@[inline] def outOfScope {m : Type → Type u} {α E : Type} [MonadExcept E m] [SpecReject E]
+    (what : String) : m α :=
+  throw (SpecReject.outOfScope what)
 
 /-- Run the nested state machine from a store action: execute `act` (the
 specialised `state_transition` / `process_slots` as an `EStateM StateTransitionError

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -7,16 +7,22 @@ machine with `StoreTransitionError`, which embeds the state type because
 `onBlock` runs the state machine inside the store machine.
 
 Each constructor carries a *typed* term per failure kind, in keeping with the
-project's stringly-typed-is-a-smell principle. The two `String` payloads
-(`assert`'s `descr`, `todo`'s `what`) are diagnostic only: they are printed on a
-vector mismatch and never branched on. The harness branches on the *constructor*
-(its classify mode), which is typed:
+project's stringly-typed-is-a-smell principle. The `String` payloads
+(`assert`'s `descr`, `todo`'s / `outOfScope`'s `what`) are diagnostic only: they
+are printed on a vector mismatch and never branched on. The harness branches on
+the *constructor* (its classify mode), which is typed:
 
 | Constructor | Classify-mode meaning |
 |---|---|
 | `assert` | an expected rejection; an invalid vector should hit one |
-| `todo` | an unimplemented branch; flagged out-of-scope, not a rejection |
+| `todo` | an unimplemented branch we intend to fill; a work-queue item, reported `xfail` |
+| `outOfScope` | a branch we deliberately do not model; reported `skip`, not counted as work |
 | `outOfBounds` / `missingKey` | a smell; well-formed input should not hit these |
+
+`todo` and `outOfScope` both name a branch that does not run, the distinction is
+intent: a `todo` is expected to pass once the work-queue reaches it, an
+`outOfScope` never will (a runner or type we chose not to implement), so it must
+not inflate the `xfail` work-queue.
 -/
 
 set_option autoImplicit false
@@ -31,8 +37,10 @@ work-queue of `FRAMEWORK_ARCHITECTURE.md` §6.1). -/
 inductive StateTransitionError where
   /-- A spec assertion failed; `descr` is the rendered condition, diagnostic only. -/
   | assert (descr : String)
-  /-- An unimplemented branch, with a documented unreachable-in-scope claim. -/
+  /-- An unimplemented branch we intend to fill: a work-queue deferral, reported `xfail`. -/
   | todo (what : String)
+  /-- A branch we deliberately do not model (an out-of-scope runner / type); reported `skip`. -/
+  | outOfScope (what : String)
   /-- Indexed access past the end: index `idx` against bound `bound`. -/
   | outOfBounds (idx bound : Nat)
   deriving Inhabited, Repr, DecidableEq
@@ -46,8 +54,10 @@ type embeds the state type, the asymmetry the error split is built on. -/
 inductive StoreTransitionError where
   /-- A spec assertion failed; diagnostic only. -/
   | assert (descr : String)
-  /-- An unimplemented branch, with a documented unreachable-in-scope claim. -/
+  /-- An unimplemented branch we intend to fill: a work-queue deferral, reported `xfail`. -/
   | todo (what : String)
+  /-- A branch we deliberately do not model (an out-of-scope runner / type); reported `skip`. -/
+  | outOfScope (what : String)
   /-- An `FcMap` lookup found no entry for `key` (the 32-byte block root). -/
   | missingKey (key : Vector UInt8 32)
   /-- A nested state-transition failure surfaced through `runStateTransition`. -/
@@ -62,7 +72,9 @@ inductive ClassifyBucket where
   | passing
   /-- An `assert` reject; correct for a vector marked invalid. -/
   | expectedRejection
-  /-- A `todo` reject; an out-of-scope deferral, not a rejection. -/
+  /-- A `todo` reject; an unimplemented work-queue branch. Reported `xfail`. -/
+  | todo
+  /-- An `outOfScope` reject; a branch we deliberately do not model. Reported `skip`. -/
   | outOfScope
   /-- An `outOfBounds` / `missingKey` reject; a likely framework or spec bug. -/
   | likelyBug
@@ -70,11 +82,13 @@ inductive ClassifyBucket where
 
 namespace ClassifyBucket
 
-/-- A short tag for wire reporting and human-readable output. -/
+/-- A short tag for wire reporting and human-readable output. `todo` reports as
+`xfail` work-queue; `outOfScope` reports as a `skip` the harness does not count. -/
 def tag : ClassifyBucket → String
   | .passing           => "pass"
   | .expectedRejection => "reject"
-  | .outOfScope        => "todo"
+  | .todo              => "todo"
+  | .outOfScope        => "skip"
   | .likelyBug         => "bug"
 
 end ClassifyBucket
@@ -82,14 +96,16 @@ end ClassifyBucket
 /-- Classify a state-transition reject by its constructor. -/
 def StateTransitionError.classify : StateTransitionError → ClassifyBucket
   | .assert _        => .expectedRejection
-  | .todo _          => .outOfScope
+  | .todo _          => .todo
+  | .outOfScope _    => .outOfScope
   | .outOfBounds _ _ => .likelyBug
 
 /-- Classify a store-transition reject by its constructor. A wrapped nested
 state failure classifies by the inner reject. -/
 def StoreTransitionError.classify : StoreTransitionError → ClassifyBucket
   | .assert _      => .expectedRejection
-  | .todo _        => .outOfScope
+  | .todo _        => .todo
+  | .outOfScope _  => .outOfScope
   | .missingKey _  => .likelyBug
   | .transition e  => e.classify
 
@@ -102,11 +118,13 @@ just the constructors. -/
 class SpecReject (E : Type) where
   /-- The failed-assertion reject. -/
   assert : String → E
-  /-- The unimplemented-branch (out-of-scope) reject. -/
+  /-- The unimplemented-branch reject; a work-queue deferral, reported `xfail`. -/
   todo   : String → E
+  /-- The deliberately-unmodelled-branch reject; reported `skip`, not a work-queue item. -/
+  outOfScope : String → E
 
-instance : SpecReject StateTransitionError := ⟨.assert, .todo⟩
-instance : SpecReject StoreTransitionError := ⟨.assert, .todo⟩
+instance : SpecReject StateTransitionError := ⟨.assert, .todo, .outOfScope⟩
+instance : SpecReject StoreTransitionError := ⟨.assert, .todo, .outOfScope⟩
 
 /-- The reporting bucket of a typed reject, as a class so a runner error generic over the
 spec reject it wraps (`RunError`) can defer to whichever spec error is inside. The two spec

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -331,7 +331,7 @@ private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
   | "SignedBeaconBlockHeader"  => runStatic (@SignedBeaconBlockHeader P) typeName bytes
   | "SignedBLSToExecutionChange" => runStatic (@SignedBLSToExecutionChange P) typeName bytes
   | "SignedVoluntaryExit"      => runStatic (@SignedVoluntaryExit P) typeName bytes
-  | _ => .error (.spec (.todo s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Fulu"))
+  | _ => .error (.spec (.outOfScope s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Fulu"))
 
 /-- Fulu's fork-interface instance at preset `P`. The runner injects `minimal` or
 `mainnet` per test; both coexist because the preset is a parameter, not a global
@@ -345,9 +345,9 @@ instance (`FRAMEWORK_ARCHITECTURE.md` §4). -/
   runOperation    := runOperationImpl P C
   runRewards      := runRewardsImpl P C
   runForkChoice   := runForkChoiceImpl P C
-  runGenesis      := fun _ _   => .error (.spec (.todo "genesis: no vectors at this pin (out of scope)"))
-  runUpgrade      := fun _     => .error (.spec (.todo "fork upgrade: Gloas only (Phase 3)"))
-  runTransition   := fun _ _ _ => .error (.spec (.todo "transition: needs the Electra parent fork (Electra→Fulu boundary)"))
+  runGenesis      := fun _ _   => .error (.spec (.outOfScope "genesis: out of scope (not modeled)"))
+  runUpgrade      := fun _     => .error (.spec (.outOfScope "fork upgrade: Gloas only (out of scope for Fulu)"))
+  runTransition   := fun _ _ _ => .error (.spec (.outOfScope "transition: needs the Electra parent fork (out of scope; Electra→Fulu boundary)"))
 
 /-- The `minimal`-preset interface (the default; runs on every push). -/
 @[reducible] def fuluInterface : ForkInterface := fuluInterfaceFor minimal minimalConfig

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -411,14 +411,14 @@ private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
   | "SignedExecutionPayloadBid"      => runStatic (@Gloas.SignedExecutionPayloadBid P) typeName bytes
   | "SignedExecutionPayloadEnvelope" => runStatic (@Gloas.SignedExecutionPayloadEnvelope P) typeName bytes
   | "SignedVoluntaryExit"        => runStatic (@Gloas.SignedVoluntaryExit P) typeName bytes
-  | _ => .error (.spec (.todo s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Gloas"))
+  | _ => .error (.spec (.outOfScope s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Gloas"))
 
 /-- Gloas's fork-interface instance at preset `P` with the config's
 `GLOAS_FORK_VERSION`. Every in-scope entry is driven: the `fork` upgrade, `stateRoot`,
 all `epoch_processing` substeps, `rewards`, the operation handlers (including the ePBS
 ones), the block spine (`sanity/blocks` / `sanity/slots` / `finality` / `random`), the
 `transition` boundary, and the node-based ePBS fork choice (`runForkChoice`). Only
-`runGenesis` stays `todo` (no genesis vectors at the pin). -/
+`runGenesis` is out of scope (the genesis runner is not modeled). -/
 @[reducible] def gloasInterfaceFor (P : Preset) (C : Config) (forkVersion : Version) : ForkInterface where
   stateRoot       := stateRootImpl P
   sszStatic       := sszStaticImpl P
@@ -429,7 +429,7 @@ ones), the block spine (`sanity/blocks` / `sanity/slots` / `finality` / `random`
   runOperation    := runOperationImpl P C
   runBlocks       := runBlocksImpl P C
   runSlots        := runSlotsImpl P C
-  runGenesis      := fun _ _   => .error (.spec (.todo "gloas genesis: not yet ported"))
+  runGenesis      := fun _ _   => .error (.spec (.outOfScope "gloas genesis: out of scope (not modeled)"))
   runTransition   := runTransitionImpl P C forkVersion
 
 /-- The `minimal`-preset / config Gloas interface. -/

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -119,7 +119,8 @@ private def handleSszStatic (iface : ForkInterface) (fields : Array String) : IO
       return "fail\tbug\tround-trip mismatch (re-serialize ≠ input)"
     else
       return "pass\tpassing\t"
-  | .error (.spec (.todo d)) => return s!"fail\ttodo\t{d}"
+  | .error (.spec (.todo d))       => return s!"fail\ttodo\t{d}"
+  | .error (.spec (.outOfScope d)) => return s!"fail\tskip\t{d}"
   | .error e =>
     let detail := (match e with
       | .decode what => s!"{what} decode failed"
@@ -178,11 +179,13 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
       | .decode what           => s!"{what} decode failed"
       | .spec (.assert d)      => d
       | .spec (.todo d)        => d
+      | .spec (.outOfScope d)  => d
       | .spec (.missingKey _)  => "missing store key"
       | .spec (.transition te) => reprStr te).replace "\t" " " |>.replace "\n" " "
     match e with
-    | .spec (.todo _) => return s!"fail\ttodo\t{detail}"
-    | _               => return s!"fail\tbug\t{detail}"
+    | .spec (.todo _)       => return s!"fail\ttodo\t{detail}"
+    | .spec (.outOfScope _) => return s!"fail\tskip\t{detail}"
+    | _                     => return s!"fail\tbug\t{detail}"
 
 /-- Process one request line into a result line, against a given fork's interface.
 Exceptions become a `fail ⇥ bug` result so a single bad case never crashes the

--- a/packages/EthCLSpecs/EthCLSpecs/Tests/WalkingSkeleton.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Tests/WalkingSkeleton.lean
@@ -58,18 +58,20 @@ example :
     (fuluInterface.runSlots (SizzLean.SSZ.serialize (default : @BeaconState minimal)) 3).toOption.isSome := by
   native_decide
 
--- A still-deferred entry (`runGenesis`) returns a `todo` reject, the typed
--- deferral safety net: a vector that reaches it fails loudly, never silently.
+-- An out-of-scope entry (`runGenesis`, a runner we deliberately do not model)
+-- returns an `outOfScope` reject: a vector that reaches it is reported `skip`,
+-- never silently passed and never counted in the `todo` work-queue.
 #guard (match fuluInterface.runGenesis #[] {} with
-  | .error (.spec (.todo _)) => true | _ => false)
+  | .error (.spec (.outOfScope _)) => true | _ => false)
 
-/-- A `genesis` request. `runGenesis` is a `todo`; the driver classifies the
-unimplemented path out-of-scope so the case fails rather than passing silently. -/
+/-- A `genesis` request. `runGenesis` is `outOfScope`; the driver classifies the
+unmodelled path `outOfScope` so the case is reported `skip` rather than passing
+silently or inflating the `xfail` work-queue. -/
 def sampleGenesisReq : CaseRequest :=
   { runner := "genesis", handler := "initialization",
     pre := ByteArray.empty, post := some ByteArray.empty, inputs := #[], caseMeta := {} }
 
--- The driver dispatches to the interface and classifies the unimplemented path.
+-- The driver dispatches to the interface and classifies the unmodelled path.
 #guard (@runCase fuluInterface sampleGenesisReq).passed = false
 #guard (@runCase fuluInterface sampleGenesisReq).bucket = ClassifyBucket.outOfScope
 

--- a/packages/EthCLSpecs/PySpecTests/test_pyspec.py
+++ b/packages/EthCLSpecs/PySpecTests/test_pyspec.py
@@ -6,14 +6,17 @@ assertion follows the reject-faithfulness audit (`SPECS_ARCHITECTURE.md` §10.2)
 
 - `bug` (`outOfBounds` / `missingKey` on well-formed input, or a server crash) is
   always a hard failure, the bug-smell the audit hunts for;
-- `todo` (an unimplemented branch) is `xfail`, the Phase-2 work-queue: it does not
-  fail the run, but it is visible and a vector that reaches it never passes
-  silently;
+- `todo` (an unimplemented branch we intend to fill) is `xfail`, the Phase-2
+  work-queue: it does not fail the run, but it is visible and a vector that reaches
+  it never passes silently;
+- `skip` (a branch we deliberately do not model, an out-of-scope runner or type) is
+  `pytest.skip`: it is not a failure and not work-queue, so it never inflates the
+  `xfail` count;
 - otherwise the case must `pass` (a valid vector's root matched, or an invalid
   vector was rejected by `assert`).
 
 As Phase 2 fills the `todo` stubs, the `xfail`s turn into passes with no test
-change.
+change. The `skip`s stay skipped, they are out of scope by design.
 """
 
 import pytest
@@ -26,6 +29,8 @@ def test_case(case, server, tmp_path):
     result = server.submit(request)
     if result.bucket == "bug":
         pytest.fail(f"{case.case_id}: bug-smell — {result.detail}")
+    if not result.passed and result.bucket == "skip":
+        pytest.skip(f"out of scope (not modeled): {result.detail}")
     if not result.passed and result.bucket == "todo":
         pytest.xfail(f"unimplemented (Phase 2 work-queue): {result.detail}")
     assert result.passed, f"{case.case_id}: {result.bucket} — {result.detail}"


### PR DESCRIPTION
The pyspec harness reported every unimplemented branch as xfail, conflating two
kinds of case: genuine work-queue items we intend to fill, and branches we
deliberately do not model (the genesis runner, ssz_static types owned elsewhere
or not needed). The out-of-scope cases inflated the xfail count and hid how much
real work remained.

## Change

Split the single `todo`→xfail path into two reject kinds:

- `todo`: an unimplemented branch we intend to fill. Reported `xfail` (work-queue), unchanged.
- `outOfScope`: a branch we deliberately do not model. Reported `skip`; not counted as work.

**Framework (EthCLLib)**
- `Errors.lean`: add an `outOfScope` constructor to both spec error types; split the classify bucket into `todo` (tag `todo`) and a genuine `outOfScope` (tag `skip`); extend `SpecReject` and both `classify` functions.
- `Assert.lean`: add the `outOfScope` throw helper alongside `todo`.
- `Driver.lean`: route `todo` and `outOfScope` classify results to their own buckets.

**Specs (EthCLSpecs)**
- Flip genuinely out-of-scope `.todo` sites to `.outOfScope`: unmodeled `ssz_static` types (both forks), `runGenesis` (both forks), Fulu `runUpgrade` / `runTransition` (need an Electra parent fork never built).
- Keep `.todo` for real work-queue items: EIP-8282 builder deposit/exit, the operations handlers that surface it, and the fork-choice `unsupported` step.
- `Server.lean`: emit the `skip` wire tag for `outOfScope` on the ssz_static and fork-choice paths.
- `WalkingSkeleton.lean`: the genesis guard now expects `outOfScope`.

**Harness**
- `test_pyspec.py`: map the `skip` bucket to `pytest.skip`.

## Result (smoke subset)

Was: gloas 195p / 57xf, fulu 152p / 44xf.

- gloas: 195 passed, 52 skipped, 5 xfailed (the 5 are all EIP-8282)
- fulu: 152 passed, 44 skipped, 0 xfailed