### PR TITLE
feat(sizzlean): close the uintN 128/256 arms of the central theorems

### DIFF
--- a/packages/SizzLean/README.md
+++ b/packages/SizzLean/README.md
@@ -60,9 +60,9 @@ theorems.
   central theorems, encode/decode roundtrip, non-malleability,
   and a schema-derived static size bound, are proved for every
   SSZ shape *except* variable-field containers:
-  `uintN 8 / 16 / 32 / 64`, `bool`, fixed-size `vector` and
-  `list`, `bitvector`, `bitlist`, and `container` over fixed-size
-  fields (recursively). Mixed-field containers are pending, see
+  `uintN 8 / 16 / 32 / 64 / 128 / 256`, `bool`, fixed-size `vector`
+  and `list`, `bitvector`, `bitlist`, and `container` over
+  fixed-size fields (recursively). Mixed-field containers are pending, see
   [Proof coverage](#proof-coverage) for the per-constructor
   table.
 
@@ -195,6 +195,8 @@ Per-constructor breakdown:
 | `.uintN 16` | ✅ ¹ | ✅ ¹ | ✅ | `bv_decide` on the LE identity |
 | `.uintN 32` | ✅ ¹ | ✅ ¹ | ✅ | `bv_decide` |
 | `.uintN 64` | ✅ ¹ | ✅ ¹ | ✅ | `bv_decide` |
+| `.uintN 128` | ✅ ⁵ | ✅ ⁵ | ✅ | `Nat`-digit induction on the `natToLEBytes` / `readNatLE` codec; no `bv_decide` axiom |
+| `.uintN 256` | ✅ ⁵ | ✅ ⁵ | ✅ | same codec proof as `.uintN 128` (e.g. `base_fee_per_gas`) |
 | `.bool` | ✅ | ✅ | ✅ | exhaustive `cases` + `rfl` |
 | `.vector t n` | ✅ ² | ✅ ² | ✅ ² | needs `0 < n` + `BasicSupported t` + `t.isFixedSize = true` |
 | `.list t cap` | ✅ ³ | ✅ ³ | ✅ ³ | needs `BasicSupported t` + `t.isFixedSize = true` + `0 < t.fixedByteSize` |
@@ -215,6 +217,11 @@ block.
 ⁴ Byte-level bit identities close by kernel `decide` over the
 finite chunk shapes (`Proofs/BitPack.lean`), so the bit arms add
 no axioms beyond the standard kernel three.
+⁵ The wide integer arms (`Proofs/UIntWide.lean`) prove the
+little-endian codec inverse `readNatLE (natToLEBytes w n) 0 w =
+n mod 256ʷ` by induction on the width (the digit step is
+`Nat.mod_mul`). Unlike the narrow arms they use no `bv_decide`, so
+they add **no axioms** beyond the standard kernel three.
 
 `serialize_injective` is a direct corollary of `decode_encode`
 (via `Except.ok.inj` + `Prod.mk.inj`), so its coverage tracks
@@ -228,7 +235,7 @@ Allowed and excluded field types:
 
 | Field type | Allowed as a container field? | Why |
 |---|:---:|---|
-| `.uintN 8 / 16 / 32 / 64` | ✅ | basic + fixed |
+| `.uintN 8 / 16 / 32 / 64 / 128 / 256` | ✅ | basic + fixed |
 | `.bool` | ✅ | basic + fixed |
 | `.vector t' n` (with `n > 0`, fixed-size `t'`, `BasicSupported t'`) | ✅ | nested vector, `(.vector t' n).isFixedSize = t'.isFixedSize` |
 | `.container fs'` (with `BasicSupportedFieldsFixed fs'`) | ✅ | nested container, `(.container fs').isFixedSize = allFixedSize fs'` |
@@ -247,17 +254,18 @@ requires extending `Supported` with a `containerVar` constructor
 plus an offset-table-invariants proof.
 
 In one line: containers with fields drawn from `{uintN8, uintN16,
-uintN32, uintN64, bool, vectorFixed, bitvector,
-containerFixed (recursively)}` are proved; containers with any
-`list` or `bitlist` field are not.
+uintN32, uintN64, uintN128, uintN256, bool, vectorFixed,
+bitvector, containerFixed (recursively)}` are proved; containers
+with any `list` or `bitlist` field are not.
 
 ### Track in progress
 
 **Phase 5 formal-verification widening:** the three central
 theorems (roundtrip, non-malleability, size bound) are landed on
 the `BasicSupported` cut, which now covers `uintN 8 / 16 / 32 /
-64`, `bool`, fixed-size `vector` and `list`, `bitvector`,
-`bitlist`, and `container` over fixed-size fields (recursively).
+64 / 128 / 256`, `bool`, fixed-size `vector` and `list`,
+`bitvector`, `bitlist`, and `container` over fixed-size fields
+(recursively).
 Widening to a universal statement over `SSZType.Supported`
 requires extending `Supported` itself to admit mixed-field
 containers (spec-layer follow-up). The library itself is

--- a/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
@@ -3,6 +3,7 @@ import SizzLean.Spec.BasicSupported
 import SizzLean.Proofs.SimpAttrs
 import SizzLean.Proofs.SerializeSize
 import SizzLean.Proofs.UInt
+import SizzLean.Proofs.UIntWide
 import SizzLean.Proofs.Bool
 import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
@@ -19,6 +20,7 @@ theorem. Per-arm proofs live in sibling modules:
 | Arm | File |
 |---|---|
 | `.uintN 8/16/32/64` | `Proofs/UInt.lean` |
+| `.uintN 128/256` | `Proofs/UIntWide.lean` |
 | `.bool` | `Proofs/Bool.lean` |
 | `.vectorFixed t n` | `Proofs/VectorFixed.lean` |
 | `.listFixed t cap` | `Proofs/ListFixed.lean` |
@@ -88,6 +90,8 @@ theorem decode_encode : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .uintN16, x => decode_encode_uintN16 x
   | _, .uintN32, x => decode_encode_uintN32 x
   | _, .uintN64, x => decode_encode_uintN64 x
+  | _, .uintN128, x => decode_encode_uintN128 x
+  | _, .uintN256, x => decode_encode_uintN256 x
   | _, .bool, b => decode_encode_bool b
   | _, .vectorFixed (t := t) (n := n) h_pos h_t h_t_fixed, v =>
       decode_encode_vectorFixed t n h_pos h_t h_t_fixed

--- a/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
@@ -3,6 +3,7 @@ import SizzLean.Spec.BasicSupported
 import SizzLean.Spec.MaxByteLength
 import SizzLean.Proofs.SimpAttrs
 import SizzLean.Proofs.BitPack
+import SizzLean.Proofs.UIntWide
 
 /-!
 # `SizzLean.Proofs.SerializeSize`: the shared size-prereq lemma
@@ -103,6 +104,16 @@ theorem size_serialize_eq_fixedByteSize :
     show (SSZType.serialize (.uintN 64) x').size = SSZType.fixedByteSize (.uintN 64)
     simp [SSZType.serialize, SSZType.fixedByteSize, uint64LE,
           ByteArray.size_push, ByteArray.size_empty]
+  | uintN128 =>
+    let x' : BitVec 128 := x
+    show (SSZType.serialize (.uintN 128) x').size = SSZType.fixedByteSize (.uintN 128)
+    rw [size_serialize_uintN128]
+    simp [SSZType.fixedByteSize]
+  | uintN256 =>
+    let x' : BitVec 256 := x
+    show (SSZType.serialize (.uintN 256) x').size = SSZType.fixedByteSize (.uintN 256)
+    rw [size_serialize_uintN256]
+    simp [SSZType.fixedByteSize]
   | bool =>
     let b : Bool := x
     show (SSZType.serialize .bool b).size = SSZType.fixedByteSize .bool

--- a/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
@@ -4,6 +4,7 @@ import SizzLean.Spec.BasicSupported
 import SizzLean.Proofs.SimpAttrs
 import SizzLean.Proofs.SerializeSize
 import SizzLean.Proofs.UInt
+import SizzLean.Proofs.UIntWide
 import SizzLean.Proofs.Bool
 import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
@@ -45,6 +46,8 @@ theorem encode_size_le_max : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .uintN16, x => encode_size_le_max_uintN16 x
   | _, .uintN32, x => encode_size_le_max_uintN32 x
   | _, .uintN64, x => encode_size_le_max_uintN64 x
+  | _, .uintN128, x => encode_size_le_max_uintN128 x
+  | _, .uintN256, x => encode_size_le_max_uintN256 x
   | _, .bool, b => encode_size_le_max_bool b
   | _, .vectorFixed (t := t) (n := n) h_pos h_t h_t_fixed, v =>
       encode_size_le_max_vectorFixed t n h_pos h_t h_t_fixed

--- a/packages/SizzLean/SizzLean/Proofs/UIntWide.lean
+++ b/packages/SizzLean/SizzLean/Proofs/UIntWide.lean
@@ -1,0 +1,287 @@
+import SizzLean.Spec.Serialize
+import SizzLean.Spec.Deserialize
+import SizzLean.Spec.Supported
+import SizzLean.Spec.BasicSupported
+import SizzLean.Spec.MaxByteLength
+import SizzLean.Proofs.SimpAttrs
+
+/-!
+# `SizzLean.Proofs.UIntWide`: `decode_encode` and size bound for `uintN 128 / 256`
+
+The four narrow integer widths (`uintN 8/16/32/64`, in
+`Proofs/UInt.lean`) serialise through fully-unrolled fixed-width
+LE writers/readers (`uint16LE`, `readUInt16LE`, …) and close by
+`bv_decide`, which bit-blasts the residual `UInt N` identity and
+adds one `Lean.ofReduceBool` axiom per arm.
+
+The two wide widths take a different route. Their `interp` is
+`BitVec 128` / `BitVec 256`, and the codec passes through the
+`Nat`-based helpers `natToLEBytes` (encode, `Spec/Serialize.lean`)
+and `readNatLE` / `readNatLEAux` (decode, `Spec/Deserialize.lean`),
+which recurse on the *width* rather than unrolling. So the natural
+proof is a `Nat` induction on the little-endian digit expansion,
+
+  `readNatLE (natToLEBytes w n .empty) 0 w = some (n % 256 ^ w)`,
+
+and it closes with **no `bv_decide` / `native_decide`**: the only
+axioms are the three standard kernel ones. The wide-integer arms
+are therefore axiom-cleaner than the narrow ones.
+
+## Lemma path
+
+1. **Codec size** (`size_natToLEBytes`): `natToLEBytes` appends
+   exactly `w` bytes to its accumulator.
+2. **Byte characterisation** (`get!_natToLEBytes`): byte `i` of
+   `natToLEBytes w n acc` (past the accumulator) is the `i`-th
+   little-endian digit `⌊n / 256ⁱ⌋ mod 256`. Proved by induction
+   on `w`, threading `acc` and reading `push` back through
+   `Array.getElem_push_{lt,eq}`.
+3. **Reader value** (`readNatLEAux_value`): folding the Horner
+   reader over any buffer whose bytes are the digits of `n`
+   rebuilds `n mod 256 ^ w`. One induction on `w` with the
+   accumulator universally generalised; the digit step is
+   `Nat.mod_mul` (`x % (a·b) = x % a + a · (x / a % b)`).
+4. **Codec inverse** (`readNatLE_natToLEBytes`): compose 1–3.
+5. **Arm closure**: `decode_encode_uintN128 / 256`,
+   `size_serialize_uintN{128,256}`, and the two
+   `encode_size_le_max_*` bounds. `Proofs/{Roundtrip,SizeBound,
+   SerializeSize}.lean` dispatch to these.
+
+## Lean idioms used here (annotated on first appearance)
+
+* `ByteArray.get!`: total indexing (`0` on out-of-range). The
+  characterisation lemmas state their facts in `get!` form to
+  avoid carrying bounds proofs; `get!_eq_getElem` bridges to the
+  bounds-checked `b[i]'h` that `readNatLEAux` uses, exactly where
+  the fold needs a concrete byte.
+* `dif_pos h`: reduce a `if h : p then … else …` (dependent-if)
+  along the `p`-true branch, given `h : p`. `readNatLEAux`'s
+  recursion is guarded by `if h : off + k < b.size`, always true
+  under our size hypotheses.
+* Nonlinear `Nat` arithmetic (`a·256ⁿ` terms) is finished by
+  `omega` *after* every nonlinear product is turned into an atom
+  by explicit `Nat.mul_assoc` / `Nat.mul_comm` rewrites; `omega`
+  itself treats each maximal product as an opaque variable.
+-/
+
+set_option autoImplicit false
+-- `decide` on `256 ^ 16 = 2 ^ 128` (and the 256-bit twin) reduces
+-- 39-digit `Nat` literals in the kernel; give the elaborator room.
+set_option maxHeartbeats 2000000
+
+namespace SizzLean.Proofs
+
+open SizzLean.Spec
+-- `natToLEBytes` / `readNatLE` / `readNatLEAux` are `protected` in
+-- `Spec/{Serialize,Deserialize}.lean` (proof-internal, kept off the
+-- general `SizzLean.Spec` surface), so the wildcard `open` above does
+-- not bring them into scope; request the three helpers explicitly.
+open SizzLean.Spec (natToLEBytes readNatLE readNatLEAux)
+
+/-! ### ByteArray indexing bridges
+
+`get!` (total) is convenient for stating byte facts without bounds
+proofs; the reader fold uses the bounds-checked `b[i]'h`. These three
+bridge the two forms and read a pushed byte back. -/
+
+/-- `get!` agrees with the bounds-checked `b[i]` when in range.
+`get!` unfolds to `b.data[i]!`, whose panic branch is discharged by
+`getElem!_pos` against the supplied bound. -/
+theorem get!_eq_getElem (b : ByteArray) (i : Nat) (h : i < b.size) :
+    b.get! i = b[i] := by
+  show b.data[i]! = b[i]
+  rw [ByteArray.getElem_eq_getElem_data]
+  exact getElem!_pos b.data i h
+
+/-- Reading a pushed byte below the push point ignores it. -/
+theorem get!_push_lt (a : ByteArray) (b : UInt8) (i : Nat) (h : i < a.size) :
+    (a.push b).get! i = a.get! i := by
+  rw [get!_eq_getElem _ _ (by rw [ByteArray.size_push]; omega), get!_eq_getElem _ _ h]
+  simp only [ByteArray.getElem_eq_getElem_data, ByteArray.data_push]
+  exact Array.getElem_push_lt h
+
+/-- Reading the pushed byte at the push point returns it. -/
+theorem get!_push_eq (a : ByteArray) (b : UInt8) :
+    (a.push b).get! a.size = b := by
+  rw [get!_eq_getElem _ _ (by rw [ByteArray.size_push]; omega)]
+  simp only [ByteArray.getElem_eq_getElem_data, ByteArray.data_push]
+  exact Array.getElem_push_eq
+
+/-! ### The little-endian byte codec -/
+
+/-- `natToLEBytes` appends exactly `width` bytes to its accumulator. -/
+theorem size_natToLEBytes (w : Nat) : ∀ (n : Nat) (acc : ByteArray),
+    (natToLEBytes w n acc).size = acc.size + w := by
+  induction w with
+  | zero => intro n acc; simp [natToLEBytes]
+  | succ k ih =>
+      intro n acc
+      show (natToLEBytes (k + 1) n acc).size = acc.size + (k + 1)
+      simp only [natToLEBytes]
+      rw [ih (n / 256) (acc.push (Nat.toUInt8 (n % 256))), ByteArray.size_push]
+      omega
+
+/-- Byte `i` of `natToLEBytes w n acc`: bytes below `acc.size` are
+the accumulator's; the `j`-th appended byte (`j = i - acc.size`) is
+the `j`-th little-endian digit `⌊n / 256ʲ⌋ mod 256`. Induct on `w`,
+threading `acc`; a `push` step splits into "below / at / above" the
+push point. -/
+theorem get!_natToLEBytes (w : Nat) : ∀ (n : Nat) (acc : ByteArray) (i : Nat),
+    i < acc.size + w →
+    (natToLEBytes w n acc).get! i =
+      if i < acc.size then acc.get! i
+      else Nat.toUInt8 ((n / 256 ^ (i - acc.size)) % 256) := by
+  induction w with
+  | zero =>
+      intro n acc i hi
+      simp only [Nat.add_zero] at hi
+      simp only [natToLEBytes, if_pos hi]
+  | succ k ih =>
+      intro n acc i hi
+      show (natToLEBytes (k + 1) n acc).get! i = _
+      simp only [natToLEBytes]
+      have hsz : (acc.push (Nat.toUInt8 (n % 256))).size = acc.size + 1 :=
+        ByteArray.size_push
+      rw [ih (n / 256) (acc.push (Nat.toUInt8 (n % 256))) i (by rw [hsz]; omega), hsz]
+      by_cases h1 : i < acc.size
+      · rw [if_pos (by omega : i < acc.size + 1), if_pos h1, get!_push_lt _ _ _ h1]
+      · by_cases h2 : i = acc.size
+        · subst h2
+          rw [if_pos (Nat.lt_succ_self acc.size), if_neg (Nat.lt_irrefl acc.size),
+              get!_push_eq]
+          simp [Nat.sub_self]
+        · rw [if_neg (by omega : ¬ i < acc.size + 1), if_neg h1]
+          have hk : i - acc.size = (i - (acc.size + 1)) + 1 := by omega
+          have hexp : (n / 256) / 256 ^ (i - (acc.size + 1)) = n / 256 ^ (i - acc.size) := by
+            rw [Nat.div_div_eq_div_mul, hk, Nat.pow_succ,
+                Nat.mul_comm (256 ^ (i - (acc.size + 1))) 256]
+          rw [hexp]
+
+/-- Specialisation to the `.empty` accumulator: byte `i` of
+`natToLEBytes w n .empty` is the `i`-th little-endian digit. -/
+theorem get!_natToLEBytes_empty (w n i : Nat) (hi : i < w) :
+    (natToLEBytes w n .empty).get! i = Nat.toUInt8 ((n / 256 ^ i) % 256) := by
+  rw [get!_natToLEBytes w n .empty i (by rw [ByteArray.size_empty]; omega),
+      ByteArray.size_empty, if_neg (Nat.not_lt_zero i), Nat.sub_zero]
+
+/-! ### The Horner reader -/
+
+/-- Folding the Horner reader over any buffer whose byte `off + i`
+is the `i`-th little-endian digit of `n` rebuilds `n mod 256 ^ w`,
+with the accumulator scaled by `256 ^ w`. Induction on `w` with
+`acc` universally generalised: the top byte contributes
+`digit · 256 ^ w`, the recursive tail rebuilds `n mod 256 ^ w`, and
+`Nat.mod_mul` splits `n mod 256 ^ (w+1)` into exactly those two
+pieces. -/
+theorem readNatLEAux_value (b : ByteArray) (off n : Nat) : ∀ (w : Nat),
+    (∀ i, i < w → off + i < b.size) →
+    (∀ i, i < w → (b.get! (off + i)).toNat = (n / 256 ^ i) % 256) →
+    ∀ (acc : Nat), readNatLEAux b off w acc = acc * 256 ^ w + n % 256 ^ w := by
+  intro w
+  induction w with
+  | zero => intro _ _ acc; simp [readNatLEAux, Nat.mod_one]
+  | succ w ih =>
+      intro hlt hval acc
+      have hw_lt : off + w < b.size := hlt w (Nat.lt_succ_self w)
+      have hstep : readNatLEAux b off (w + 1) acc =
+          readNatLEAux b off w (acc * 256 + (b[off + w]'hw_lt).toNat) := by
+        simp only [readNatLEAux]
+        rw [dif_pos hw_lt]
+      have hbridge : (b[off + w]'hw_lt).toNat = (n / 256 ^ w) % 256 := by
+        rw [← get!_eq_getElem b (off + w) hw_lt]
+        exact hval w (Nat.lt_succ_self w)
+      have hlt' : ∀ i, i < w → off + i < b.size :=
+        fun i hi => hlt i (Nat.lt_succ_of_lt hi)
+      have hval' : ∀ i, i < w → (b.get! (off + i)).toNat = (n / 256 ^ i) % 256 :=
+        fun i hi => hval i (Nat.lt_succ_of_lt hi)
+      rw [hstep, hbridge, ih hlt' hval' (acc * 256 + (n / 256 ^ w) % 256)]
+      -- Digit step: n % 256^(w+1) = n % 256^w + 256^w · (n / 256^w % 256).
+      have hmod : n % 256 ^ (w + 1) = n % 256 ^ w + 256 ^ w * ((n / 256 ^ w) % 256) := by
+        rw [Nat.pow_succ, Nat.mod_mul]
+      rw [hmod, Nat.pow_succ]
+      -- Turn every nonlinear product into an atom, then `omega`.
+      generalize hp : 256 ^ w = p
+      rw [Nat.add_mul, Nat.mul_assoc, Nat.mul_comm 256 p, Nat.mul_comm ((n / p) % 256) p]
+      omega
+
+/-- **Codec inverse**: reading `w` little-endian bytes back off the
+`w`-byte encoding of `n` returns `n mod 256 ^ w`. The buffer has
+size exactly `w` (so the `off + width > size` guard is false), and
+its bytes are the digits of `n` (`get!_natToLEBytes_empty`), so
+`readNatLEAux_value` at `acc = 0` closes it. -/
+theorem readNatLE_natToLEBytes (w n : Nat) :
+    readNatLE (natToLEBytes w n .empty) 0 w = some (n % 256 ^ w) := by
+  have hsize : (natToLEBytes w n .empty).size = w := by
+    rw [size_natToLEBytes]; simp [ByteArray.size_empty]
+  unfold readNatLE
+  rw [if_neg (by rw [hsize]; omega)]
+  have hval := readNatLEAux_value (natToLEBytes w n .empty) 0 n w
+    (fun i hi => by rw [hsize]; omega)
+    (fun i hi => by
+      rw [Nat.zero_add, get!_natToLEBytes_empty w n i hi]
+      exact UInt8.toNat_ofNat_of_lt' (Nat.mod_lt _ (by decide)))
+    0
+  rw [hval]
+  simp
+
+/-! ### uintN 128 / 256 arms -/
+
+/-- Exact serialized size of a `uintN 128`: 16 bytes. -/
+theorem size_serialize_uintN128 (x : BitVec 128) :
+    (SSZType.serialize (.uintN 128) x).size = 16 := by
+  have h_ser : SSZType.serialize (.uintN 128) x = natToLEBytes 16 x.toNat .empty := by
+    unfold SSZType.serialize; rfl
+  rw [h_ser, size_natToLEBytes]
+  simp [ByteArray.size_empty]
+
+/-- Exact serialized size of a `uintN 256`: 32 bytes. -/
+theorem size_serialize_uintN256 (x : BitVec 256) :
+    (SSZType.serialize (.uintN 256) x).size = 32 := by
+  have h_ser : SSZType.serialize (.uintN 256) x = natToLEBytes 32 x.toNat .empty := by
+    unfold SSZType.serialize; rfl
+  rw [h_ser, size_natToLEBytes]
+  simp [ByteArray.size_empty]
+
+/-- Roundtrip for `.uintN 128`. The encoder emits 16 LE bytes of
+`x.toNat`; the decoder reads them back as `x.toNat mod 256^16`, and
+`256^16 = 2^128` with `x.toNat < 2^128` collapses the modulus, so
+`BitVec.ofNat 128 x.toNat = x`. No `bv_decide`. -/
+theorem decode_encode_uintN128 (x : BitVec 128) :
+    SSZType.deserialize (.uintN 128) (SSZType.serialize (.uintN 128) x) =
+      .ok (x, (SSZType.serialize (.uintN 128) x).size) := by
+  have h_ser : SSZType.serialize (.uintN 128) x = natToLEBytes 16 x.toNat .empty := by
+    unfold SSZType.serialize; rfl
+  rw [size_serialize_uintN128, h_ser]
+  unfold SSZType.deserialize
+  simp only [readNatLE_natToLEBytes]
+  have h256 : (256 : Nat) ^ 16 = 2 ^ 128 := by decide
+  rw [h256, Nat.mod_eq_of_lt x.isLt, BitVec.ofNat_toNat, BitVec.setWidth_eq]
+
+/-- Roundtrip for `.uintN 256`. Identical recipe with 32 bytes and
+`256^32 = 2^256`. -/
+theorem decode_encode_uintN256 (x : BitVec 256) :
+    SSZType.deserialize (.uintN 256) (SSZType.serialize (.uintN 256) x) =
+      .ok (x, (SSZType.serialize (.uintN 256) x).size) := by
+  have h_ser : SSZType.serialize (.uintN 256) x = natToLEBytes 32 x.toNat .empty := by
+    unfold SSZType.serialize; rfl
+  rw [size_serialize_uintN256, h_ser]
+  unfold SSZType.deserialize
+  simp only [readNatLE_natToLEBytes]
+  have h256 : (256 : Nat) ^ 32 = 2 ^ 256 := by decide
+  rw [h256, Nat.mod_eq_of_lt x.isLt, BitVec.ofNat_toNat, BitVec.setWidth_eq]
+
+/-- Size bound for `.uintN 128`: serialized size `16` equals the
+schema bound `⌈128/8⌉`. -/
+theorem encode_size_le_max_uintN128 (x : BitVec 128) :
+    (SSZType.serialize (.uintN 128) x).size ≤ SSZType.maxByteLength (.uintN 128) := by
+  rw [size_serialize_uintN128]
+  simp [SSZType.maxByteLength]
+
+/-- Size bound for `.uintN 256`: serialized size `32` equals the
+schema bound `⌈256/8⌉`. -/
+theorem encode_size_le_max_uintN256 (x : BitVec 256) :
+    (SSZType.serialize (.uintN 256) x).size ≤ SSZType.maxByteLength (.uintN 256) := by
+  rw [size_serialize_uintN256]
+  simp [SSZType.maxByteLength]
+
+end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Repr/Class.lean
+++ b/packages/SizzLean/SizzLean/Repr/Class.lean
@@ -39,7 +39,9 @@ are then thin wrappers; `SSZ.roundtrip` lifts the spec-side
 The library's `decode_encode` proof currently covers the
 `BasicSupported` subset:
 
-* `.uintN 8 / 16 / 32 / 64`, `.bool`: basic primitives.
+* `.uintN 8 / 16 / 32 / 64` and `.uintN 128 / 256`, `.bool`:
+  basic primitives (the wide integers close by the `Nat`-digit
+  codec proof in `Proofs/UIntWide.lean`).
 * `.vector t n` / `.list t cap` / `.container fs`: general
   composites over fixed-size element / field types
   (`BasicSupported t` with `t.isFixedSize = true`).

--- a/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
+++ b/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
@@ -20,7 +20,10 @@ Proofs/ reaches over to discharge the theorems).
 ## Coverage
 
 * **Basic integers**: `.uintN 8 / 16 / 32 / 64` (closed in
-  `Proofs/UInt.lean` via `unfold` + `bv_decide`).
+  `Proofs/UInt.lean` via `unfold` + `bv_decide`) and
+  `.uintN 128 / 256` (closed in `Proofs/UIntWide.lean` by
+  `Nat`-digit induction on the `natToLEBytes` / `readNatLE` codec,
+  with no `bv_decide` axiom).
 * **Bool**: `.bool` (closed by `cases`, in `Proofs/Bool.lean`).
 * **Composites**: `.vector t n` / `.list t cap` /
   `.container fs` over fixed-size element / field types
@@ -80,6 +83,15 @@ inductive SSZType.BasicSupported : SSZType → Prop
   | uintN32 : SSZType.BasicSupported (.uintN 32)
   /-- 64-bit little-endian unsigned integer. -/
   | uintN64 : SSZType.BasicSupported (.uintN 64)
+  /-- 128-bit little-endian unsigned integer. Unlike the narrow
+  widths, the roundtrip closes by `Nat`-digit induction on the
+  `natToLEBytes` / `readNatLE` codec (`Proofs/UIntWide.lean`), with
+  no `bv_decide` axiom. -/
+  | uintN128 : SSZType.BasicSupported (.uintN 128)
+  /-- 256-bit little-endian unsigned integer (e.g.
+  `ExecutionPayload.base_fee_per_gas`). Same codec proof as
+  `uintN128`. -/
+  | uintN256 : SSZType.BasicSupported (.uintN 256)
   /-- `Bool`, single-byte 0/1. -/
   | bool : SSZType.BasicSupported .bool
   /-- Fixed-length vector with fixed-size element type and

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -94,6 +94,27 @@ def readUInt64LE (b : ByteArray) (off : Nat) : Option UInt64 :=
           (g 7 (by omega) <<< 56))
   else .none
 
+/-- Horner fold behind `readNatLE`: read bytes `b[off + k - 1] …
+b[off + 0]` most-significant-first into `acc`. Structurally
+recursive on `k`. Lifted out of `readNatLE` as a top-level
+definition (rather than an inner `let rec`) so the `uintN 128 /
+256` roundtrip proof in `Proofs/UIntWide.lean` can reason about it
+through its own equation lemmas.
+
+`protected` for the same reason as `natToLEBytes`: proof-internal,
+reached only by the explicit `open` in the proof file, never by a
+bare `open SizzLean.Spec`. -/
+protected def readNatLEAux (b : ByteArray) (off : Nat) : (k acc : Nat) → Nat
+  | 0,     acc => acc
+  | k + 1, acc =>
+      -- Read `b[off + k]` (the byte with positional weight 256^k).
+      let idx := off + k
+      if h : idx < b.size then
+        SizzLean.Spec.readNatLEAux b off k (acc * 256 + (b[idx]'h).toNat)
+      else
+        -- guarded by `readNatLE`'s outer size check; defensive
+        acc * 256
+
 /-- Read `width` little-endian bytes from `b` starting at `off` as a
 `Nat`. Used for `uintN 128 / 256` widths where the value is stored
 as a `BitVec n`. Returns `none` if the buffer is too short.
@@ -102,21 +123,12 @@ Horner-style accumulation reading from the *most-significant* byte
 down to the *least-significant*: byte `b[off + width - 1]` is read
 first (folded into `acc`), then `b[off + width - 2]`, …, finally
 `b[off + 0]`. The recursion is structurally on `k = width`,
-counting down. -/
-private def readNatLE (b : ByteArray) (off width : Nat) : Option Nat :=
+counting down (see `readNatLEAux`).
+
+`protected` for the same reason as `readNatLEAux`. -/
+protected def readNatLE (b : ByteArray) (off width : Nat) : Option Nat :=
   if off + width > b.size then .none
-  else
-    let rec go : (k acc : Nat) → Nat
-      | 0,     acc => acc
-      | k + 1, acc =>
-          -- Read `b[off + k]` (the byte with positional weight 256^k).
-          let idx := off + k
-          if h : idx < b.size then
-            go k (acc * 256 + (b[idx]'h).toNat)
-          else
-            -- guarded by the outer size check; defensive
-            acc * 256
-    .some (go width 0)
+  else .some (SizzLean.Spec.readNatLEAux b off width 0)
 
 /-! ### Variable-size container helper: pre-extract field offsets
 
@@ -296,13 +308,13 @@ def SSZType.deserialize : (s : SSZType) → ByteArray → Except SSZError (s.int
       -- 16 little-endian bytes → `BitVec 128`. The `interp` arm for
       -- `.uintN n` (n ∉ {8,16,32,64}) reduces to `BitVec n`, so the
       -- `BitVec.ofNat 128 _` typechecks at `interp (.uintN 128)`.
-      match readNatLE b 0 16 with
+      match SizzLean.Spec.readNatLE b 0 16 with
       | .some n => .ok (BitVec.ofNat 128 n, 16)
       | .none   => .error .tooShort
   | .uintN 256, b =>
       -- 32 little-endian bytes → `BitVec 256`. Used by
       -- `ExecutionPayload.base_fee_per_gas` (Bellatrix+).
-      match readNatLE b 0 32 with
+      match SizzLean.Spec.readNatLE b 0 32 with
       | .some n => .ok (BitVec.ofNat 256 n, 32)
       | .none   => .error .tooShort
   | .uintN _,  _ => .error .tooShort -- non-spec uintN width (only {8,16,32,64,128,256} valid)

--- a/packages/SizzLean/SizzLean/Spec/Serialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Serialize.lean
@@ -191,14 +191,23 @@ def uint64LE (x : UInt64) : ByteArray :=
 
 /-- `Nat` → `width` little-endian bytes (truncating). Used for the
 `BitVec n`-backed fallback at `uintN` widths beyond 64 and for
-generic offset emission. Recurses structurally on `width`. -/
-private def natToLEBytes : (width : Nat) → (n : Nat) → ByteArray → ByteArray
+generic offset emission. Recurses structurally on `width`.
+
+`protected`: the Layer 2 roundtrip proof for the `uintN 128 / 256`
+arms in `Proofs/UIntWide.lean` reasons through this writer's
+per-byte recursion, so it must be reachable, but it is
+proof-internal, not part of the general `SizzLean.Spec` surface.
+`protected` keeps a bare `open SizzLean.Spec` from pulling it into
+scope; the proof file names it with an explicit
+`open SizzLean.Spec (natToLEBytes)`. -/
+protected def natToLEBytes : (width : Nat) → (n : Nat) → ByteArray → ByteArray
   | 0,     _, acc => acc
-  | k + 1, m, acc => natToLEBytes k (m / 256) (acc.push (Nat.toUInt8 (m % 256)))
+  | k + 1, m, acc =>
+      SizzLean.Spec.natToLEBytes k (m / 256) (acc.push (Nat.toUInt8 (m % 256)))
 
 /-- `BitVec n` → `⌈n/8⌉` little-endian bytes. -/
 private def bitvecToLE (n : Nat) (b : BitVec n) : ByteArray :=
-  natToLEBytes ((n + 7) / 8) b.toNat .empty
+  SizzLean.Spec.natToLEBytes ((n + 7) / 8) b.toNat .empty
 
 /-! ### Bit packing (LSB-first within each byte)
 
@@ -286,11 +295,11 @@ def SSZType.serialize : (s : SSZType) → s.interp → ByteArray
       -- `interp` in `Spec/Interp.lean`). Force the defeq via `let`
       -- so the typeclass machinery sees `BitVec 128` for `.toNat`.
       let x' : BitVec 128 := x
-      natToLEBytes 16 x'.toNat .empty
+      SizzLean.Spec.natToLEBytes 16 x'.toNat .empty
   | .uintN 256,           x  =>
       -- Used by `ExecutionPayload.base_fee_per_gas` (Bellatrix+).
       let x' : BitVec 256 := x
-      natToLEBytes 32 x'.toNat .empty
+      SizzLean.Spec.natToLEBytes 32 x'.toNat .empty
   | .uintN _,             _  =>
       -- Non-spec `uintN` widths (only {8,16,32,64,128,256} valid).
       -- Returning `.empty` keeps `serialize` total.

--- a/packages/SizzLean/SizzLeanTests/ReprExamples.lean
+++ b/packages/SizzLean/SizzLeanTests/ReprExamples.lean
@@ -121,6 +121,21 @@ example (x : UInt32) : SSZ.deserialize (SSZ.serialize x) = .ok x :=
 example (x : UInt64) : SSZ.deserialize (SSZ.serialize x) = .ok x :=
   SSZ.roundtrip .uintN64 x
 
+/-! ### Wide integer arm examples: `uintN 128` and `uintN 256`
+
+The `SSZRepr (BitVec 128)` / `(BitVec 256)` instances
+(`Repr/Instances.lean`) pin the two spec-only widths at shapes
+`.uintN 128` / `.uintN 256` with identity isos. These gates
+compile only if `decode_encode` discharges the wide arms
+(`Proofs/UIntWide.lean`) through the user surface, and, unlike the
+narrow arms, they carry no `bv_decide` axiom. -/
+
+example (x : BitVec 128) : SSZ.deserialize (SSZ.serialize x) = .ok x :=
+  SSZ.roundtrip .uintN128 x
+
+example (x : BitVec 256) : SSZ.deserialize (SSZ.serialize x) = .ok x :=
+  SSZ.roundtrip .uintN256 x
+
 /-! ### Composite arm examples
 
 `BasicSupported` also covers general `vectorFixed`, `listFixed`,
@@ -208,5 +223,17 @@ example (vs : SSZType.interpFields [.uintN 8, .bitvector 10]) :
   decode_encode (.containerFixed
                   (.cons .uintN8 rfl
                     (.cons (.bitvector (by decide)) rfl .nil))) vs
+
+/-- A container carrying a `uint256` field alongside a `uint64`,
+the `ExecutionPayload`-style layout that motivated the wide-integer
+arms: `.uintN 256` is fixed-size, so it qualifies under
+`BasicSupportedFieldsFixed`. -/
+example (vs : SSZType.interpFields [.uintN 64, .uintN 256]) :
+    SSZType.deserialize (.container [.uintN 64, .uintN 256])
+        (SSZType.serialize (.container [.uintN 64, .uintN 256]) vs) =
+      Except.ok (vs, (SSZType.serialize (.container [.uintN 64, .uintN 256]) vs).size) :=
+  decode_encode (.containerFixed
+                  (.cons .uintN64 rfl
+                    (.cons .uintN256 rfl .nil))) vs
 
 end SizzLeanTests.ReprExamples

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -118,9 +118,11 @@ the pyspec `ethereum/consensus-spec-tests` release vectors;
 Phase 4 built the performance layer on top of the now-known-good
 library; **Phase 5 (Stage 18) widens the three theorems** toward
 universal `Supported` coverage. As of this writing
-`BasicSupported` covers `uintN 8/16/32/64`, `bool`, fixed-size
-`vector` and `list`, `bitvector`, `bitlist` (both via the
-bit-packing inverse in `Proofs/BitPack.lean`), and `container`
+`BasicSupported` covers `uintN 8/16/32/64` and `uintN 128/256`
+(the wide arms via the `Nat`-digit codec proof in
+`Proofs/UIntWide.lean`, with no `bv_decide` axiom), `bool`,
+fixed-size `vector` and `list`, `bitvector`, `bitlist` (both via
+the bit-packing inverse in `Proofs/BitPack.lean`), and `container`
 over fixed-size fields (recursively). See
 `Spec/BasicSupported.lean` and the README's *Proof coverage*
 table. Mixed-field containers remain open; the `SSZ.roundtrip`
@@ -1465,7 +1467,7 @@ plans as to the document itself.
 | **2: User surface** | Layer 3 (`SSZRepr` + deriving handler) and the Day-1 `FFI/Sha256` `@[extern] opaque` instance. | FFI/Sha256 has no dependency on the verification frontier. SHA-256 is opaque from Day 1; its NIST-conformance assertion is in the TCB. The `SSZ.roundtrip` user-surface corollary is gated by `BasicSupported r.shape` until Stage 18 widens it. The cached Merkle-tree work (Layer 4) has moved to Phase 4. |
 | **3: Application + empirical validation** | Layer 5 (Eth types) + `SizzLeanTests/Sha256Vectors` (consumes `ethereum/consensus-spec-tests` release vectors). | Conformance runs against the verified spec functions (`SSZ.hashTreeRoot` from Layer 1, uncached). This is the empirical safety net for both the verified and asserted-equivalent paths, and the gating signal for both Phase 4 (performance) and Phase 5 (proofs): passing here is what makes either investment well-targeted. |
 | **4: Production primitives + deferred hardening** | Layer 4 (`Tree`, `TreeBacked`, the cached Merkle layer); pure-Lean `Hasher/Sha256Spec.lean` + `@[csimp]` (removes the FFI assertion from TCB); performance work (`ViewDU`-style deferred-update overlay, batched SHA-256, hash-consing). | All stages independent and order-agnostic among themselves. The cache layer lands here (not Phase 2) because it's a *performance* layer asserted equivalent to the spec; deferring it past empirical validation means its property tests have a known-good reference oracle (the spec, validated in Phase 3). The Approach C `profile%` macro is not on the plan; see §8 for the rationale (no fork through Gloas uses EIP-7495 / EIP-7916 / EIP-8016 forms). |
-| **5: Complete formal verification** | **Stage 18: widen `BasicSupported` toward `SSZType.Supported` / `SupportedBounded`, closing `decode_encode`, `serialize_injective`, `encode_size_le_max` arm by arm.** Currently closed: `uintN 8/16/32/64`, `bool`, fixed-size `vector` and `list`, and `container` over fixed-size fields (recursively). Open: `bitvector`, `bitlist`, mixed-field containers. | Positioned last by design: empirical conformance from Phase 3 ensures the proof effort targets a known-correct implementation, not a speculative one. The publishable non-malleability artefact lands when the remaining arms close. |
+| **5: Complete formal verification** | **Stage 18: widen `BasicSupported` toward `SSZType.Supported` / `SupportedBounded`, closing `decode_encode`, `serialize_injective`, `encode_size_le_max` arm by arm.** Currently closed: `uintN 8/16/32/64/128/256`, `bool`, fixed-size `vector` and `list`, `bitvector`, `bitlist`, and `container` over fixed-size fields (recursively). Open: mixed-field containers. | Positioned last by design: empirical conformance from Phase 3 ensures the proof effort targets a known-correct implementation, not a speculative one. The publishable non-malleability artefact lands when the remaining arms close. |
 
 The single highest-risk implementation item is gindex arithmetic in
 `Node.setAt`. Mitigation: structural recursion on an explicit `List Bool`

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1401,6 +1401,7 @@ Replaces the Stage 5–6 first-cut theorems on `BasicSupported`.
 | Arm | Status | Proof file |
 |---|---|---|
 | `.uintN 8 / 16 / 32 / 64` | ✅ | `Proofs/UInt.lean` |
+| `.uintN 128 / 256` | ✅ | `Proofs/UIntWide.lean` (`Nat`-digit codec inverse; no `bv_decide` axiom) |
 | `.bool` | ✅ | `Proofs/Bool.lean` |
 | `.vector t n` (general, `0 < n`, fixed-size `t`) | ✅ | `Proofs/VectorFixed.lean` |
 | `.list t cap` (general, fixed-size `t`, `0 < t.fixedByteSize`) | ✅ | `Proofs/ListFixed.lean` |


### PR DESCRIPTION
## Summary

Closes #17. Extends the three central theorems (`decode_encode`, `serialize_injective`, `encode_size_le_max`) to the two remaining SSZ basic integer widths, **`uintN 128`** and **`uintN 256`**, filling the last gap in the basic-integer row of the proof-coverage table. `uint256` backs `ExecutionPayload.base_fee_per_gas` (Bellatrix onward); `uint128` appears in several spec containers.

Follow-up to #10 (bit shapes).

## Approach: a different, axiom-cleaner proof than the narrow arms

The `uintN 8/16/32/64` arms (`Proofs/UInt.lean`) serialize through fully-unrolled fixed-width LE writers/readers and close by `bv_decide`, which adds one `Lean.ofReduceBool` SAT-certificate axiom per arm.

The wide widths take the `Nat`-based `natToLEBytes` (encode) / `readNatLE` (decode) codec, which recurses on the width rather than unrolling. So the natural proof is a `Nat`-digit induction on the little-endian expansion:

```
readNatLE (natToLEBytes w n .empty) 0 w = some (n % 256 ^ w)
```

The digit step is `Nat.mod_mul` (`x % (a·b) = x % a + a·(x/a % b)`). This uses **no `bv_decide` / `native_decide`**, so the wide arms add **no axioms** beyond the standard kernel three (`propext`, `Classical.choice`, `Quot.sound`), verified by `#print axioms`:

```
'decode_encode_uintN128' depends on axioms: [propext, Classical.choice, Quot.sound]
'decode_encode_uintN256' depends on axioms: [propext, Classical.choice, Quot.sound]
'encode_size_le_max_uintN128' depends on axioms: [propext, Quot.sound]
```

## Changes

- **New `Proofs/UIntWide.lean`**: the codec-inverse lemma chain (`size_natToLEBytes`, `get!_natToLEBytes`, `readNatLEAux_value`, `readNatLE_natToLEBytes`) plus the four arm lemmas.
- **`Spec/BasicSupported.lean`**: new `uintN128` / `uintN256` constructors.
- **Dispatchers**: `decode_encode` (`Roundtrip.lean`), `encode_size_le_max` (`SizeBound.lean`), and `size_serialize_eq_fixedByteSize` (`SerializeSize.lean`) gain the two arms; `serialize_injective` inherits automatically.
- **Visibility** (following the convention set in #10's review): `natToLEBytes` / `readNatLE` are now `protected` (was `private`), and the inner `readNatLE.go` `let rec` is lifted to a top-level `readNatLEAux` so the proof can reason about it through its own equation lemmas and name the three helpers via an explicit `open SizzLean.Spec (…)`. Behaviour is unchanged.
- **Acceptance gates** (`SizzLeanTests/ReprExamples.lean`): user-surface roundtrips for `BitVec 128` / `BitVec 256`, and a spec-level container carrying a `uint256` field.
- **Docs**: README proof-coverage table + footnote, `docs/ARCHITECTURE.md`, `docs/PLAN.md` Stage 18 table, and the `BasicSupported` / `Repr/Class.lean` docstrings.

## Test plan

- [x] `lake build SizzLean` green.
- [x] `lake build SizzLeanTests` green (acceptance `example` gates for `uintN 128`, `uintN 256`, and a `uint256`-field container).
- [x] Axiom audit: the wide arms and `readNatLE_natToLEBytes` depend on only the three standard kernel axioms; no new `bv_decide`/`native_decide` footprint.