### PR TITLE
feat(ethclspecs): implement Gloas EIP-8282 builder-request processing

### DIFF
--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -170,6 +170,7 @@ inductive OpKind where
   | voluntaryExitChurn | blsToExecutionChange | depositRequest | withdrawalRequest
   | consolidationRequest | blockHeader | syncAggregate | withdrawals | executionPayload
   | payloadAttestation | executionPayloadBid | parentExecutionPayload
+  | builderDepositRequest | builderExitRequest
   deriving DecidableEq, Repr, Inhabited
 
 /-- Parse a pyspec `operations/<handler>` directory name to its `OpKind`. The single site
@@ -193,6 +194,8 @@ def OpKind.ofString? : String → Option OpKind
   | "payload_attestation"      => some .payloadAttestation
   | "execution_payload_bid"    => some .executionPayloadBid
   | "parent_execution_payload" => some .parentExecutionPayload
+  | "builder_deposit_request"  => some .builderDepositRequest
+  | "builder_exit_request"     => some .builderExitRequest
   | _                          => none
 
 /-- The `epoch_processing/<handler>` axis as a typed tag, one constructor per pyspec

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -145,8 +145,9 @@ private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
     | .executionPayload      => (decodeOp (@BeaconBlockBody P) opBytes).map (fun body => do
         assert cmeta.executionValid
         processExecutionPayload body)
-    -- Gloas / EIP-7732-only operation handlers; not standalone Fulu operations.
-    | .voluntaryExitChurn | .payloadAttestation | .executionPayloadBid | .parentExecutionPayload =>
+    -- Gloas / EIP-7732 / EIP-8282-only operation handlers; not standalone Fulu operations.
+    | .voluntaryExitChurn | .payloadAttestation | .executionPayloadBid | .parentExecutionPayload
+    | .builderDepositRequest | .builderExitRequest =>
         .error (.spec (.todo s!"operations/{reprStr kind}: not a standalone Fulu operation"))
   match dispatch with
   | .error e     => .error e

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -136,7 +136,8 @@ pre-state. The non-ePBS handlers are inherited from Fulu (`Gloas.Operations`); t
 ePBS-modified / ePBS-new ones are Gloas-specific: `proposer_slashing` (builder-payment
 cleanup), payload-aware `attestation`, `payload_attestation`, the builder-aware
 `withdrawals`, `execution_payload_bid`, `parent_execution_payload`, `block_header`,
-and the builder-branch `voluntary_exit` / `deposit_request`. -/
+the EIP-8282 `builder_deposit_request` / `builder_exit_request`, and the builder-branch
+`voluntary_exit` / `deposit_request`. -/
 private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
     (preBytes opBytes : ByteArray) (cmeta : CaseMeta) : Except (RunError StateTransitionError) ByteArray := do
   let box0 ← decodeState P preBytes
@@ -165,6 +166,8 @@ private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
     | .depositRequest         => (decodeOp (@DepositRequest P) opBytes).map processDepositRequest
     | .withdrawalRequest      => (decodeOp (@WithdrawalRequest P) opBytes).map processWithdrawalRequest
     | .consolidationRequest   => (decodeOp (@ConsolidationRequest P) opBytes).map processConsolidationRequest
+    | .builderDepositRequest  => (decodeOp (@Gloas.BuilderDepositRequest P) opBytes).map processBuilderDepositRequest
+    | .builderExitRequest     => (decodeOp (@Gloas.BuilderExitRequest P) opBytes).map processBuilderExitRequest
     | .syncAggregate          => (decodeOp (@SyncAggregate P) opBytes).map processSyncAggregate
     -- Handlers EIP-7732 does not drive as standalone Gloas operations.
     | .deposit | .executionPayload =>

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
@@ -84,9 +84,9 @@ state's queue (`process_deposit_request`) or an in-progress accumulator
 forkdef isPendingValidator (pendingDeposits : Array PendingDeposit) (pubkey : BLSPubkey) : Bool :=
   pendingDeposits.any fun d =>
     d.pubkey == pubkey && isValidDepositSignature d.pubkey d.withdrawalCredentials d.amount d.signature
-/-- `initiate_builder_exit`. Retained for the deferred EIP-8282
+/-- `initiate_builder_exit`. The EL-triggered builder exit, called by
 `process_builder_exit_request` (alpha.11 moved builder exits off `process_voluntary_exit`
-to this EL-triggered path); not yet wired, so it currently has no caller. -/
+to this path). -/
 forkdef initiateBuilderExit (builderIndex : BuilderIndex) : StateTransition Unit := do
   let epoch := currentEpochOf (← get)
   modifyState fun state =>
@@ -150,6 +150,60 @@ forkdef onboardBuildersFromPendingDeposits : StateTransition Unit := do
       applyDepositForBuilder d.pubkey d.withdrawalCredentials d.amount d.signature d.slot
 
   modifyState fun state => sszUpdate state with pendingDeposits := sszOfArray kept
+
+/-! ## EIP-8282 builder-request handlers
+
+The EL-triggered builder onboarding / exit path (alpha.11). `apply_parent_execution_payload`
+runs these over the parent payload's `ExecutionRequests.builder_deposits` /
+`builder_exits` lists, after the validator deposit / withdrawal / consolidation requests. -/
+
+/-- `is_valid_builder_deposit_signature`: the builder-deposit proof-of-possession.
+Like `is_valid_deposit_signature`, the domain is fixed (`compute_domain(DOMAIN_BUILDER_DEPOSIT)`
+over the genesis fork version and a zero `genesis_validators_root`), so verification is a
+single BLS gate through the `[CryptoBackend]` seam. -/
+forkdef isValidBuilderDepositSignature (request : BuilderDepositRequest) : Bool :=
+  let msg : DepositMessage :=
+    { pubkey := request.pubkey, withdrawalCredentials := request.withdrawalCredentials, amount := request.amount }
+  let domain := computeDomain Const.domainBuilderDeposit Const.genesisForkVersion (Vector.replicate 32 0)
+  blsVerify request.pubkey (computeSigningRoot msg domain) request.signature
+
+/-- `process_builder_deposit_request` (EIP-8282): for a new builder pubkey with a valid
+proof-of-possession, onboard it (the `version` byte and execution address come from the
+withdrawal credentials, stamped at `state.slot`); for an existing builder, top up its
+balance and, if it had already initiated exit, push its withdrawable epoch back out. -/
+forkdef processBuilderDepositRequest (request : BuilderDepositRequest) : StateTransition Unit := do
+  let state ← get
+  match (sszGet state builders).findIdx? (·.pubkey == request.pubkey) with
+  | none =>
+    if isValidBuilderDepositSignature request then
+      addBuilderToRegistry request.pubkey (credPrefix request.withdrawalCredentials)
+        (addressOfCred request.withdrawalCredentials) request.amount (sszGet state slot)
+  | some builderIndex =>
+    let epoch := currentEpochOf state
+    modifyState fun state =>
+      sszModify state builders[builderIndex]! as b =>
+        { b with
+          balance := b.balance + request.amount,
+          withdrawableEpoch :=
+            if b.withdrawableEpoch != Const.farFutureEpoch
+            then epoch + Const.minBuilderWithdrawabilityDelay
+            else b.withdrawableEpoch }
+
+/-- `process_builder_exit_request` (EIP-8282): an EL-triggered builder exit. A no-op
+unless the pubkey names an active builder whose registered execution address matches the
+request's `source_address` and that has no pending balance to withdraw; otherwise it
+initiates the builder's exit. -/
+forkdef processBuilderExitRequest (request : BuilderExitRequest) : StateTransition Unit := do
+  let state ← get
+  match (sszGet state builders).findIdx? (·.pubkey == request.pubkey) with
+  | none => pure ()
+  | some idx =>
+    let builderIndex : BuilderIndex := UInt64.ofNat idx
+    let builder := sszGet state builders[idx]!
+    if isActiveBuilder state builderIndex
+        && builder.executionAddress == request.sourceAddress
+        && getPendingBalanceToWithdrawForBuilder state builderIndex == 0 then
+      initiateBuilderExit builderIndex
 
 /-! ## Gloas-modified operations -/
 
@@ -441,10 +495,8 @@ forkdef applyParentExecutionPayload (requests : ExecutionRequests) : StateTransi
   for d in requests.deposits do processDepositRequest d
   for w in requests.withdrawals do processWithdrawalRequest w
   for c in requests.consolidations do processConsolidationRequest c
-  -- Deferred: EIP-8282 builder-deposit / builder-exit request processing is not yet
-  -- ported; a non-empty list xfails the runner (todo) rather than diverging the root.
-  unless requests.builderDeposits.size == 0 && requests.builderExits.size == 0 do
-    throw (StateTransitionError.todo "gloas builder_deposit/builder_exit processing: EIP-8282 not yet ported")
+  for bd in requests.builderDeposits do processBuilderDepositRequest bd
+  for be in requests.builderExits do processBuilderExitRequest be
 
   -- Settle the parent's payment if it is still in the two-epoch window; outside it,
   -- queue any remaining value directly as a builder withdrawal.


### PR DESCRIPTION
## What

`apply_parent_execution_payload` in `Gloas/Operations.lean` deferred the EIP-8282 builder-deposit / builder-exit request lists with a `.todo`. This ports both handlers against the pinned `v1.7.0-alpha.11` consensus-specs.

## Changes

New handlers in `Gloas/Operations.lean`:

- **`isValidBuilderDepositSignature`** — the builder-deposit proof-of-possession, a single BLS gate over `compute_domain(DOMAIN_BUILDER_DEPOSIT)` (genesis fork version, zero `genesis_validators_root`), modeled on the existing `isValidDepositSignature`.
- **`processBuilderDepositRequest`** — for a new builder pubkey with a valid PoP, onboards it (`version` byte and execution address taken from the withdrawal credentials, stamped at `state.slot`); for an existing builder, tops up its balance and refreshes its withdrawable epoch if it had already initiated exit. A bad signature for a new pubkey is a silent no-op, matching the spec (there is no `assert`).
- **`processBuilderExitRequest`** — the EL-triggered exit, a no-op unless the pubkey names an active builder whose registered execution address matches the request's `source_address` and that has no pending balance to withdraw.

All supporting helpers (`addBuilderToRegistry`, `getPendingBalanceToWithdrawForBuilder`, `isActiveBuilder`, `initiateBuilderExit`, `addressOfCred`, `credPrefix`) already existed and matched alpha.11.

Wiring:

- Replaced the `.todo` throw in `apply_parent_execution_payload` with the two request loops, in spec order (after deposits / withdrawals / consolidations).
- alpha.11 also ships **standalone** `builder_deposit_request` / `builder_exit_request` operation vectors. Added two `OpKind` constructors and their `ofString?` mappings (`EthCLLib`), routed them in the Gloas operation dispatch, and added the Fulu deferral arm to keep the exhaustive match compiling.

## Testing

Conformance (`gloas`, `subset=0`):

- **minimal:** 42 passed (builder_deposit_request + builder_exit_request + parent_execution_payload), 0 xfailed.
- **mainnet:** 30 passed (the two builder operation suites), 0 xfailed.

The 29 cases that previously xfailed with `StateTransitionError.todo "...no fork drives this handler"` now all pass, covering new-builder, slot-recycling, top-up, withdrawable-epoch refresh, invalid-signature, and every exit guard branch. CI smoke gate green for both forks.