### PR TITLE
feat(sizzlean): close the bitvector/bitlist arms of the central theorems

### DIFF
--- a/packages/SizzLean/README.md
+++ b/packages/SizzLean/README.md
@@ -59,11 +59,10 @@ theorems.
 - **Machine-checked correctness across most of SSZ.** The three
   central theorems, encode/decode roundtrip, non-malleability,
   and a schema-derived static size bound, are proved for every
-  SSZ shape *except* the bit-level types and variable-field
-  containers: `uintN 8 / 16 / 32 / 64`, `bool`, fixed-size
-  `vector` and `list`, and `container` over fixed-size fields
-  (recursively). Bit-level types (`bitvector`, `bitlist`) and
-  mixed-field containers are pending, see
+  SSZ shape *except* variable-field containers:
+  `uintN 8 / 16 / 32 / 64`, `bool`, fixed-size `vector` and
+  `list`, `bitvector`, `bitlist`, and `container` over fixed-size
+  fields (recursively). Mixed-field containers are pending, see
   [Proof coverage](#proof-coverage) for the per-constructor
   table.
 
@@ -199,8 +198,8 @@ Per-constructor breakdown:
 | `.bool` | ✅ | ✅ | ✅ | exhaustive `cases` + `rfl` |
 | `.vector t n` | ✅ ² | ✅ ² | ✅ ² | needs `0 < n` + `BasicSupported t` + `t.isFixedSize = true` |
 | `.list t cap` | ✅ ³ | ✅ ³ | ✅ ³ | needs `BasicSupported t` + `t.isFixedSize = true` + `0 < t.fixedByteSize` |
-| `.bitvector n` | ❌ | ❌ | ❌ | bit-packing inverse (`packBitsLE` / `unpackBitsLEAux`) not yet shipped |
-| `.bitlist cap` | ❌ | ❌ | ❌ | needs bit-packing inverse + `msbPos` delimiter recovery |
+| `.bitvector n` | ✅ ⁴ | ✅ ⁴ | ✅ | needs `0 < n`; bit-packing inverse in `Proofs/BitPack.lean` |
+| `.bitlist cap` | ✅ ⁴ | ✅ ⁴ | ✅ | bit-packing inverse + `msbPos` delimiter recovery |
 | `.container fs` | see below | see below | see below | — |
 
 ¹ Adds one `_native.bv_decide.ax_*` axiom per arm (SAT certificate
@@ -213,6 +212,9 @@ none.
 the mutual `decode_encode` ↔ `decode_encode_containerFixed_aux`
 block.
 ³ Same recursion shape as `.vector`.
+⁴ Byte-level bit identities close by kernel `decide` over the
+finite chunk shapes (`Proofs/BitPack.lean`), so the bit arms add
+no axioms beyond the standard kernel three.
 
 `serialize_injective` is a direct corollary of `decode_encode`
 (via `Except.ok.inj` + `Prod.mk.inj`), so its coverage tracks
@@ -230,7 +232,7 @@ Allowed and excluded field types:
 | `.bool` | ✅ | basic + fixed |
 | `.vector t' n` (with `n > 0`, fixed-size `t'`, `BasicSupported t'`) | ✅ | nested vector, `(.vector t' n).isFixedSize = t'.isFixedSize` |
 | `.container fs'` (with `BasicSupportedFieldsFixed fs'`) | ✅ | nested container, `(.container fs').isFixedSize = allFixedSize fs'` |
-| `.bitvector n` | ❌ | not in `BasicSupported` yet (would qualify once the bitvector arm lands, it *is* fixed-size) |
+| `.bitvector n` (with `n > 0`) | ✅ | bit-packed + fixed, `(.bitvector n).fixedByteSize = ⌈n/8⌉` |
 | `.list t' cap` | ❌ | `(.list _ _).isFixedSize = false`, structurally excluded |
 | `.bitlist cap` | ❌ | `(.bitlist _).isFixedSize = false`, structurally excluded |
 
@@ -245,22 +247,21 @@ requires extending `Supported` with a `containerVar` constructor
 plus an offset-table-invariants proof.
 
 In one line: containers with fields drawn from `{uintN8, uintN16,
-uintN32, uintN64, bool, vectorFixed, containerFixed (recursively)}`
-are proved; containers with any `bitvector`, `list`, or `bitlist`
-field are not.
+uintN32, uintN64, bool, vectorFixed, bitvector,
+containerFixed (recursively)}` are proved; containers with any
+`list` or `bitlist` field are not.
 
 ### Track in progress
 
 **Phase 5 formal-verification widening:** the three central
 theorems (roundtrip, non-malleability, size bound) are landed on
 the `BasicSupported` cut, which now covers `uintN 8 / 16 / 32 /
-64`, `bool`, fixed-size `vector` and `list`, and `container` over
-fixed-size fields (recursively). Widening to a universal statement
-over `SSZType.Supported` requires closing the remaining
-`bitvector` and `bitlist` arms (bit-packing inverse), plus
-extending `Supported` itself to admit mixed-field containers
-(spec-layer follow-up). The library itself is complete; this
-track only closes the proof obligation.
+64`, `bool`, fixed-size `vector` and `list`, `bitvector`,
+`bitlist`, and `container` over fixed-size fields (recursively).
+Widening to a universal statement over `SSZType.Supported`
+requires extending `Supported` itself to admit mixed-field
+containers (spec-layer follow-up). The library itself is
+complete; this track only closes the proof obligation.
 
 See [`docs/PLAN.md`](docs/PLAN.md) for the staged plan and
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the design

--- a/packages/SizzLean/SizzLean/Proofs/BitPack.lean
+++ b/packages/SizzLean/SizzLean/Proofs/BitPack.lean
@@ -1,0 +1,564 @@
+import SizzLean.Spec.Supported
+import SizzLean.Spec.BasicSupported
+import SizzLean.Spec.MaxByteLength
+import SizzLean.Proofs.SimpAttrs
+
+/-!
+# `SizzLean.Proofs.BitPack`: the bit-packing inverse and the bit-shape arms
+
+Proves that LSB-first bit packing (`Spec/Serialize.lean`) and
+unpacking (`Spec/Deserialize.lean`) are mutual inverses, then
+closes `decode_encode` and `encode_size_le_max` for the
+`.bitvector n` and `.bitlist cap` arms. This is the file that
+`Serialize.lean:211` and `Deserialize.lean:169` promised when they
+made `bitsToByte`, `packBitsLE`, `byteToBits`, and
+`unpackBitsLEAux` public.
+
+## Lemma path
+
+1. **Single-byte inverse** (`byteToBits_bitsToByte`): reading the
+   8 LSB-first bits of a packed byte returns the packed chunk plus
+   zero padding. Bit-level facts about one byte are finite, so the
+   whole family closes by `decide` after case analysis on the
+   chunk shape: `bitsToByte_shiftRight_length` (bits at or above
+   the chunk length are unset) and `msbPos_bitsToByte_append_true`
+   (a trailing `true` bit is the most significant set bit) follow
+   the same recipe.
+2. **Byte-stream lift** (`packBitsLE_unpackBitsLEAux_inverse`):
+   the single-byte inverse lifted over `packBitsLE`'s
+   8-bits-per-byte recursion, with the padding characterised as
+   `List.replicate _ false` so consumers can strip it with
+   `List.take_left'`. Companions: `size_packBitsLE` (exact output
+   size) and `packBitsLE_last_byte` (the final byte is the packed
+   final chunk, which the decoders' padding / delimiter checks
+   inspect).
+3. **Numeric bridge** (`bitsToNat_range_testBit`): the decoder
+   rebuilds a `BitVec` by folding unpacked bits into a `Nat`;
+   this identifies that fold with `Nat.testBit`, so
+   `BitVec.ofNat_toNat` closes the value roundtrip.
+4. **Arm closure**: `decode_encode_bitvector`,
+   `decode_encode_bitlist`, and the two `encode_size_le_max_*`
+   bounds, walking the decoders' guard branches with the
+   lemmas above. `Proofs/Roundtrip.lean` and `Proofs/SizeBound.lean`
+   dispatch to these.
+
+## Proof style notes
+
+* The list matches enumerate chunk shapes of length 0 through 7
+  plus the 8-cons shape, mirroring `packBitsLE`'s own match
+  structure, so each equation of the spec function applies
+  directly and the recursive arm descends on a strict subterm
+  (`rest`), which the structural checker accepts.
+* `revert … ; decide`: `decide` needs a closed decidable
+  proposition; reverting the pattern-bound `Bool` variables turns
+  the per-shape goal into `∀ (b₀ … : Bool), …`, a finite
+  conjunction the kernel evaluates. No `native_decide`, so no
+  compiler axiom enters the proof path (per CLAUDE.md's tactic
+  guidance for non-hash decidable goals).
+* `ByteArray.get!` (used by `unpackBitsLEAux`) and the
+  bounds-checked `b[i]'h` (used by the decoders) are bridged once
+  in `get!_eq_getElem`; everything downstream works with the
+  total `get!` form.
+-/
+
+set_option autoImplicit false
+-- The `decide` families below evaluate up to 2⁸ byte-level cases
+-- per shape; give the elaborator room.
+set_option maxHeartbeats 10000000
+
+namespace SizzLean.Proofs
+
+open SizzLean.Spec
+
+/-! ### ByteArray indexing bridges -/
+
+/-- `get!` agrees with the bounds-checked `b[i]` when in range.
+`get!` unfolds to `b.data[i]!`, whose panicking branch is
+irrelevant here; `getElem!_pos` (core) discharges it against the
+supplied bound. -/
+theorem get!_eq_getElem (b : ByteArray) (i : Nat) (h : i < b.size) :
+    b.get! i = b[i] := by
+  show b.data[i]! = b[i]
+  rw [ByteArray.getElem_eq_getElem_data]
+  exact getElem!_pos b.data i h
+
+/-- Reading index 0 of a single-byte array returns that byte. -/
+theorem get!_push_zero (x : UInt8) : (ByteArray.empty.push x).get! 0 = x := by
+  rw [get!_eq_getElem _ _ (by simp [ByteArray.size_push, ByteArray.size_empty])]
+  rfl
+
+/-! ### Single-byte inverses (the `decide` family)
+
+Every lemma in this section quantifies over one packed chunk of
+at most 8 booleans, a finite domain the kernel can enumerate. -/
+
+/-- Unpacking a packed chunk of at most 8 bits returns the chunk,
+zero-padded to the full byte width. The padding is `false` bits
+because `bitsToByte` never sets a position at or beyond the chunk
+length. -/
+theorem byteToBits_bitsToByte : ∀ (bs : List Bool), bs.length ≤ 8 →
+    byteToBits (bitsToByte bs 0 0) = bs ++ List.replicate (8 - bs.length) false
+  | [], _ => by decide
+  | [b0], _ => by revert b0; decide
+  | [b0, b1], _ => by revert b0 b1; decide
+  | [b0, b1, b2], _ => by revert b0 b1 b2; decide
+  | [b0, b1, b2, b3], _ => by revert b0 b1 b2 b3; decide
+  | [b0, b1, b2, b3, b4], _ => by revert b0 b1 b2 b3 b4; decide
+  | [b0, b1, b2, b3, b4, b5], _ => by revert b0 b1 b2 b3 b4 b5; decide
+  | [b0, b1, b2, b3, b4, b5, b6], _ => by revert b0 b1 b2 b3 b4 b5 b6; decide
+  | [b0, b1, b2, b3, b4, b5, b6, b7], _ => by
+      revert b0 b1 b2 b3 b4 b5 b6 b7; decide
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: rest, h => by
+      simp only [List.length_cons] at h
+      omega
+
+/-- Exact-width corollary of `byteToBits_bitsToByte`: a full
+8-bit chunk roundtrips with no padding. Kept as its own `decide`
+so the 8-cons arm of the stream lift can cite it without
+`List.append_nil` cleanup. -/
+theorem byteToBits_bitsToByte_eight (b0 b1 b2 b3 b4 b5 b6 b7 : Bool) :
+    byteToBits (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0) =
+      [b0, b1, b2, b3, b4, b5, b6, b7] := by
+  revert b0 b1 b2 b3 b4 b5 b6 b7; decide
+
+/-- Bits at or above the chunk length are unset: shifting the
+packed byte right by the chunk length yields zero. This is the
+fact behind the bitvector decoder's zero-padding validation.
+Restricted to `length < 8` because a `UInt8` shift by 8 wraps to
+a shift by 0. -/
+theorem bitsToByte_shiftRight_length : ∀ (bs : List Bool), bs.length < 8 →
+    bitsToByte bs 0 0 >>> Nat.toUInt8 bs.length = 0
+  | [], _ => by decide
+  | [b0], _ => by revert b0; decide
+  | [b0, b1], _ => by revert b0 b1; decide
+  | [b0, b1, b2], _ => by revert b0 b1 b2; decide
+  | [b0, b1, b2, b3], _ => by revert b0 b1 b2 b3; decide
+  | [b0, b1, b2, b3, b4], _ => by revert b0 b1 b2 b3 b4; decide
+  | [b0, b1, b2, b3, b4, b5], _ => by revert b0 b1 b2 b3 b4 b5; decide
+  | [b0, b1, b2, b3, b4, b5, b6], _ => by revert b0 b1 b2 b3 b4 b5 b6; decide
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest, h => by
+      simp only [List.length_cons] at h
+      omega
+
+/-- A packed chunk ending in a `true` bit has its most significant
+set bit exactly at the chunk's data length. This is the bitlist
+delimiter-recovery fact: `msbPos` on the final byte finds the
+delimiter, whatever the data bits below it are. -/
+theorem msbPos_bitsToByte_append_true : ∀ (bs : List Bool), bs.length ≤ 7 →
+    msbPos (bitsToByte (bs ++ [true]) 0 0) = some bs.length
+  | [], _ => by decide
+  | [b0], _ => by revert b0; decide
+  | [b0, b1], _ => by revert b0 b1; decide
+  | [b0, b1, b2], _ => by revert b0 b1 b2; decide
+  | [b0, b1, b2, b3], _ => by revert b0 b1 b2 b3; decide
+  | [b0, b1, b2, b3, b4], _ => by revert b0 b1 b2 b3 b4; decide
+  | [b0, b1, b2, b3, b4, b5], _ => by revert b0 b1 b2 b3 b4 b5; decide
+  | [b0, b1, b2, b3, b4, b5, b6], _ => by revert b0 b1 b2 b3 b4 b5 b6; decide
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest, h => by
+      simp only [List.length_cons] at h
+      omega
+
+/-! ### The byte-stream lift -/
+
+/-- `packBitsLE` emits exactly `⌈length/8⌉` bytes. The match
+enumerates the same shapes as `packBitsLE` itself so each spec
+equation applies directly; the 8-cons arm recurses on `rest`. -/
+theorem size_packBitsLE : ∀ (bs : List Bool),
+    (packBitsLE bs).size = (bs.length + 7) / 8
+  | [] => by simp [packBitsLE]
+  | [b0] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1, b2] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1, b2, b3] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1, b2, b3, b4] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1, b2, b3, b4, b5] => by simp [packBitsLE, ByteArray.size_push]
+  | [b0, b1, b2, b3, b4, b5, b6] => by simp [packBitsLE, ByteArray.size_push]
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest => by
+      have ih := size_packBitsLE rest
+      simp only [packBitsLE, List.length_cons]
+      rw [ByteArray.size_append, ByteArray.size_push, ByteArray.size_empty, ih]
+      omega
+
+/-- Unpacking one pushed byte reads it back through `byteToBits`. -/
+theorem unpackBitsLEAux_single (byte : UInt8) :
+    unpackBitsLEAux (ByteArray.empty.push byte) 1 0 = byteToBits byte := by
+  simp only [unpackBitsLEAux, get!_push_zero, List.append_nil]
+
+/-- Unpacking is insensitive to an already-consumed prefix:
+reading `k` bytes of `a ++ b` starting at `a.size + off` reads
+them from `b` at `off`. The bound `off + k ≤ b.size` keeps every
+`get!` in range so the two sides read the same bytes. -/
+theorem unpackBitsLEAux_append_shift (a b : ByteArray) :
+    ∀ (k off : Nat), off + k ≤ b.size →
+      unpackBitsLEAux (a ++ b) k (a.size + off) = unpackBitsLEAux b k off
+  | 0, _, _ => by simp [unpackBitsLEAux]
+  | k + 1, off, h => by
+      have h_off : off < b.size := by omega
+      have h_tot : a.size + off < (a ++ b).size := by
+        rw [ByteArray.size_append]; omega
+      have h_byte : (a ++ b).get! (a.size + off) = b.get! off := by
+        rw [get!_eq_getElem _ _ h_tot, get!_eq_getElem _ _ h_off,
+            ByteArray.getElem_append_right (by omega)]
+        simp [Nat.add_sub_cancel_left]
+      have h_rec := unpackBitsLEAux_append_shift a b k (off + 1) (by omega)
+      simp only [unpackBitsLEAux, h_byte]
+      rw [show a.size + off + 1 = a.size + (off + 1) from Nat.add_assoc a.size off 1,
+          h_rec]
+
+/-- Shared closing step for the sub-byte shapes of the stream
+inverse: one packed byte, unpacked and identified with the chunk
+plus padding. -/
+private theorem unpack_pack_small (bs : List Bool) (h_le : bs.length ≤ 7)
+    (h_pack : packBitsLE bs = ByteArray.empty.push (bitsToByte bs 0 0)) :
+    unpackBitsLEAux (packBitsLE bs) ((bs.length + 7) / 8) 0 =
+      bs ++ List.replicate ((bs.length + 7) / 8 * 8 - bs.length) false := by
+  by_cases h_nil : bs = []
+  · subst h_nil
+    simp [packBitsLE, unpackBitsLEAux]
+  · have h_pos : 0 < bs.length := List.length_pos_iff.mpr h_nil
+    have h_count : (bs.length + 7) / 8 = 1 := by omega
+    rw [h_count, show 1 * 8 - bs.length = 8 - bs.length from by omega,
+        h_pack, unpackBitsLEAux_single, byteToBits_bitsToByte bs (by omega)]
+
+/-- **The core inverse** (issue #9, deliverable 1): unpacking
+`⌈length/8⌉` bytes of a packed bit list recovers the bits, plus
+`false` padding filling the final byte. Consumers strip the
+padding with `List.take_left'` since the data length is theirs to
+know (bitvector: the schema's `n`; bitlist: the recovered
+delimiter position). -/
+theorem packBitsLE_unpackBitsLEAux_inverse : ∀ (bs : List Bool),
+    unpackBitsLEAux (packBitsLE bs) ((bs.length + 7) / 8) 0 =
+      bs ++ List.replicate ((bs.length + 7) / 8 * 8 - bs.length) false
+  | [] => by simp [packBitsLE, unpackBitsLEAux]
+  | [b0] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1, b2] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1, b2, b3] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1, b2, b3, b4] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1, b2, b3, b4, b5] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | [b0, b1, b2, b3, b4, b5, b6] => unpack_pack_small _ (by simp) (by simp [packBitsLE])
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest => by
+      have ih := packBitsLE_unpackBitsLEAux_inverse rest
+      have h_size_rest := size_packBitsLE rest
+      have h_pack : packBitsLE (b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest) =
+          (ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+            packBitsLE rest := by
+        simp [packBitsLE]
+      have h_count :
+          ((b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest).length + 7) / 8 =
+            (rest.length + 7) / 8 + 1 := by
+        simp only [List.length_cons]; omega
+      rw [h_pack, h_count]
+      -- One step of `unpackBitsLEAux` (count matches the `k + 1` equation).
+      simp only [unpackBitsLEAux]
+      -- The first byte of the append is the packed head chunk.
+      have h_get :
+          ((ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+              packBitsLE rest).get! 0 =
+            bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0 := by
+        rw [get!_eq_getElem _ _
+              (by rw [ByteArray.size_append, ByteArray.size_push, ByteArray.size_empty]
+                  omega),
+            ByteArray.getElem_append_left
+              (by simp [ByteArray.size_push, ByteArray.size_empty])]
+        rfl
+      rw [h_get, byteToBits_bitsToByte_eight]
+      -- The remaining count reads entirely from `packBitsLE rest`;
+      -- shift the offset past the head byte and apply the IH.
+      have h_shift :
+          unpackBitsLEAux
+              ((ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+                packBitsLE rest)
+              ((rest.length + 7) / 8) (0 + 1) =
+            unpackBitsLEAux (packBitsLE rest) ((rest.length + 7) / 8) 0 := by
+        have h := unpackBitsLEAux_append_shift
+          (ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0))
+          (packBitsLE rest) ((rest.length + 7) / 8) 0 (by rw [h_size_rest]; omega)
+        simpa [ByteArray.size_push, ByteArray.size_empty] using h
+      rw [h_shift, ih]
+      -- Reconcile the cons chain and the two padding widths.
+      have h_pad : ((rest.length + 7) / 8 + 1) * 8 -
+            (b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest).length =
+          (rest.length + 7) / 8 * 8 - rest.length := by
+        simp only [List.length_cons]; omega
+      rw [h_pad]
+      simp [List.cons_append]
+
+/-- The final byte of a packed stream is the packed final chunk.
+The decoders inspect this byte: the bitvector decoder validates
+its padding bits, the bitlist decoder locates the delimiter in
+it. -/
+theorem packBitsLE_last_byte : ∀ (bs : List Bool), bs ≠ [] →
+    (packBitsLE bs).get! ((bs.length + 7) / 8 - 1) =
+      bitsToByte (bs.drop (8 * ((bs.length + 7) / 8 - 1))) 0 0
+  | [], h => absurd rfl h
+  | [b0], _ => by revert b0; decide
+  | [b0, b1], _ => by revert b0 b1; decide
+  | [b0, b1, b2], _ => by revert b0 b1 b2; decide
+  | [b0, b1, b2, b3], _ => by revert b0 b1 b2 b3; decide
+  | [b0, b1, b2, b3, b4], _ => by revert b0 b1 b2 b3 b4; decide
+  | [b0, b1, b2, b3, b4, b5], _ => by revert b0 b1 b2 b3 b4 b5; decide
+  | [b0, b1, b2, b3, b4, b5, b6], _ => by revert b0 b1 b2 b3 b4 b5 b6; decide
+  | b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest, _ => by
+      have h_pack : packBitsLE (b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest) =
+          (ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+            packBitsLE rest := by
+        simp [packBitsLE]
+      cases rest with
+      | nil =>
+          -- Exactly one full byte: index 0, the whole list is the chunk.
+          revert b0 b1 b2 b3 b4 b5 b6 b7; decide
+      | cons r rs =>
+          have ih := packBitsLE_last_byte (r :: rs) (by simp)
+          have h_size_rest := size_packBitsLE (r :: rs)
+          -- Index arithmetic: the head byte shifts everything by one.
+          have h_idx :
+              ((b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: r :: rs).length + 7) / 8 - 1 =
+                (((r :: rs).length + 7) / 8 - 1) + 1 := by
+            simp only [List.length_cons]; omega
+          have h_pos : 0 < ((r :: rs).length + 7) / 8 := by
+            simp only [List.length_cons]; omega
+          rw [h_pack, h_idx]
+          -- Reading past the singleton prefix lands in `packBitsLE (r :: rs)`.
+          have h_read :
+              ((ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+                  packBitsLE (r :: rs)).get! ((((r :: rs).length + 7) / 8 - 1) + 1) =
+                (packBitsLE (r :: rs)).get! (((r :: rs).length + 7) / 8 - 1) := by
+            have h_in : (((r :: rs).length + 7) / 8 - 1) + 1 <
+                ((ByteArray.empty.push (bitsToByte [b0, b1, b2, b3, b4, b5, b6, b7] 0 0)) ++
+                  packBitsLE (r :: rs)).size := by
+              rw [ByteArray.size_append, ByteArray.size_push, ByteArray.size_empty,
+                  h_size_rest]
+              omega
+            have h_in' : ((r :: rs).length + 7) / 8 - 1 < (packBitsLE (r :: rs)).size := by
+              rw [h_size_rest]; omega
+            rw [get!_eq_getElem _ _ h_in, get!_eq_getElem _ _ h_in',
+                ByteArray.getElem_append_right
+                  (by simp [ByteArray.size_push, ByteArray.size_empty])]
+            simp [ByteArray.size_push, ByteArray.size_empty]
+          rw [h_read, ih]
+          -- The dropped prefix on the right shrinks by the 8 head bits.
+          have h_drop :
+              (b0 :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: r :: rs).drop
+                  (8 * ((((r :: rs).length + 7) / 8 - 1) + 1)) =
+                (r :: rs).drop (8 * (((r :: rs).length + 7) / 8 - 1)) := by
+            rw [show 8 * ((((r :: rs).length + 7) / 8 - 1) + 1) =
+                  8 * (((r :: rs).length + 7) / 8 - 1) + 8 by omega]
+            rw [Nat.add_comm, ← List.drop_drop]
+            simp
+          rw [h_drop]
+
+/-! ### Bits-to-Nat bridge -/
+
+/-- The decoder's bit fold agrees with `Nat.testBit` sampling:
+folding the low `n` test bits of `m` rebuilds `m mod 2ⁿ`. The
+step case rewrites `List.range (n+1)` head-first
+(`List.range_succ_eq_map`) so the fold's LSB-first orientation
+lines up with `testBit`'s, then `Nat.mod_mul` splits the modulus
+`2·2ⁿ` into low bit plus shifted remainder. -/
+theorem bitsToNat_range_testBit : ∀ (n m : Nat),
+    bitsToNat ((List.range n).map (fun i => Nat.testBit m i)) = m % 2 ^ n
+  | 0, m => by simp [bitsToNat, Nat.mod_one]
+  | n + 1, m => by
+      rw [List.range_succ_eq_map]
+      have h_fun : ((fun i => Nat.testBit m i) ∘ Nat.succ) =
+          (fun i => Nat.testBit (m / 2) i) := by
+        funext i
+        simp [Function.comp, Nat.succ_eq_add_one, Nat.testBit_add_one]
+      simp only [List.map_cons, List.map_map, h_fun]
+      show (if Nat.testBit m 0 then 1 else 0) + 2 * _ = _
+      rw [bitsToNat_range_testBit n (m / 2),
+          Nat.pow_succ, Nat.mul_comm (2 ^ n) 2, Nat.mod_mul]
+      rcases Nat.mod_two_eq_zero_or_one m with h | h <;> simp [Nat.testBit_zero, h]
+
+/-- Specialisation to a bitvector's LSB-first bit samples:
+`BitVec.getLsbD` is `Nat.testBit` on `toNat` by definition, and
+`toNat < 2ⁿ` collapses the modulus. -/
+theorem bitsToNat_getLsbD_range (n : Nat) (bv : BitVec n) :
+    bitsToNat ((List.range n).map (fun i => bv.getLsbD i)) = bv.toNat := by
+  have h : (fun i => bv.getLsbD i) = (fun i => Nat.testBit bv.toNat i) := rfl
+  rw [h, bitsToNat_range_testBit, Nat.mod_eq_of_lt bv.isLt]
+
+/-! ### The bitvector arm -/
+
+/-- Exact serialized size of a bitvector: `⌈n/8⌉` bytes. Cited by
+the `bitvector` arm of `size_serialize_eq_fixedByteSize`
+(`Proofs/SerializeSize.lean`) since `.bitvector` is a fixed-size
+shape admissible inside vectors, lists, and containers. -/
+theorem size_serialize_bitvector (n : Nat) (bv : BitVec n) :
+    (SSZType.serialize (.bitvector n) bv).size = (n + 7) / 8 := by
+  unfold SSZType.serialize bitvecToBytes
+  rw [size_packBitsLE]
+  simp
+
+/-- Roundtrip for `.bitvector n`, `n > 0` (issue #9, deliverable
+2). The proof walks `deserializeBitvector`'s branches: the size
+check closes by `size_packBitsLE`; the zero-padding guard closes
+by `packBitsLE_last_byte` + `bitsToByte_shiftRight_length`; the
+value rebuild closes by the core inverse +
+`bitsToNat_getLsbD_range` + `BitVec.ofNat_toNat`. -/
+theorem decode_encode_bitvector (n : Nat) (h_pos : 0 < n) (bv : BitVec n) :
+    SSZType.deserialize (.bitvector n) (SSZType.serialize (.bitvector n) bv) =
+      .ok (bv, (SSZType.serialize (.bitvector n) bv).size) := by
+  -- Fix the encoder output and its size once.
+  have h_len : ((List.range n).map (fun i => bv.getLsbD i)).length = n := by simp
+  have h_ser : SSZType.serialize (.bitvector n) bv =
+      packBitsLE ((List.range n).map (fun i => bv.getLsbD i)) := by
+    unfold SSZType.serialize bitvecToBytes
+    rfl
+  have h_size : (packBitsLE ((List.range n).map (fun i => bv.getLsbD i))).size =
+      (n + 7) / 8 := by
+    rw [size_packBitsLE, h_len]
+  -- The decoded bit prefix is exactly the encoder's input bits.
+  have h_take : (unpackBitsLEAux (packBitsLE ((List.range n).map (fun i => bv.getLsbD i)))
+        ((n + 7) / 8) 0).take n =
+      (List.range n).map (fun i => bv.getLsbD i) := by
+    have h_inv := packBitsLE_unpackBitsLEAux_inverse
+      ((List.range n).map (fun i => bv.getLsbD i))
+    rw [h_len] at h_inv
+    rw [h_inv, List.take_left' h_len]
+  have h_val : BitVec.ofNat n (bitsToNat ((List.range n).map (fun i => bv.getLsbD i))) =
+      bv := by
+    rw [bitsToNat_getLsbD_range, BitVec.ofNat_toNat, BitVec.setWidth_eq]
+  rw [h_ser, h_size]
+  unfold SSZType.deserialize
+  rw [deserializeBitvector, dif_neg (by omega : ¬ n = 0), dif_pos h_size]
+  by_cases h_u : (n + 7) / 8 * 8 - n > 0
+  · -- Partial final byte: the zero-padding guard runs. Identify the
+    -- last byte with the packed final chunk, whose high bits are unset.
+    rw [if_pos h_u]
+    have h_ne : (List.range n).map (fun i => bv.getLsbD i) ≠ [] := by
+      intro h_con
+      have := congrArg List.length h_con
+      rw [h_len] at this
+      simp at this
+      omega
+    have h_last := packBitsLE_last_byte _ h_ne
+    rw [h_len] at h_last
+    have h_chunk_len :
+        (((List.range n).map (fun i => bv.getLsbD i)).drop (8 * ((n + 7) / 8 - 1))).length =
+          n - 8 * ((n + 7) / 8 - 1) := by
+      rw [List.length_drop, h_len]
+    -- The guard's shift amount is the final chunk's length.
+    have h_shift0 :
+        bitsToByte (((List.range n).map (fun i => bv.getLsbD i)).drop
+            (8 * ((n + 7) / 8 - 1))) 0 0 >>>
+          Nat.toUInt8 (8 - ((n + 7) / 8 * 8 - n)) = 0 := by
+      rw [show 8 - ((n + 7) / 8 * 8 - n) =
+            (((List.range n).map (fun i => bv.getLsbD i)).drop
+              (8 * ((n + 7) / 8 - 1))).length by rw [h_chunk_len]; omega]
+      exact bitsToByte_shiftRight_length _ (by rw [h_chunk_len]; omega)
+    -- Convert the goal's bounds-checked read into `get!` form and rewrite.
+    have h_lastByte : ∀ (hlt : (packBitsLE ((List.range n).map (fun i => bv.getLsbD i))).size - 1 <
+          (packBitsLE ((List.range n).map (fun i => bv.getLsbD i))).size),
+        (packBitsLE ((List.range n).map (fun i => bv.getLsbD i)))[
+            (packBitsLE ((List.range n).map (fun i => bv.getLsbD i))).size - 1]'hlt =
+          bitsToByte (((List.range n).map (fun i => bv.getLsbD i)).drop
+            (8 * ((n + 7) / 8 - 1))) 0 0 := by
+      intro hlt
+      rw [← get!_eq_getElem _ _ hlt, h_size]
+      exact h_last
+    simp only [h_lastByte, h_shift0]
+    simp only [ne_eq, UInt8.zero_and, not_true_eq_false, ite_false]
+    simp only [h_take, h_val]
+  · -- The bit width fills its bytes exactly: no guard.
+    rw [if_neg h_u]
+    simp only [h_take, h_val]
+
+/-! ### The bitlist arm -/
+
+/-- Roundtrip for `.bitlist cap` (issue #9, deliverable 3). The
+encoder appends the delimiter bit and packs;
+`msbPos_bitsToByte_append_true` recovers its position from the
+final byte, which pins the decoded data length to the original
+`size`, and the core inverse returns the data bits. -/
+theorem decode_encode_bitlist (cap : Nat) (xs : { bs : Array Bool // bs.size ≤ cap }) :
+    SSZType.deserialize (.bitlist cap) (SSZType.serialize (.bitlist cap) xs) =
+      .ok (xs, (SSZType.serialize (.bitlist cap) xs).size) := by
+  have h_len : xs.val.toList.length = xs.val.size := Array.length_toList
+  have h_ser : SSZType.serialize (.bitlist cap) xs =
+      packBitsLE (xs.val.toList ++ [true]) := by
+    unfold SSZType.serialize bitlistToBytes
+    rfl
+  have h_bits_len : (xs.val.toList ++ [true]).length = xs.val.size + 1 := by
+    simp [h_len]
+  have h_size : (packBitsLE (xs.val.toList ++ [true])).size = (xs.val.size + 8) / 8 := by
+    rw [size_packBitsLE, h_bits_len]
+  have h_size_pos : 0 < (xs.val.size + 8) / 8 := by omega
+  rw [h_ser, h_size]
+  unfold SSZType.deserialize
+  rw [deserializeBitlist, dif_neg (by rw [h_size]; omega)]
+  -- Identify the final byte: the packed final data chunk plus the
+  -- delimiter bit.
+  have h_ne : xs.val.toList ++ [true] ≠ [] := by simp
+  have h_last := packBitsLE_last_byte _ h_ne
+  rw [h_bits_len] at h_last
+  have h_prefix_le : 8 * ((xs.val.size + 1 + 7) / 8 - 1) ≤ xs.val.toList.length := by
+    rw [h_len]; omega
+  have h_drop : (xs.val.toList ++ [true]).drop (8 * ((xs.val.size + 1 + 7) / 8 - 1)) =
+      xs.val.toList.drop (8 * ((xs.val.size + 1 + 7) / 8 - 1)) ++ [true] :=
+    List.drop_append_of_le_length h_prefix_le
+  rw [h_drop] at h_last
+  have h_chunk_len : (xs.val.toList.drop (8 * ((xs.val.size + 1 + 7) / 8 - 1))).length =
+      xs.val.size % 8 := by
+    rw [List.length_drop, h_len]; omega
+  have h_msb := msbPos_bitsToByte_append_true
+    (xs.val.toList.drop (8 * ((xs.val.size + 1 + 7) / 8 - 1)))
+    (by rw [h_chunk_len]; omega)
+  rw [h_chunk_len] at h_msb
+  -- Read the goal's bounds-checked last byte through `get!`.
+  have h_lastByte : ∀ (hlt : (packBitsLE (xs.val.toList ++ [true])).size - 1 <
+        (packBitsLE (xs.val.toList ++ [true])).size),
+      (packBitsLE (xs.val.toList ++ [true]))[
+          (packBitsLE (xs.val.toList ++ [true])).size - 1]'hlt =
+        bitsToByte (xs.val.toList.drop (8 * ((xs.val.size + 1 + 7) / 8 - 1)) ++ [true]) 0 0 := by
+    intro hlt
+    rw [← get!_eq_getElem _ _ hlt, h_size,
+        show (xs.val.size + 8) / 8 - 1 = (xs.val.size + 1 + 7) / 8 - 1 by omega]
+    exact h_last
+  simp only [h_lastByte, h_msb]
+  -- The recovered total bit count is the original data length.
+  have h_total : ((packBitsLE (xs.val.toList ++ [true])).size - 1) * 8 + xs.val.size % 8 =
+      xs.val.size := by
+    rw [h_size]; omega
+  rw [h_total, if_neg (by omega : ¬ xs.val.size > cap)]
+  -- Unpack and take back the data bits.
+  have h_take : (unpackBitsLEAux (packBitsLE (xs.val.toList ++ [true]))
+        (packBitsLE (xs.val.toList ++ [true])).size 0).take xs.val.size =
+      xs.val.toList := by
+    have h_inv := packBitsLE_unpackBitsLEAux_inverse (xs.val.toList ++ [true])
+    rw [h_bits_len] at h_inv
+    rw [h_size, show (xs.val.size + 8) / 8 = (xs.val.size + 1 + 7) / 8 by omega, h_inv,
+        List.append_assoc, List.take_left' h_len]
+  rw [h_take]
+  simp only [Array.toArray_toList]
+  rw [dif_pos xs.property, h_size]
+
+/-! ### Size bounds for the two arms -/
+
+/-- Size bound for `.bitvector n`: the serialized size *is* the
+schema bound `⌈n/8⌉`. -/
+theorem encode_size_le_max_bitvector (n : Nat) (bv : BitVec n) :
+    (SSZType.serialize (.bitvector n) bv).size ≤
+      SSZType.maxByteLength (.bitvector n) := by
+  rw [size_serialize_bitvector]
+  unfold SSZType.maxByteLength
+  exact Nat.le_refl _
+
+/-- Size bound for `.bitlist cap`: `size ≤ cap` data bits plus the
+delimiter fit inside the schema bound `⌈(cap+1)/8⌉`. -/
+theorem encode_size_le_max_bitlist (cap : Nat) (xs : { bs : Array Bool // bs.size ≤ cap }) :
+    (SSZType.serialize (.bitlist cap) xs).size ≤
+      SSZType.maxByteLength (.bitlist cap) := by
+  have h_ser : SSZType.serialize (.bitlist cap) xs =
+      packBitsLE (xs.val.toList ++ [true]) := by
+    unfold SSZType.serialize bitlistToBytes
+    rfl
+  have h_len : xs.val.toList.length = xs.val.size := Array.length_toList
+  have h_le := xs.property
+  rw [h_ser, size_packBitsLE]
+  unfold SSZType.maxByteLength
+  simp only [List.length_append, List.length_cons, List.length_nil, h_len]
+  omega
+
+end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Proofs/BitPack.lean
+++ b/packages/SizzLean/SizzLean/Proofs/BitPack.lean
@@ -69,6 +69,11 @@ set_option maxHeartbeats 10000000
 namespace SizzLean.Proofs
 
 open SizzLean.Spec
+-- `deserializeBitvector` / `deserializeBitlist` are `protected` in
+-- `Spec/Deserialize.lean` (proof-internal, kept off the general
+-- `SizzLean.Spec` surface), so the wildcard `open` above does not
+-- bring them into scope; request the two decoders explicitly.
+open SizzLean.Spec (deserializeBitvector deserializeBitlist)
 
 /-! ### ByteArray indexing bridges -/
 

--- a/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
@@ -8,6 +8,7 @@ import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
 import SizzLean.Proofs.ContainerFixed
 import SizzLean.Proofs.FixedElems
+import SizzLean.Proofs.BitPack
 
 /-!
 # `SizzLean.Proofs.Roundtrip`: `decode_encode` dispatch over `BasicSupported`
@@ -21,6 +22,7 @@ theorem. Per-arm proofs live in sibling modules:
 | `.bool` | `Proofs/Bool.lean` |
 | `.vectorFixed t n` | `Proofs/VectorFixed.lean` |
 | `.listFixed t cap` | `Proofs/ListFixed.lean` |
+| `.bitvector n` / `.bitlist cap` | `Proofs/BitPack.lean` |
 
 ## A short note on Lean's recursion checker
 
@@ -93,6 +95,8 @@ theorem decode_encode : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .listFixed (t := t) (cap := cap) h_t h_t_fixed h_sz_pos, xs =>
       decode_encode_listFixed t cap h_t h_t_fixed h_sz_pos
         (fun y => decode_encode h_t y) xs
+  | _, .bitvector (n := n) h_pos, bv => decode_encode_bitvector n h_pos bv
+  | _, .bitlist (cap := cap), xs => decode_encode_bitlist cap xs
   | _, .containerFixed (fs := fs) h_fs, vs => by
       -- Reduce the encoder's `(fix, var)` shape to just `fix` (var = .empty for
       -- all-fixed fields), then dispatch into the mutual aux for field-list induction.

--- a/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
@@ -2,6 +2,7 @@ import SizzLean.Spec.Supported
 import SizzLean.Spec.BasicSupported
 import SizzLean.Spec.MaxByteLength
 import SizzLean.Proofs.SimpAttrs
+import SizzLean.Proofs.BitPack
 
 /-!
 # `SizzLean.Proofs.SerializeSize`: the shared size-prereq lemma
@@ -125,6 +126,15 @@ theorem size_serialize_eq_fixedByteSize :
     rw [Nat.mul_comm]
   | listFixed _ _ =>
     -- `(.list t cap).isFixedSize = false`; `h_fixed : false = true` is absurd.
+    simp [SSZType.isFixedSize] at h_fixed
+  | bitvector _h_pos =>
+    rename_i n
+    let bv : BitVec n := x
+    show (SSZType.serialize (.bitvector n) bv).size = SSZType.fixedByteSize (.bitvector n)
+    rw [size_serialize_bitvector]
+    simp [SSZType.fixedByteSize]
+  | bitlist =>
+    -- `(.bitlist cap).isFixedSize = false`; absurd like `listFixed`.
     simp [SSZType.isFixedSize] at h_fixed
   | containerFixed h_fs =>
     rename_i fs

--- a/packages/SizzLean/SizzLean/Proofs/SimpAttrs.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SimpAttrs.lean
@@ -35,12 +35,12 @@ on the def name picks them all up. Tagged here:
 Deliberately *not* tagged:
 
 * `SSZType.interp` itself: see above.
-* Private bit-packing helpers (`bitsToByte`, `packBitsLE`,
-  `bitsToNat`, `msbPos`, `byteToBits`, `unpackBitsLEAux`,
-  `bitvecToBytes`, `bitlistToBytes`, `deserializeBitvector`,
-  `deserializeBitlist`, the LE primitive readers/writers). These
-  reduce only inside dedicated round-trip lemmas (e.g.
-  `packBitsLE_unpackBitsLE_inverse`); leaving them out of the
+* Bit-packing helpers (`bitsToByte`, `packBitsLE`, `bitsToNat`,
+  `msbPos`, `byteToBits`, `unpackBitsLEAux`, `bitvecToBytes`,
+  `bitlistToBytes`, `deserializeBitvector`, `deserializeBitlist`,
+  the LE primitive readers/writers). These reduce only inside the
+  dedicated round-trip lemmas of `Proofs/BitPack.lean` (e.g.
+  `packBitsLE_unpackBitsLEAux_inverse`); leaving them out of the
   global set prevents `simp` loops and keeps the search space
   small.
 

--- a/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
@@ -8,6 +8,7 @@ import SizzLean.Proofs.Bool
 import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
 import SizzLean.Proofs.ContainerFixed
+import SizzLean.Proofs.BitPack
 
 /-!
 # `SizzLean.Proofs.SizeBound`: encoded-size upper bound
@@ -51,6 +52,8 @@ theorem encode_size_le_max : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .listFixed (t := t) (cap := cap) h_t h_t_fixed _h_sz_pos, xs =>
       encode_size_le_max_listFixed t cap h_t h_t_fixed
         (fun y => encode_size_le_max h_t y) xs
+  | _, .bitvector (n := n) _h_pos, bv => encode_size_le_max_bitvector n bv
+  | _, .bitlist (cap := cap), xs => encode_size_le_max_bitlist cap xs
   | _, .containerFixed (fs := fs) h_fs, vs => by
       -- Same dispatch as `decode_encode`'s container arm, reduce the
       -- encoder's `(fix ++ var)` shape to size = `fixedByteSizeFields fs`,

--- a/packages/SizzLean/SizzLean/Repr/Class.lean
+++ b/packages/SizzLean/SizzLean/Repr/Class.lean
@@ -43,6 +43,8 @@ The library's `decode_encode` proof currently covers the
 * `.vector t n` / `.list t cap` / `.container fs`: general
   composites over fixed-size element / field types
   (`BasicSupported t` with `t.isFixedSize = true`).
+* `.bitvector n` (`0 < n`) / `.bitlist cap`: bit-packed shapes,
+  closed by the bit-packing inverse in `Proofs/BitPack.lean`.
 * `.container [.bool, .bool]`: concrete two-`Bool` container,
   exposed as a `def`-level alias of `containerFixed (.cons .bool
   rfl (.cons .bool rfl .nil))` so the hand-written `Pair` example
@@ -50,10 +52,9 @@ The library's `decode_encode` proof currently covers the
 
 The user-surface corollary inherits that gate: a user type whose
 shape sits inside `BasicSupported` enjoys verified roundtrip; a
-user type whose shape is outside `BasicSupported` (`.bitvector`
-and `.bitlist`, neither covered by a bit-packing inverse proof in
-this layer) enjoys total `serialize` / `deserialize` (the spec
-functions are total) but no verified roundtrip. The gate is
+user type whose shape is outside it (mixed fixed/variable-size
+container fields) enjoys total `serialize` / `deserialize` (the
+spec functions are total) but no verified roundtrip. The gate is
 honest about scope and grows automatically as the proof set
 widens.
 

--- a/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
+++ b/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
@@ -27,18 +27,16 @@ Proofs/ reaches over to discharge the theorems).
   (closed in `Proofs/{VectorFixed,ListFixed,ContainerFixed}.lean`
   via mutual induction with the shared prereq
   `Proofs/SerializeSize.lean`).
+* **Bit shapes**: `.bitvector n` (with `0 < n`) and
+  `.bitlist cap` (closed in `Proofs/BitPack.lean` via the
+  bit-packing inverse `packBitsLE_unpackBitsLEAux_inverse` plus
+  `msbPos` delimiter recovery for the bitlist).
 
 ## Outside `BasicSupported`
 
-* **Bitvector** (`.bitvector n` with `0 < n`): the bit-packing
-  inverse `packBitsLE_unpackBitsLEAux_inverse` has no proof in
-  this layer.
-* **Bitlist** (`.bitlist cap`): needs `msbPos` delimiter
-  recovery on top of the bitvector prerequisites.
-
-Both arms remain `Supported` (the spec implements them and
-conformance passes), but the `decode_encode` corollary is
-ungated for these shapes.
+* **Mixed-field containers** (some variable-size fields): the
+  offset-table decode path sits outside `Supported` itself;
+  admitting it here is separate spec-layer work.
 
 ## Why two mutually inductive predicates
 
@@ -99,6 +97,14 @@ inductive SSZType.BasicSupported : SSZType → Prop
                 SSZType.BasicSupported t → t.isFixedSize = true →
                 0 < t.fixedByteSize →
                 SSZType.BasicSupported (.list t cap)
+  /-- Bit-packed fixed-width vector. The `n > 0` precondition
+  mirrors the spec's zero-length rejection, same as `vectorFixed`.
+  Roundtrip closes in `Proofs/BitPack.lean`. -/
+  | bitvector : ∀ {n : Nat}, 0 < n → SSZType.BasicSupported (.bitvector n)
+  /-- Bit-packed variable-length list (up to `cap` data bits) with
+  its trailing delimiter bit. Roundtrip closes in
+  `Proofs/BitPack.lean` via `msbPos` delimiter recovery. -/
+  | bitlist : ∀ {cap : Nat}, SSZType.BasicSupported (.bitlist cap)
   /-- Container with an all-fixed-size, all-`BasicSupported`
   field list. -/
   | containerFixed : ∀ {fs : List SSZType},

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -198,8 +198,10 @@ def msbPosAux (byte : UInt8) : Nat → Option Nat
 
 def msbPos (byte : UInt8) : Option Nat := msbPosAux byte 7
 
-/-- `bitvector n` decoder. -/
-private def deserializeBitvector (n : Nat) (b : ByteArray) :
+/-- `bitvector n` decoder. Public (not `private`) for the same
+reason as the bit-unpacking helpers above: the Layer 2 roundtrip
+proof in `Proofs/BitPack.lean` reasons through its branches. -/
+def deserializeBitvector (n : Nat) (b : ByteArray) :
     Except SSZError (BitVec n × Nat) :=
   -- Per SSZ spec: bitvectors must have `n > 0`. The
   -- `ssz_generic/bitvector/invalid/bitvec_0` test asserts the
@@ -238,8 +240,9 @@ private def deserializeBitvector (n : Nat) (b : ByteArray) :
 Empty buffer ⇒ `bitlistMissingDelimiter` (no delimiter at all).
 Last byte = `0x00` ⇒ same error.
 Otherwise: the position of the most-significant `1` in the last byte
-is the bit-position of the delimiter; bits before it are data. -/
-private def deserializeBitlist (cap : Nat) (b : ByteArray) :
+is the bit-position of the delimiter; bits before it are data.
+Public (not `private`) so `Proofs/BitPack.lean` can reach it. -/
+def deserializeBitlist (cap : Nat) (b : ByteArray) :
     Except SSZError ({ bs : Array Bool // bs.size ≤ cap } × Nat) :=
   if h : b.size = 0 then .error .bitlistMissingDelimiter
   else

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -198,10 +198,13 @@ def msbPosAux (byte : UInt8) : Nat → Option Nat
 
 def msbPos (byte : UInt8) : Option Nat := msbPosAux byte 7
 
-/-- `bitvector n` decoder. Public (not `private`) for the same
-reason as the bit-unpacking helpers above: the Layer 2 roundtrip
-proof in `Proofs/BitPack.lean` reasons through its branches. -/
-def deserializeBitvector (n : Nat) (b : ByteArray) :
+/-- `bitvector n` decoder. `protected`: the Layer 2 roundtrip proof
+in `Proofs/BitPack.lean` reasons through its branches, so it must be
+reachable, but it is proof-internal, not part of the general
+`SizzLean.Spec` surface. `protected` keeps a bare `open
+SizzLean.Spec` from pulling it into scope; the proof file names it
+with an explicit `open SizzLean.Spec (deserializeBitvector)`. -/
+protected def deserializeBitvector (n : Nat) (b : ByteArray) :
     Except SSZError (BitVec n × Nat) :=
   -- Per SSZ spec: bitvectors must have `n > 0`. The
   -- `ssz_generic/bitvector/invalid/bitvec_0` test asserts the
@@ -241,8 +244,10 @@ Empty buffer ⇒ `bitlistMissingDelimiter` (no delimiter at all).
 Last byte = `0x00` ⇒ same error.
 Otherwise: the position of the most-significant `1` in the last byte
 is the bit-position of the delimiter; bits before it are data.
-Public (not `private`) so `Proofs/BitPack.lean` can reach it. -/
-def deserializeBitlist (cap : Nat) (b : ByteArray) :
+`protected` for the same reason as `deserializeBitvector`:
+proof-internal, reached only by the explicit `open` in
+`Proofs/BitPack.lean`, never by a bare `open SizzLean.Spec`. -/
+protected def deserializeBitlist (cap : Nat) (b : ByteArray) :
     Except SSZError ({ bs : Array Bool // bs.size ≤ cap } × Nat) :=
   if h : b.size = 0 then .error .bitlistMissingDelimiter
   else
@@ -377,8 +382,8 @@ def SSZType.deserialize : (s : SSZType) → ByteArray → Except SSZError (s.int
                           let arr := xs.toArray
                           if h : arr.size ≤ cap then .ok (⟨arr, h⟩, b.size)
                           else .error .outOfRange
-  | .bitvector n, b => deserializeBitvector n b
-  | .bitlist cap, b => deserializeBitlist cap b
+  | .bitvector n, b => SizzLean.Spec.deserializeBitvector n b
+  | .bitlist cap, b => SizzLean.Spec.deserializeBitlist cap b
   | .container fs, b =>
       if SSZType.allFixedSize fs then
         SSZType.deserializeFixedFields fs b 0

--- a/packages/SizzLean/SizzLeanTests/ReprExamples.lean
+++ b/packages/SizzLean/SizzLeanTests/ReprExamples.lean
@@ -21,9 +21,9 @@ user-facing surface.
 ## Why `Pair {a b : Bool}` as the example
 
 `SSZ.roundtrip` is gated by `SSZType.BasicSupported r.shape`
-(`Repr/Class.lean`), and `BasicSupported` currently covers
-the four native-width integers (`.uintN 8` / `16` / `32` / `64`),
-`.bool`, and `.container [.bool, .bool]` (see
+(`Repr/Class.lean`); `BasicSupported` covers the four
+native-width integers (`.uintN 8` / `16` / `32` / `64`), `.bool`,
+the bit shapes, and the fixed-size composites (see
 `Spec/BasicSupported.lean`). The smallest non-trivial user
 structure that lives in `BasicSupported` is a two-`Bool`
 container, exactly the `Pair` defined below.
@@ -165,5 +165,48 @@ example (vs : SSZType.interpFields [.uintN 8, .uintN 16, .uintN 32]) :
                   (.cons .uintN8 rfl
                     (.cons .uintN16 rfl
                       (.cons .uintN32 rfl .nil)))) vs
+
+/-! ### Bit-shape arm examples
+
+`BasicSupported` covers `.bitvector n` (`0 < n`) and
+`.bitlist cap` through the bit-packing inverse in
+`Proofs/BitPack.lean`. The widths exercise both decoder branches:
+10 is not a byte multiple (the zero-padding guard runs on the
+partial final byte), 16 is (the guard is skipped). -/
+
+/-- Roundtrip for a 10-bit bitvector. The witness carries the
+`0 < n` precondition, mirroring `vectorFixed`. -/
+example (bv : BitVec 10) :
+    SSZType.deserialize (.bitvector 10)
+        (SSZType.serialize (.bitvector 10) bv) =
+      Except.ok (bv, (SSZType.serialize (.bitvector 10) bv).size) :=
+  decode_encode (.bitvector (by decide)) bv
+
+/-- Roundtrip for a 16-bit (whole-byte) bitvector. -/
+example (bv : BitVec 16) :
+    SSZType.deserialize (.bitvector 16)
+        (SSZType.serialize (.bitvector 16) bv) =
+      Except.ok (bv, (SSZType.serialize (.bitvector 16) bv).size) :=
+  decode_encode (.bitvector (by decide)) bv
+
+/-- Roundtrip for a bitlist capped at 100 data bits. No side
+condition: the delimiter bit makes every encoding non-empty,
+including the empty bitlist's `0x01`. -/
+example (xs : { bs : Array Bool // bs.size ≤ 100 }) :
+    SSZType.deserialize (.bitlist 100)
+        (SSZType.serialize (.bitlist 100) xs) =
+      Except.ok (xs, (SSZType.serialize (.bitlist 100) xs).size) :=
+  decode_encode .bitlist xs
+
+/-- A container carrying a bitvector field: `.bitvector n` is
+fixed-size, so it qualifies under `BasicSupportedFieldsFixed`
+alongside the basic integers. -/
+example (vs : SSZType.interpFields [.uintN 8, .bitvector 10]) :
+    SSZType.deserialize (.container [.uintN 8, .bitvector 10])
+        (SSZType.serialize (.container [.uintN 8, .bitvector 10]) vs) =
+      Except.ok (vs, (SSZType.serialize (.container [.uintN 8, .bitvector 10]) vs).size) :=
+  decode_encode (.containerFixed
+                  (.cons .uintN8 rfl
+                    (.cons (.bitvector (by decide)) rfl .nil))) vs
 
 end SizzLeanTests.ReprExamples

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -119,10 +119,11 @@ Phase 4 built the performance layer on top of the now-known-good
 library; **Phase 5 (Stage 18) widens the three theorems** toward
 universal `Supported` coverage. As of this writing
 `BasicSupported` covers `uintN 8/16/32/64`, `bool`, fixed-size
-`vector` and `list`, and `container` over fixed-size fields
-(recursively). See `Spec/BasicSupported.lean` and the
-README's *Proof coverage* table. `bitvector`, `bitlist`, and
-mixed-field containers remain open; the `SSZ.roundtrip`
+`vector` and `list`, `bitvector`, `bitlist` (both via the
+bit-packing inverse in `Proofs/BitPack.lean`), and `container`
+over fixed-size fields (recursively). See
+`Spec/BasicSupported.lean` and the README's *Proof coverage*
+table. Mixed-field containers remain open; the `SSZ.roundtrip`
 user-surface corollary is gated by `BasicSupported r.shape` until
 those land. The asterisk on "verified by inheritance" is
 intentional and small: passing empirical conformance is what

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1405,8 +1405,8 @@ Replaces the Stage 5–6 first-cut theorems on `BasicSupported`.
 | `.vector t n` (general, `0 < n`, fixed-size `t`) | ✅ | `Proofs/VectorFixed.lean` |
 | `.list t cap` (general, fixed-size `t`, `0 < t.fixedByteSize`) | ✅ | `Proofs/ListFixed.lean` |
 | `.container fs` (general, `BasicSupportedFieldsFixed fs`) | ✅ | `Proofs/ContainerFixed.lean` (helpers) + `Proofs/Roundtrip.lean` (mutual block) |
-| `.bitvector n` (`0 < n`) | ⏸ deferred | needs `packBitsLE` / `unpackBitsLEAux` inverse |
-| `.bitlist cap` | ⏸ deferred | needs bit-packing inverse + `msbPos` delimiter recovery |
+| `.bitvector n` (`0 < n`) | ✅ | `Proofs/BitPack.lean` (`packBitsLE` / `unpackBitsLEAux` inverse) |
+| `.bitlist cap` | ✅ | `Proofs/BitPack.lean` (inverse + `msbPos` delimiter recovery) |
 | mixed-field `.container` (≥1 variable-size field) | ⏸ outside `Supported` | needs `Supported` extension first |
 
 Shared prerequisite shipped: `Proofs/SerializeSize.lean`, the
@@ -1416,46 +1416,45 @@ prerequisite the composite arms recurse through and is reused by
 the three theorems' composite-arm dispatch.
 
 **Remaining deliverables.**
-- `packages/SizzLean/SizzLean/Proofs/BitPack.lean` (planned):
-  `packBitsLE` / `unpackBitsLEAux` inverse lemma. The per-byte
-  inverse `byteToBits (bitsToByte [b₀..b₇] 0 0) = [b₀..b₇]` closes
-  via 256-case `cases <;> decide` in ~2 s; the full byte-stream
-  inverse is ~200–400 lines due to the 8-bit-vs-1-byte recursion
-  mismatch.
-- `packages/SizzLean/SizzLean/Proofs/BitVector.lean` (planned):
-  `.bitvector n` arm; depends on BitPack.
-- `packages/SizzLean/SizzLean/Proofs/BitList.lean` (planned):
-  `.bitlist cap` arm with `msbPos` delimiter recovery; depends
-  on BitPack.
 - Spec-layer extension for mixed-field containers (out of scope
   for Stage 18 as currently scoped; it would require a new
   `containerVar` constructor on `Supported` plus offset-table
   invariants).
-- The `SSZ.roundtrip` user-surface corollary loses its
-  `BasicSupported r.shape` precondition once the bit-level arms
-  close (mixed-field containers are blocked one layer deeper, on
-  the `Supported` predicate itself).
+- The `SSZ.roundtrip` user-surface corollary keeps its
+  `BasicSupported r.shape` precondition until mixed-field
+  containers land (blocked one layer deeper, on the `Supported`
+  predicate itself).
+
+Shipped since the original scoping:
+`packages/SizzLean/SizzLean/Proofs/BitPack.lean` carries the
+`packBitsLE` / `unpackBitsLEAux` inverse *and* both bit-shape
+arms (the separate BitVector.lean / BitList.lean files proved
+unnecessary; the arm closures are short once the inverse and its
+finite `decide` companions are in place). The per-byte identities
+(inverse, high-bit vanishing, `msbPos` delimiter recovery) close
+by kernel `decide` over the ≤ 2⁸ chunk shapes; the byte-stream
+lift mirrors `packBitsLE`'s own 8-cons match structure so the
+structural checker accepts the recursion.
 
 **Final acceptance.** Three theorems closed universally over
 `Supported` / `SupportedBounded` with no `sorry`, no `native_decide`
 on the proof path. The current shipping cut closes everything
-*except* `bitvector`, `bitlist`, and mixed-field containers;
+*except* mixed-field containers;
 `decode_encode`'s axiom footprint is exactly three
 `_native.bv_decide.ax_*` axioms (from the multi-byte `uintN`
-arms) plus the standard kernel axioms, and `encode_size_le_max`
-adds none. Note that the bv_decide axioms are a documented
-deviation from the original Stage 18 acceptance and could be
-removed by replacing `bv_decide` with hand-written `BitVec`
-proofs (substantially more code).
+arms) plus the standard kernel axioms (the bit arms add none), and
+`encode_size_le_max` adds none. Note that the bv_decide axioms are
+a documented deviation from the original Stage 18 acceptance and
+could be removed by replacing `bv_decide` with hand-written
+`BitVec` proofs (substantially more code).
 
 **Risk.** Lowered from the original "highest in project" since
-the composite arms (general `vector` / `list` / `container`) are
-now shipped without the predicted research-grade difficulty.
-The mutual-block trick on `(BasicSupported,
-BasicSupportedFieldsFixed)` resolved the closure-termination
-issue cleanly. Remaining risk concentrates in `bitlist`
-(`msbPos` delimiter recovery is genuinely intricate) and in any
-future mixed-field-container work.
+the composite arms (general `vector` / `list` / `container`) and
+both bit arms are now shipped without the predicted
+research-grade difficulty. The mutual-block trick on
+`(BasicSupported, BasicSupportedFieldsFixed)` resolved the
+closure-termination issue cleanly. Remaining risk concentrates
+in the future mixed-field-container work.
 
 **Notes.** Each arm's arrival extends `SSZ.roundtrip`
 automatically; downstream Eth-types instances pick up the wider
@@ -1489,4 +1488,4 @@ the per-constructor table users see.
 | 2: User surface | Stages 7–9 | complete |
 | 3: Application + empirical validation | Stages 10–11, **11.1** | **complete.** `ssz_generic`: **1865/1865 cases pass**. `ssz_static` (minimal preset, full `--all` sweep): **38991/38991 cases pass** across all seven mainline forks (`phase0`, `altair`, `bellatrix`, `capella`, `deneb`, `electra`, `fulu`), zero failures, zero skipped. Conformance pinned at consensus-spec-tests **v1.6.0-beta.0** in `scripts/run_conformance.py` so the Fulu / Gloas containers track the post-v1.5.0 main-branch spec (Fulu BeaconState is now its own struct with `proposer_lookahead`; Gloas BeaconState is its own struct with the nine EIP-7732 ePBS fields). Preset duplication is eliminated by the `ssz_struct_for_presets` macro (`packages/LeanEthCS/LeanEthCS/PresetStruct.lean`); preset-sensitive containers are written once with `@@CONST` / `@%TypeName` placeholders and emitted twice (`.Minimal` / `.Mainnet`). Mainnet validated at `--limit 2` across all forks (1641/1641); mainnet `--all` is a `workflow_dispatch` button. CLI dispatch uses the `<preset>/<fork>:<type>` identifier scheme (legacy `<fork>:<type>` defaults to minimal). **CI integration**: `.github/workflows/lean_action_ci.yml` runs the conformance script at `--limit 1` on every push/PR. **Stage 11.1, harness modernisation:** `eth_ssz_vector_runner batch` mode (one process spawn per sweep, tab-separated request/response over stdin/stdout, ~70× speedup on `ssz_generic`); `tqdm` progress bar; per-fork explicit `Inherited.lean` re-exports in LeanEthCS killing the inheritance heuristic in the dispatcher; Tests/ rename to package-prefixed `SizzLeanTests/` / `LeanSha256Tests/` for umbrella-build namespace disambiguation. EIP-7441 (Whisk) deferred per scope; EIP-7732 (ePBS) Gloas containers tracked (BeaconState shape implemented; supporting types `Builder`, `BuilderPendingPayment`, `BuilderPendingWithdrawal`, and `ExecutionPayloadBid` ship in `Forks/Gloas/`). |
 | 4: Production primitives + deferred hardening | Stages 12, 13, 14a–d, **14e**, 15, 17a–e (Stage 16 dropped, see note) | **Cache backbone + ergonomic surface + Sha256Spec green: 14a–e + 15 in.** Stage 12: three hand-built trees match `Spec.SSZType.hashTreeRoot` via `native_decide`. Stage 13: 200-case randomized property test (`gindexBits` on `List Bool` so the Nimbus Feb-2025 gindex bug class is unrepresentable). Stage 14a: `TreeBacked` scaffold. Stage 14b: `Node.ofShape` produces interior-populated trees byte-identical to the spec; coherence verified on 8 composite types. Stage 14c: cached `setField` operations; property tests pass for 100 + 30 mutations. Stage 14d: `Node.setManyAt` batched walker (100-case property test on disjoint distinct paths) plus `sszUpdate t with f := v, g.h := w, vec[i] := x` term-elaborated syntax (50-case flat-multi + 20-case nested-path + 30-case vector-index + 30-case alias-coverage gates). Index syntax handles both `Vector` and `SSZList` with composite element types; the list path emits the `[false]` mix-in-length prefix automatically. `TreeBacked H T` / `CachedSSZ H T` pin the hasher in the *type*, picked once at `TreeBacked.ofValue` time, then inferred by every downstream `sszUpdate` / `hashTreeRootCached` call; mixing hashers within one cached value is a type error. Two exploratory pieces were tried and removed: a `derive_tree_setters` macro and `TreeBacked/Container.lean` (hand-written setters obsoleted by `sszUpdate`'s index syntax). **Stage 14e, `SSZ.Box` union + curated public surface:** closed inductive over the two cache flavours with four smart constructors (`SSZ.FastBox` / `SSZ.PureBox` Sha256-pinned, `SSZ.CachedBox` / `SSZ.UncachedBox` hasher-explicit); `sszUpdate` extended with two-arm box dispatch; read-side `sszGet b a.b[i].c` macro mirrors `sszUpdate`'s path syntax and expands to `b.view.a.b[i].c` so user code never types `.view`; `CachedSSZ.ofValue` / `.hashTreeRoot` user-facing aliases. Stage 15: pure-Lean `Sha256Spec` ships as a kernel-reducible Lean SHA-256 implementation, validated empirically against the FFI on 185 cases (5 NIST + 100 random combine + 80 random hash). **Stage 17a (pending overlay):** `pending : Std.TreeMap Nat (PendingWrite T)` where `PendingWrite T = T → Option Node` is a closure that reads the current `view` at commit time and returns `none` for view-side no-op writes (OOB index updates). Cross-statement batching is automatic and free; closure-based read-from-view keeps overlapping parent/child writes mutually consistent. **Stage 17b:** batched SHA-256 FFI primitive (`sha256BatchCombine`) shipped with named axiom and equivalence tests; scalar inner loop in `csrc/sha256_batch.c` for now (AVX-512 swap is 17b.1 follow-up, keeps the FFI surface identical). **Stage 17c:** bounded-LRU hash-consing primitive (`Node.mkPair`) shipped opt-in; default cached path bypasses it. **Stage 17d:** `@[specialize]` on the three `SSZ.serialize/deserialize/hashTreeRoot` surfaces. **Stage 17e:** `Node.commitAndHash` fuses commit + root walk into a single spine walk; `Node.ofShape`'s builders (`ofLeaves`, `ofSubtrees`, `mixInLength`) pre-fill `(some root)` cache slots at construction so `merkleRootWithCache` on a fresh subtree short-circuits in O(1) at the top. **Bench (`packages/SizzLean/SizzLeanBench/`, run via `just sizzlean-bench`):** seven scenarios S1–S7 across small (`Validator` / `ValidatorSet16`), large (`ValidatorSet256`), and realistic (`SizzLeanBench.Fulu.BeaconState`, mainnet preset, ~1024 validators) fixtures. Headline rows: **S6 BlockProcessingLarge** ~2.4× cached vs pure; **S7 FuluStateTransition** ~2.0× cached vs pure. S7's Fulu types live in `SizzLeanBench/Fulu.lean` as a bench-local reference copy so `SizzLeanBench` doesn't need a LeanEthCS dependency (`LeanEthCS` already depends on `SizzLean`, so the reverse would close a cycle). |
-| 5: Complete formal verification | Stage 18 | **in progress.** `BasicSupported` now covers `uintN 8 / 16 / 32 / 64`, `bool`, general `vector` / `list` over fixed-size elements, and general `container` over fixed-size fields (recursively). Shared prereq `Proofs/SerializeSize.lean` lands the `size_serialize_eq_fixedByteSize` mutual proof. Per-arm proofs split across `Proofs/{UInt,Bool,VectorFixed,ListFixed,ContainerFixed,FixedElems,Roundtrip,SizeBound}.lean`; `decode_encode`'s axiom footprint is three `_native.bv_decide.ax_*` (uintN16/32/64), `encode_size_le_max`'s is zero non-standard axioms. Open arms: `bitvector`, `bitlist` (need `packBitsLE` / `unpackBitsLEAux` inverse). Mixed-field containers remain outside `SSZType.Supported` itself, separate spec-layer work. See the Stage 18 section above and the README's *Proof coverage* table. |
+| 5: Complete formal verification | Stage 18 | **in progress.** `BasicSupported` now covers `uintN 8 / 16 / 32 / 64`, `bool`, general `vector` / `list` over fixed-size elements, `bitvector` / `bitlist` (the `packBitsLE` / `unpackBitsLEAux` inverse plus `msbPos` delimiter recovery, `Proofs/BitPack.lean`), and general `container` over fixed-size fields (recursively, `bitvector` fields included). Shared prereq `Proofs/SerializeSize.lean` lands the `size_serialize_eq_fixedByteSize` mutual proof. Per-arm proofs split across `Proofs/{UInt,Bool,VectorFixed,ListFixed,ContainerFixed,FixedElems,BitPack,Roundtrip,SizeBound}.lean`; `decode_encode`'s axiom footprint is three `_native.bv_decide.ax_*` (uintN16/32/64, the bit arms add none), `encode_size_le_max`'s is zero non-standard axioms. Mixed-field containers remain outside `SSZType.Supported` itself, separate spec-layer work. See the Stage 18 section above and the README's *Proof coverage* table. |


### PR DESCRIPTION
## Summary

Closes #9. Add the bit-packing inverse and close the `.bitvector` and `.bitlist` arms of the core SizzLean theorems so they are covered by `SSZType.BasicSupported`.

## What changed

All changes live in `packages/SizzLean/`:

- `SizzLean/Proofs/BitPack.lean` (new): the per-byte identity `byteToBits_bitsToByte`, the byte-stream lift `packBitsLE_unpackBitsLEAux_inverse`, msb-position delimiter recovery for bitlists, and the roundtrip + size-bound arms for `.bitvector n` (with `0 < n`) and `.bitlist cap`.
- `SizzLean/Spec/BasicSupported.lean`: add `bitvector` and `bitlist` constructors and update docstrings.
- `SizzLean/Spec/Deserialize.lean`: make `deserializeBitvector` and `deserializeBitlist` public (remove `private`) so proofs can reason through their branches; behaviour is unchanged.
- `SizzLean/Proofs/{Roundtrip,SizeBound,SerializeSize}.lean`: dispatch the new arms for the central theorems and add the fixed-size arm for `.bitvector`.
- `SizzLeanTests/ReprExamples.lean`: add `example` gates that typecheck `BitVec 10`, `BitVec 16`, a capped bitlist, and a small container with a `bitvector` field.
- Docs updated: `packages/SizzLean/README.md`, `packages/SizzLean/docs/ARCHITECTURE.md`, and `packages/SizzLean/docs/PLAN.md` reflect the new proof coverage.

## Test plan

- `lake build` (full monorepo) is green.
- Per-package Lean test suites pass.
- `just sizzlean-pyspec-full`: 2215 passed, 294 xfailed (xfails are the pre-existing out-of-scope cases).
- `just ethcl-pyspec-smoke`: 200 passed, 52 skipped (pre-existing skips).
- New `example` gates in `ReprExamples.lean` exercise the shapes at typecheck time.

## Risk / trust footprint

None added. No new `axiom`, no `sorry`, no `partial def`, no `native_decide`, no `unsafe`, no new `@[extern]`. `#print axioms` shows the new bit arms depend only on the standard kernel axioms (`propext`, `Classical.choice`, `Quot.sound`). `decode_encode`'s axiom footprint is unchanged.

## Notes for reviewers

- The byte-level identities close by kernel `decide` over the finite per-byte shapes, so the proofs do not introduce compiler-trusting axioms.
- The byte-stream lift mirrors the encoder's 8-cons structure so the structural checker accepts the recursion without `termination_by`.
- Mixed-field containers remain outside this PR; they require a separate change to the `Supported` predicate.

## LICENSE (LGPL version 3)

- [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.

