### PR TITLE
fix(sizzlean): add the wide uintN widths to Supported and machine-check the subset claim

### DIFF
--- a/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
+++ b/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
@@ -1,5 +1,6 @@
 import SizzLean.Spec.Type
 import SizzLean.Spec.Serialize  -- for isFixedSize / allFixedSize
+import SizzLean.Spec.Supported  -- for the subset theorem below
 
 /-!
 # `SizzLean.Spec.BasicSupported`: the predicate the proof set grows over
@@ -9,7 +10,11 @@ that the three central theorems (`decode_encode`,
 `serialize_injective`, `encode_size_le_max`) are proved for. Each
 constructor here names an `SSZType` shape on which the proofs
 close exhaustively; adding a constructor obliges the proofs to
-extend.
+extend. The subset relation is machine-checked by
+`supported_of_basicSupported` at the bottom of this file, so the
+two predicates cannot drift apart silently (adding a
+`BasicSupported` constructor without its `Supported` counterpart
+breaks the build).
 
 The predicate lives in `Spec/` (not `Proofs/`) because the
 user-facing `SSZ.roundtrip` corollary in `Repr/Class.lean`
@@ -134,5 +139,66 @@ inductive SSZType.BasicSupportedFieldsFixed : List SSZType → Prop
            SSZType.BasicSupportedFieldsFixed ts →
            SSZType.BasicSupportedFieldsFixed (t :: ts)
 end
+
+/-! ### The subset relation, machine-checked
+
+The module docstring's claim that `BasicSupported` is a subset of
+`Supported` used to be prose only, and it silently broke when the
+`uintN 128 / 256` constructors landed on `BasicSupported` before
+`Supported` knew about the wide widths. The mutual theorem below
+turns the claim into a build-enforced invariant: each
+`BasicSupported` constructor maps to its `Supported` counterpart,
+dropping the proof-only preconditions (`0 < n` on `vectorFixed` /
+`bitvector`, `0 < t.fixedByteSize` on `listFixed`) that
+`BasicSupported` carries and `Supported` does not. -/
+
+mutual
+
+/-- Every `BasicSupported` shape is `Supported`: the proof-coverage
+predicate never claims a shape the codec does not implement.
+Structural recursion over the `(BasicSupported,
+BasicSupportedFieldsFixed)` inductive pair, mirroring the mutual
+blocks in `Proofs/Roundtrip.lean`. -/
+theorem SSZType.supported_of_basicSupported : ∀ {s : SSZType},
+    SSZType.BasicSupported s → SSZType.Supported s
+  | _, .uintN8 => .uintN8
+  | _, .uintN16 => .uintN16
+  | _, .uintN32 => .uintN32
+  | _, .uintN64 => .uintN64
+  | _, .uintN128 => .uintN128
+  | _, .uintN256 => .uintN256
+  | _, .bool => .bool
+  | _, .vectorFixed _h_pos h_t h_t_fixed =>
+      .vectorFixed (SSZType.supported_of_basicSupported h_t) h_t_fixed
+  | _, .listFixed h_t h_t_fixed _h_sz_pos =>
+      .listFixed (SSZType.supported_of_basicSupported h_t) h_t_fixed
+  | _, .bitvector _h_pos => .bitvector
+  | _, .bitlist => .bitlist
+  | _, .containerFixed h_fs =>
+      .containerFixed (SSZType.supportedFieldsFixed_of_basicSupportedFieldsFixed h_fs)
+
+/-- Field-list companion: pointwise lift of
+`supported_of_basicSupported` over a container's field list. -/
+theorem SSZType.supportedFieldsFixed_of_basicSupportedFieldsFixed :
+    ∀ {fs : List SSZType},
+    SSZType.BasicSupportedFieldsFixed fs → SSZType.SupportedFieldsFixed fs
+  | _, .nil => .nil
+  | _, .cons h_t h_t_fixed h_ts =>
+      .cons (SSZType.supported_of_basicSupported h_t) h_t_fixed
+        (SSZType.supportedFieldsFixed_of_basicSupportedFieldsFixed h_ts)
+
+end
+
+/-- The subset is *strict*: `Supported` admits shapes the proof set
+does not cover. `.bitvector 0` is the smallest witness, `Supported`
+has no positivity precondition, while `BasicSupported.bitvector`
+requires `0 < n` because the spec's decoder rejects zero-width
+bitvectors and the universal roundtrip would be false. -/
+example : SSZType.Supported (.bitvector 0) := .bitvector
+
+/-- And `.bitvector 0` is indeed outside `BasicSupported`: `cases`
+exposes the constructor's `0 < 0` precondition, absurd by `omega`. -/
+example : ¬ SSZType.BasicSupported (.bitvector 0) := fun h => by
+  cases h; omega
 
 end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/Supported.lean
+++ b/packages/SizzLean/SizzLean/Spec/Supported.lean
@@ -61,6 +61,11 @@ inductive SSZType.Supported : SSZType → Prop
   | uintN16        : SSZType.Supported (.uintN 16)
   | uintN32        : SSZType.Supported (.uintN 32)
   | uintN64        : SSZType.Supported (.uintN 64)
+  /-- The two wide spec widths (`uint128` / `uint256`), implemented
+  through the `Nat`-based `natToLEBytes` / `readNatLE` codec rather
+  than the fully-unrolled fixed-width writers of the narrow arms. -/
+  | uintN128       : SSZType.Supported (.uintN 128)
+  | uintN256       : SSZType.Supported (.uintN 256)
   | bool           : SSZType.Supported .bool
   | bitvector      : ∀ {n : Nat}, SSZType.Supported (.bitvector n)
   | bitlist        : ∀ {cap : Nat}, SSZType.Supported (.bitlist cap)
@@ -109,6 +114,8 @@ inductive SSZType.SupportedBounded : SSZType → Prop
   | uintN16        : SSZType.SupportedBounded (.uintN 16)
   | uintN32        : SSZType.SupportedBounded (.uintN 32)
   | uintN64        : SSZType.SupportedBounded (.uintN 64)
+  | uintN128       : SSZType.SupportedBounded (.uintN 128)
+  | uintN256       : SSZType.SupportedBounded (.uintN 256)
   | bool           : SSZType.SupportedBounded .bool
   | bitvector      : ∀ {n : Nat}, SSZType.SupportedBounded (.bitvector n)
   | bitlist        : ∀ {cap : Nat}, SSZType.SupportedBounded (.bitlist cap)


### PR DESCRIPTION
## Summary

Closes #20. Follow-up to #18.

`Supported` / `SupportedBounded` (`Spec/Supported.lean`) still enumerated only `uintN 8/16/32/64`, although the `natToLEBytes` / `readNatLE` codec implements the 128- and 256-bit widths and #18 added them to `BasicSupported`. That silently broke `BasicSupported.lean`'s documented invariant that `BasicSupported` is a strict subset of `Supported`, and left `uint128` / `uint256` fields without a `Supported` witness inside vectors, lists, and containers.
i'll verify the eddsa jwt against the configured pubkey, assert sub === chainId:wallet, and credit the lowercased wallet, never the request body. the mint/idempotency/crash-safety core stays as is, just swapping the recovery front door for the token verify. will ping you for the pubkey + issuer/aud once i wire it. thanks for the clear breakdown
## Changes

- `uintN128` / `uintN256` constructors added to `SSZType.Supported` and `SSZType.SupportedBounded`.
- The prose subset claim is now a build-enforced theorem: `supported_of_basicSupported` (mutual with its field-list companion `supportedFieldsFixed_of_basicSupportedFieldsFixed`), structural recursion over the `(BasicSupported, BasicSupportedFieldsFixed)` pair. The drift happened precisely because the invariant lived in a docstring; from now on, adding a `BasicSupported` constructor without its `Supported` counterpart breaks the build.
- Two `example`s witness that the subset is *strict* via `.bitvector 0` (`Supported` carries no positivity precondition; `BasicSupported` does, because the spec decoder rejects zero-width bitvectors).

## Test plan

- [x] `lake build SizzLean SizzLeanTests` green (170 jobs).
- [x] No linter warnings in the two touched files.