### PR TITLE
style(sizzlean): silence unused-variable warnings in SizeBound

### DIFF
--- a/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
@@ -76,8 +76,8 @@ cons head, call `encode_size_le_max` on the field's
 `BasicSupported` witness to derive `fixedByteSize t ≤
 maxByteLength t`. -/
 theorem encode_size_le_max_containerFields_aux : ∀ {fs : List SSZType}
-    (h_fs : SSZType.BasicSupportedFieldsFixed fs)
-    (vs : SSZType.interpFields fs),
+    (_h_fs : SSZType.BasicSupportedFieldsFixed fs)
+    (_vs : SSZType.interpFields fs),
     SSZType.fixedByteSizeFields fs ≤ SSZType.maxByteLengthFields fs
   | _, .nil, _ => by
       unfold SSZType.fixedByteSizeFields SSZType.maxByteLengthFields


### PR DESCRIPTION
## Summary

Closes #11. Silence the two `unusedVariables` linter warnings in `Proofs/SizeBound.lean`.

## What changed

- `packages/SizzLean/SizzLean/Proofs/SizeBound.lean`: prefix the unused `∀`-telescope binders of `encode_size_le_max_containerFields_aux` (`h_fs` / `vs`) with `_`. Every equation arm already rebinds those arguments positionally, so the telescope names were dead.

## Test plan

- `lake build SizzLean` is green with **no warnings** (the two `SizeBound.lean:79/80` warnings are gone).
- Behaviour and proof term unchanged; only binder names differ.

## Risk / trust footprint

None. No `axiom`, `sorry`, `partial def`, `native_decide`, `unsafe`, or `@[extern]` added or removed. Names-only change.

## Notes for reviewers

Pre-existing warnings, confirmed against `main` (not introduced by #10). The docstring already documents the roles of the two binders, so the `_`-prefix costs no readability. Matches the fix suggested in #11.

## LICENSE (LGPL version 3)
- [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.