### PR TITLE
ci: block PRs that list AI agents as co-authors

### DIFF
--- a/.github/workflows/ai_coauthor_guard.yml
+++ b/.github/workflows/ai_coauthor_guard.yml
@@ -1,0 +1,63 @@
+name: AI co-author guard
+
+# Blocks merge when any commit in the PR lists a known AI agent
+# (Claude, Copilot, Gemini, Codeium, Cody, Aider, …) as a Co-authored-by
+# trailer. Pair this with a branch-protection rule on the base branch that
+# requires the `check` job below to be green before a PR can merge; the
+# workflow alone only produces a status check, the rule is what enforces it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    # No checkout needed: the GitHub REST API exposes each commit's full
+    # message (trailers included) via `pulls/{n}/commits`. `--paginate`
+    # covers PRs larger than the 250-commit default page.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject AI-agent co-authors
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Known AI-agent identifiers (case-insensitive, grep ERE). A
+          # Co-authored-by trailer mentioning any of these fails the check.
+          # Add new agents here as they appear. Matched against the whole
+          # trailer line, so a human contributor whose name collides with one
+          # of these tokens (e.g. someone literally named Claude) would also
+          # be blocked; narrow a token to an email domain (anthropic\.com) if
+          # that bites.
+          AI_AGENTS='anthropic\.com|claude|copilot|gemini|codeium|cody|aider'
+
+          # Extract every Co-authored-by trailer in the PR, tagged with its
+          # commit's short SHA for actionable feedback. `gh api --jq`
+          # raw-outputs one line per trailer; trailer lines are single
+          # physical lines, so SHA + trailer share a line with no
+          # embedded-newline ambiguity. Agent matching is left to grep so the
+          # AI_AGENTS list stays plain regex with no jq-string escaping.
+          trailers=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" \
+            --paginate \
+            --jq '
+              .[] | .sha as $sha
+              | (.commit.message | split("\n") | .[])
+              | select(test("(?i)^\\s*Co-authored-by:"))
+              | "\($sha[0:8])  \(.)"
+            ')
+
+          offenders=$(printf '%s\n' "$trailers" | grep -iE "$AI_AGENTS" || true)
+
+          if [ -n "$offenders" ]; then
+            echo "::error title=AI co-author detected::One or more commits list an AI agent as co-author. Remove the Co-authored-by trailer (or drop the commit) before merging."
+            printf '%s\n' "$offenders" | sed 's/^/    /'
+            exit 1
+          fi
+
+          echo "No AI-agent co-authors detected."


### PR DESCRIPTION
## Summary

Adds a `pull_request` workflow (`AI co-author guard`) that fails the check when any commit in the PR lists a known AI agent as a `Co-authored-by:` trailer. Paired with a branch-protection rule requiring the `check` job, this prevents merging such PRs.

## What changed

- New file `.github/workflows/ai_coauthor_guard.yml`:
  - Triggers on `pull_request` (opened, synchronize, reopened).
  - Fetches every PR commit via `gh api repos/{owner}/{repo}/pulls/{n}/commits` (paginated).
  - Extracts `Co-authored-by:` trailer lines tagged with the commit's short SHA, using `jq`.
  - Matches trailers against a known-agent list with `grep -iE`; fails (`exit 1`) on any hit, printing the offending trailers as a `::error::` annotation.
  - Agent list (one-line grep ERE, easy to extend): `anthropic\.com|claude|copilot|gemini|codeium|cody|aider`.
  - Uses the auto-provisioned `GITHUB_TOKEN`, scoped via `permissions: contents: read, pull-requests: read`. No checkout needed.

## Test plan

- [x] Verified the `jq` trailer extraction + `grep` agent matching against a mock payload containing a Claude trailer, a Copilot trailer, and human-only trailers: only the AI trailers were flagged, with correct short SHAs.
- [x] Verified the clean (no AI) payload yields an empty offenders string and exits 0.
- [x] Confirmed both control-flow paths (`set -euo pipefail`, `grep ... || true`, explicit `exit 1`) behave correctly.
- [ ] CI run on this PR confirms the workflow executes green on a clean PR (this is the first run of the workflow).

## Risk / trust footprint

None. Adds a CI workflow file only; no Lean source, no `sorry`/`partial def`/`@[extern]`/`native_decide`/axiom changes, no build deps.

## Notes for reviewers

- **Enforcement is a separate, manual step.** The workflow produces a status check; the actual merge block requires a branch-protection rule on `main` (Settings -> Branches -> require status check `check` from the "AI co-author guard" workflow). The workflow cannot set that rule on its own.
- **Matching is by identifier, case-insensitive, against the whole trailer line.** A human co-author literally named "Claude" would also be blocked; narrow that token to the email domain `anthropic\.com` if that ever bites. Documented inline.
- Agent matching is done in `grep` (not `jq`) on purpose: `gh api --jq` does not forward jq options like `--arg`, so keeping the editable agent list as a plain grep ERE avoids jq-string escaping pitfalls.
- Fail-closed: if `gh api` errors, `set -euo pipefail` fails the step (blocks merge) rather than silently allowing.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.