### PR TITLE
feat(ethclspecs): fork-choice throw-faithfulness sweep (get_forkchoice_store + FOCIL)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,11 @@
 #
 # The pyspec recipes need a Python venv. Run `just setup-python` once first.
 
+# xdist worker count for the full pyspec sweeps; `auto` (one per core) is the
+# historical default. Override on memory-constrained machines:
+# `PYTEST_JOBS=2 just ethcl-pyspec-full`.
+pytest_jobs := env_var_or_default("PYTEST_JOBS", "auto")
+
 # List every recipe with its description
 default:
     @just --list --unsorted
@@ -251,24 +256,27 @@ ethcl-pyspec args="": _ensure-venv
 # xfail as the Phase-2 work-queue, so the run is green (exit 0) iff no in-scope
 # vector hits a bug-smell or a real mismatch. Mainnet / full sweep run on demand.
 
-# CI smoke gate: EthCLSpecs pyspec dev subset for both forks at minimal
+# CI smoke gate: EthCLSpecs pyspec dev subset for all three forks at minimal
 [group('ethcl')]
 ethcl-pyspec-smoke: _ensure-venv
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=fulu --subset=2
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=gloas --subset=2
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --fork=heze --subset=2
 
 # The complete in-scope sweep: every collected vector (`--subset=0`) for the
-# full matrix of {fulu, gloas} × {minimal, mainnet}, sharded across cores. The
-# two minimal forks finish quickly; the two mainnet forks are the long poles
+# full matrix of {fulu, gloas, heze} × {minimal, mainnet}, sharded across cores. The
+# three minimal forks finish quickly; the three mainnet forks are the long poles
 # (real-size SSZ + crypto). Each xdist worker holds its own warm `pyspec_server`.
 
-# Full EthCLSpecs pyspec sweep: {fulu,gloas} × {minimal,mainnet}, sharded across cores
+# Full EthCLSpecs pyspec sweep: {fulu,gloas,heze} × {minimal,mainnet}, sharded across cores
 [group('ethcl')]
 ethcl-pyspec-full: _ensure-venv
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=minimal --fork=fulu
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=minimal --fork=gloas
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=mainnet --fork=fulu
-    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n auto --preset=mainnet --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=fulu
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=minimal --fork=heze
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=fulu
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=gloas
+    cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q --subset=0 -n {{ pytest_jobs }} --preset=mainnet --fork=heze
 
 # ═════════════════════════════════════════════════════════════════════════
 # SizzLean — SSZ library

--- a/Justfile
+++ b/Justfile
@@ -229,7 +229,7 @@ _ensure-venv:
     fi
 
 # ═════════════════════════════════════════════════════════════════════════
-# EthCLSpecs — consensus-spec framework + Fulu / Gloas fork bodies
+# EthCLSpecs — consensus-spec framework + Fulu / Gloas / Heze fork bodies
 #
 # EthCLLib + EthCLSpecs (the consensus-spec framework + Fulu/Gloas bodies). The
 # `*Tests` libs carry the framework + spec `#guard` / `native_decide` self-tests
@@ -237,7 +237,7 @@ _ensure-venv:
 # building them fires the gates.
 # ═════════════════════════════════════════════════════════════════════════
 
-# EthCLLib + EthCLSpecs self-tests (framework + Fulu/Gloas spec gates)
+# EthCLLib + EthCLSpecs self-tests (framework + fork spec gates)
 [group('ethcl')]
 ethcl-test:
     lake build EthCLLib EthCLLibTests EthCLSpecs EthCLSpecsTests
@@ -252,7 +252,7 @@ ethcl-pyspec args="": _ensure-venv
     cd packages/EthCLSpecs/PySpecTests && {{ justfile_directory() }}/.venv/bin/python -m pytest -q {{ args }}
 
 # CI smoke gate for EthCLSpecs pyspec: the dev subset (a few cases per
-# handler) at minimal for both forks. Currently-green formats pass; the rest
+# handler) at minimal for all three forks. Currently-green formats pass; the rest
 # xfail as the Phase-2 work-queue, so the run is green (exit 0) iff no in-scope
 # vector hits a bug-smell or a real mismatch. Mainnet / full sweep run on demand.
 
@@ -288,7 +288,7 @@ ethcl-pyspec-full: _ensure-venv
 # boolean, the test-only containers); the EIP-7495 / 7916 / 8016 progressive /
 # stable / compatible forms are out of `SizzLean`'s universe and xfail. The
 # per-fork consensus-container `ssz_static` vectors run inside the EthCLSpecs
-# `ethcl-pyspec*` recipes (Fulu + Gloas), not here.
+# `ethcl-pyspec*` recipes (the fork bodies), not here.
 # ═════════════════════════════════════════════════════════════════════════
 
 # `SizzLeanTests.PendingListShrink` Cases 4/5/7 deliberately drive

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Upstream repository: <https://github.com/etheorem/etheorem>.
 ```
 LeanSha256 ─────────────┐
                         ├─→ SizzLean ──→ EthCLLib ──→ EthCLSpecs
-LeanHazmatSha256 ───────┘   (SSZ +       (consensus    (Fulu / Gloas
+LeanHazmatSha256 ───────┘   (SSZ +       (consensus    (Fulu…Heze
    (FFI SHA-256)            cache)        framework)    fork bodies)
 
 LeanHazmat* (FFI crypto family):  Sha256 · Bls · Kzg   (consumed à la carte)
@@ -40,10 +40,10 @@ independent build target:
 - **[`packages/EthCLLib/`](packages/EthCLLib/)** +
   **[`packages/EthCLSpecs/`](packages/EthCLSpecs/README.md)**: the
   consensus-spec framework (the fork-authoring DSL, the effect monad, the SSZ
-  container front-end, the pyspec driver) and the executable Fulu and
-  Gloas fork bodies built on it. EthCLSpecs declares its containers in-spec and
+  container front-end, the pyspec driver) and the executable Fulu, Gloas,
+  and Heze fork bodies built on it. EthCLSpecs declares its containers in-spec and
   ships the `pyspec_server` runner that drives the state-transition,
-  fork-choice, and `ssz_static` pyspec runs for both forks.
+  fork-choice, and `ssz_static` pyspec runs for all three forks.
 - **[`packages/LeanSha256/`](packages/LeanSha256/README.md)**: pure-Lean
   SHA-256 reference. NIST CAVP-validated, kernel-reducible. No FFI.
 - **[`packages/SizzLean/`](packages/SizzLean/README.md)**: SSZ
@@ -84,12 +84,13 @@ pure-Lean `Sha256Spec` reference, and the cache layer
 gindex-driven `setManyAt`, fused commit `Node.commitAndHash`,
 closure-based pending overlay, `sszUpdate` macro,
 `SSZ.Box` user surface) are all landed. The executable consensus
-spec covers the Fulu and Gloas forks (state transition, fork choice,
-and the SSZ containers declared in-spec, including Fulu's
-`proposer_lookahead` and the Gloas ePBS additions: the nine EIP-7732
-`BeaconState` fields plus the `Builder` / `ExecutionPayloadBid` types).
+spec covers the Fulu, Gloas, and Heze forks (state transition, fork
+choice, and the SSZ containers declared in-spec, including Fulu's
+`proposer_lookahead`, the Gloas ePBS additions: the nine EIP-7732
+`BeaconState` fields plus the `Builder` / `ExecutionPayloadBid` types,
+and Heze's EIP-7805 FOCIL inclusion-list layer).
 Pyspec pinned at consensus-spec-tests
-[v1.7.0-alpha.10](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.10)
+[v1.7.0-alpha.11](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.11)
 in the pytest harnesses. The universal proof set
 (`decode_encode`, `serialize_injective`, `encode_size_le_max`
 over `SSZType.Supported`) and the AVX-512 SIMD inner loop for
@@ -108,7 +109,7 @@ Per-subpackage design docs live next to the code they describe:
   [`FRAMEWORK_ARCHITECTURE.md`](packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md)
   (the EthCLLib framework and fork-authoring DSL), and
   [`SPECS_ARCHITECTURE.md`](packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md)
-  (how the Fulu and Gloas specs are organized, ported, and tested).
+  (how the fork specs are organized, ported, and tested).
   [`PLAN.md`](packages/EthCLSpecs/docs/PLAN.md) sequences the
   implementation phases; `IMPLEMENTATION_NOTES.md`, `DISCREPANCIES.md`,
   and `FUTURE_WORK.md` track deviations, spec disagreements, and
@@ -188,7 +189,7 @@ Toolchain pinned in [`lean-toolchain`](lean-toolchain) (elan picks it up).
 
 ```bash
 # From the repo root — common targets by name:
-lake build EthCLSpecs       # consensus spec (Fulu / Gloas); pulls in EthCLLib + SizzLean
+lake build EthCLSpecs       # consensus spec (Fulu / Gloas / Heze); pulls in EthCLLib + SizzLean
 lake build SizzLean         # SSZ library (serialize / deserialize / Merkleization)
 lake build LeanSha256       # pure-Lean SHA-256 reference
 lake build LeanPoseidon     # standalone Poseidon2 island (fires its anchor KAT)
@@ -257,7 +258,7 @@ Two `pytest-xdist` harnesses drive long-lived Lean servers against the
 server, so there is no per-vector Lean startup.
 
 - **EthCLSpecs** (`packages/EthCLSpecs/PySpecTests/`, the `pyspec_server`
-  runner): the Fulu and Gloas state transition, fork choice, and per-fork
+  runner): the Fulu, Gloas, and Heze state transition, fork choice, and per-fork
   `ssz_static` container vectors.
 - **SizzLean** (`packages/SizzLean/PySpecTests/`, the `ssz_generic_runner`):
   the fork-agnostic `ssz_generic` wire-format suite (uints, basic vectors,
@@ -269,18 +270,18 @@ server, so there is no per-vector Lean startup.
 just setup-python
 
 # Dev-subset smoke gates (a few cases per handler):
-just ethcl-pyspec-smoke         # Fulu + Gloas: transition / fork choice / ssz_static
+just ethcl-pyspec-smoke         # all three forks: transition / fork choice / ssz_static
 just sizzlean-pyspec-smoke   # ssz_generic
 
 # Full sweeps:
-just ethcl-pyspec-full               # both presets, both forks
+just ethcl-pyspec-full               # both presets, all three forks
 just sizzlean-pyspec-full    # every in-scope wire-format vector
 ```
 
 ### Coverage
 
 Pinned at consensus-spec-tests
-[v1.7.0-alpha.10](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.10).
+[v1.7.0-alpha.11](https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.7.0-alpha.11).
 
 - **`ssz_generic`** (SizzLean): 2188 in-scope cases pass across every handler
   (uints, basic_vector, bitvector, bitlist, boolean, containers). The 292
@@ -288,7 +289,8 @@ Pinned at consensus-spec-tests
   SizzLean's `SSZType` universe and xfail. The test-only container shapes
   (`VarTestStruct`, `ComplexTestStruct`, `BitsStruct`, …) are hard-coded in
   `packages/SizzLean/SszGenericRunner.lean`.
-- **`ssz_static`** (EthCLSpecs, Fulu + Gloas): the consensus containers
+- **`ssz_static`** (EthCLSpecs, Gloas + Heze; Fulu's containers ride on
+  SizzLean's own suites): the consensus containers
   EthCLSpecs models pass at both the minimal and mainnet presets; the types it
   does not model (light-client, gossip-aggregation, networking identifiers,
   signing helpers) xfail as out of scope. Earlier forks (Phase 0 through

--- a/README.md
+++ b/README.md
@@ -289,8 +289,7 @@ Pinned at consensus-spec-tests
   SizzLean's `SSZType` universe and xfail. The test-only container shapes
   (`VarTestStruct`, `ComplexTestStruct`, `BitsStruct`, …) are hard-coded in
   `packages/SizzLean/SszGenericRunner.lean`.
-- **`ssz_static`** (EthCLSpecs, Gloas + Heze; Fulu's containers ride on
-  SizzLean's own suites): the consensus containers
+- **`ssz_static`** (EthCLSpecs, Fulu + Gloas + Heze): the consensus containers
   EthCLSpecs models pass at both the minimal and mainnet presets; the types it
   does not model (light-client, gossip-aggregation, networking identifiers,
   signing helpers) xfail as out of scope. Earlier forks (Phase 0 through

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
@@ -18,7 +18,8 @@ The reject-faithfulness audit (`SPECS_ARCHITECTURE.md` §10.2) is encoded in
 | valid (`post` present) | root matches | pass |
 | valid | any error, or wrong root | fail |
 | invalid (`post` absent) | `assert` reject | pass |
-| invalid | `outOfBounds` / `missingKey` reject | pass, **flagged** (bug-smell) |
+| invalid | `outOfBounds` / `missingKey` reject (caught `IndexError`) | pass, **flagged** (bug-smell) |
+| invalid | `arithmetic` reject (uncaught `ValueError` / `ZeroDivisionError`) | fail (the reference does not catch it) |
 | invalid | `todo` reject | fail (an unimplemented path is not a validation) |
 | invalid | ran clean | fail (should have rejected) |
 
@@ -151,12 +152,15 @@ def runCase [ForkInterface] (req : CaseRequest) : CaseResult :=
     -- Valid vector that rejected: a failure, classified by the reject.
     { passed := false, bucket := e.classify, detail := reprStr e }
   | .error e, none =>
-    -- Invalid vector that rejected: faithful iff it was an `assert`. A bug-smell
-    -- reject still counts as rejected but is flagged; a `todo` / `outOfScope` fails
-    -- (not a validation) and reports as its own bucket (xfail / skip respectively).
+    -- Invalid vector that rejected: faithful iff the reject is one the reference catches.
+    -- An `assert` (AssertionError) is the clean expected rejection; a caught bug-smell
+    -- (`outOfBounds` = IndexError) still counts as rejected but is flagged. An `uncaughtFault`
+    -- (a `ValueError` / `ZeroDivisionError` the reference propagates, not catches) fails, as do
+    -- a `todo` / `outOfScope` (not a validation), each reporting as its own bucket.
     match e.classify with
     | .expectedRejection => { passed := true,  bucket := .expectedRejection, detail := reprStr e }
     | .likelyBug         => { passed := true,  bucket := .likelyBug, detail := reprStr e, flagged := true }
+    | .uncaughtFault     => { passed := false, bucket := .uncaughtFault, detail := reprStr e }
     | .todo              => { passed := false, bucket := .todo, detail := reprStr e }
     | .outOfScope        => { passed := false, bucket := .outOfScope, detail := reprStr e }
     | .passing           => { passed := false, bucket := .likelyBug, detail := "unreachable classify" }

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
@@ -18,7 +18,8 @@ The reject-faithfulness audit (`SPECS_ARCHITECTURE.md` §10.2) is encoded in
 | valid (`post` present) | root matches | pass |
 | valid | any error, or wrong root | fail |
 | invalid (`post` absent) | `assert` reject | pass |
-| invalid | `outOfBounds` / `missingKey` reject (caught `IndexError`) | pass, **flagged** (bug-smell) |
+| invalid | `outOfBounds` reject (caught `IndexError`) | pass, **flagged** (bug-smell) |
+| invalid | `decode` failure (our decoder, not a raise) | fail, **flagged** (bug-smell) |
 | invalid | `arithmetic` reject (uncaught `ValueError` / `ZeroDivisionError`) | fail (the reference does not catch it) |
 | invalid | `todo` reject | fail (an unimplemented path is not a validation) |
 | invalid | ran clean | fail (should have rejected) |
@@ -64,8 +65,8 @@ structure CaseResult where
   bucket : ClassifyBucket
   /-- A diagnostic line (root mismatch, reject descriptor, …). -/
   detail : String
-  /-- An invalid vector rejected by `outOfBounds` / `missingKey` (rejected, but a
-  smell worth surfacing). -/
+  /-- A bug-smell worth surfacing on the wire: an invalid vector rejected by
+  `outOfBounds`, or any case whose container failed to decode (`RunError.decode`). -/
   flagged : Bool := false
   deriving Inhabited, Repr
 
@@ -151,7 +152,17 @@ def runCase [ForkInterface] (req : CaseRequest) : CaseResult :=
   | .error e, some _ =>
     -- Valid vector that rejected: a failure, classified by the reject.
     { passed := false, bucket := e.classify, detail := reprStr e }
-  | .error e, none =>
+  | .error (.decode what), none =>
+    -- A decode failure is our decoder's bug, never the invalid vector's expected raise.
+    -- Every post-less case decodes before any spec code runs (`decodeState`, `decodeOp`,
+    -- `runBlocksImpl`), so scoring this as a rejection would report a handler's whole
+    -- `invalid_*` half as passing on one broken container layout. The store machine
+    -- decided the same question the same way at `298bf02`
+    -- (`StoreTransitionError.decodeFailure` is excluded from `isExpectedRejection`).
+    -- Still flagged, so the wire keeps the smell marker.
+    { passed := false, bucket := .likelyBug, detail := s!"decode failed: {what}",
+      flagged := true }
+  | .error (.spec e), none =>
     -- Invalid vector that rejected: faithful iff the reject is one the reference catches.
     -- An `assert` (AssertionError) is the clean expected rejection; a caught bug-smell
     -- (`outOfBounds` = IndexError) still counts as rejected but is flagged. An `uncaughtFault`

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -173,9 +173,10 @@ open EthCLLib.Spec in
 /-- `checkStepValidity` scores a `valid: false` step by the reference runner's caught set:
 `.assert` (bare and `.transition`-wrapped) and `.transition (.outOfBounds …)`, the store
 machine's only index-miss shape, are the expected rejection (pass, threading the error-time
-store). A `.missingKey` (a bare-`Dict` `KeyError`) or a `.transition (.arithmetic …)` (a
-`uint64` `ValueError`), neither of which the reference catches, propagates as a failure;
-`.todo` / `.outOfScope` stay deferrals. Each conjunct is a concrete evaluation, closed by `rfl`
+store). A `.missingKey` (a bare-`Dict` `KeyError`), a `.transition (.arithmetic …)` (a `uint64`
+`ValueError`), or a `.decodeFailure` (a decoder / container bug, never a spec raise), none of
+which the reference catches, propagates as a failure; `.todo` / `.outOfScope` stay deferrals.
+Each conjunct is a concrete evaluation, closed by `rfl`
 (`Except` carries no `DecidableEq`, so `decide` cannot run). -/
 example :
     checkStepValidity (σ := Nat) false (.error (.assert "x", 7)) = .ok 7
@@ -185,23 +186,27 @@ example :
       = .error (.missingKey (Vector.replicate 32 0))
   ∧ checkStepValidity (σ := Nat) false (.error (.transition (.arithmetic "x"), 7))
       = .error (.transition (.arithmetic "x"))
+  ∧ checkStepValidity (σ := Nat) false (.error (.decodeFailure "x", 7)) = .error (.decodeFailure "x")
   ∧ checkStepValidity (σ := Nat) false (.error (.todo "later", 7)) = .error (.todo "later")
   ∧ checkStepValidity (σ := Nat) false (.error (.outOfScope "n/a", 7)) = .error (.outOfScope "n/a") :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 open EthCLLib.Spec in
 /-- Decode a fork-choice step's SSZ `bytes` to its typed value and run `f` on it, or
 short-circuit to the step's reject when the bytes do not deserialize. Factors the
 decode-or-reject the `block` / `attestation` / `attester_slashing` step arms repeat: each
 decodes its own wire type through the fork's `SSZRepr` and, on a parse failure, fails the
-step with a `<label> decode failed` assertion paired with `before` (nothing ran, so the
-error-time store is the pre-step store). `label` names the wire type in that message;
-`f` runs the handler over the decoded value (typically `runOn before …`). -/
+step with a `<label> decode failed` `decodeFailure` reject paired with `before` (nothing ran,
+so the error-time store is the pre-step store). That reject is a decoder / container bug, NOT
+an expected rejection: fork-choice vectors are always well-formed, so a parse miss here is our
+bug, and modeling it as `.assert` would let a `valid:false` step falsely PASS on a broken
+decoder. `label` names the wire type in that message; `f` runs the handler over the decoded
+value (typically `runOn before …`). -/
 def decodeStepOr {α σ : Type} [SizzLean.SSZRepr α] (bytes : ByteArray) (label : String)
     (before : σ) (f : α → Except (StoreTransitionError × σ) σ) :
     Except (StoreTransitionError × σ) σ :=
   match SizzLean.SSZ.deserialize (T := α) bytes with
-  | .error _    => .error (.assert s!"fork_choice: {label} decode failed", before)
+  | .error _    => .error (.decodeFailure s!"fork_choice: {label} decode failed", before)
   | .ok value   => f value
 
 /-- The `operations/<handler>` axis as a typed tag, one constructor per pyspec

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -144,14 +144,24 @@ The step itself never decides pass/fail; this does. A step expected valid that s
 threads its new store; one expected invalid that is rejected rolls back to `before` and
 continues (the rejection is the expected result). The two mismatches, a valid step that is
 rejected and an invalid step that is accepted, are failures: the first returns the step's
-own error, the second a typed mismatch. So a fork interpreter runs each step to an
-`Except` outcome and pipes it through here; the valid/invalid policy lives in one place. -/
+own error, the second a typed mismatch.
+
+Which rejects count as "the expected rejection" mirrors the reference runner's catch set
+(`AssertionError` / `IndexError`): `.assert`, `.missingKey` (this codebase's image of the
+pinned membership asserts fused into `getOrThrow` reads), and a wrapped state-transition
+`.assert` / `.outOfBounds`. A `.todo` / `.outOfScope` (bare or wrapped) is OUR deferral,
+not the vector's expected reject: the spec assert the step encodes was never exercised,
+so it propagates and the case reports xfail / skip instead of falsely passing. -/
 def checkStepValidity {σ : Type} (before : σ) (expectedValid : Bool)
     (outcome : Except StoreTransitionError σ) : Except StoreTransitionError σ :=
   match outcome, expectedValid with
   | .ok after, true  => .ok after
   | .ok _,     false => .error (.assert "fork_choice: step accepted but expected invalid")
-  | .error _,  false => .ok before
+  | .error e,  false =>
+    match e with
+    | .todo _ | .outOfScope _
+    | .transition (.todo _) | .transition (.outOfScope _) => .error e
+    | _ => .ok before
   | .error e,  true  => .error e
 
 open EthCLLib.Spec in
@@ -283,7 +293,9 @@ class ForkInterface where
   a skip, and everything else (a `.decode`, an escaping `.assert`, a `.missingKey`,
   a wrapped `.outOfBounds`) a likely bug. Expected per-step rejections are resolved
   inside the interpreter by `checkStepValidity`, so an `.assert` that escapes this
-  far was not expected by any step. Drives `fork_choice/*`. -/
+  far was not expected by any step. A `.todo` / `.outOfScope` escaping from an
+  expected-invalid step is the runner's own deferral surfacing (the step's spec
+  assert was never reached), reported xfail / skip. Drives `fork_choice/*`. -/
   runForkChoice : ByteArray → ByteArray → Array FcStep → Except (RunError StoreTransitionError) Unit
   /-- Build a genesis state from the eth1 inputs and return its root. Drives
   `genesis`. -/

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -68,8 +68,8 @@ structure CaseMeta where
 
 /-- One step of a `fork_choice` vector's `steps.yaml`, decoded by the runner.
 `checks` carries the expected store values to compare; `unsupported` marks a step
-the runner does not model (a `get_proposer_head` / `should_override` check), so the
-case is reported out-of-scope rather than falsely passing. -/
+the runner does not model (a `should_override` check, an unrecognized key), so the
+case reports `todo` (an xfail) rather than falsely passing. -/
 inductive FcStep where
   /-- `{tick: t}`: advance the store clock to absolute time `t` (seconds). -/
   | tick (time : Nat)
@@ -112,8 +112,8 @@ inductive FcStep where
   | checkTime (t : Nat)
   /-- `checks.genesis_time`. -/
   | checkGenesisTime (t : Nat)
-  /-- A check the runner does not model (`get_proposer_head` /
-  `should_override_forkchoice_update`); the case is out-of-scope. -/
+  /-- A check the runner does not model (`should_override_forkchoice_update`, an
+  unrecognized step or check key); the case reports `todo`, an xfail. -/
   | unsupported (reason : String)
   deriving Inhabited
 
@@ -271,7 +271,7 @@ class ForkInterface where
   block, fold the `steps`, and verify each `checks` step. `.ok` ⇒ every check
   matched; `.error e` carries a `RunError StoreTransitionError` the harness
   classifies: a `.decode` is a likely bug, and a wrapped `.spec` reject classifies
-  by its constructor (`.todo` an out-of-scope deferral, `.assert` an expected
+  by its constructor (`.todo` an unmodeled-branch xfail, `.assert` an expected
   rejection, `.missingKey` / a wrapped `.outOfBounds` a likely bug). Drives
   `fork_choice/*`. -/
   runForkChoice : ByteArray → ByteArray → Array FcStep → Except (RunError StoreTransitionError) Unit

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -118,12 +118,15 @@ inductive FcStep where
   deriving Inhabited
 
 /-- Run a state-only `EStateM` action on `s` and project its result to `Except`: the new
-store on success, the reject on failure. The bridge from a fork-choice handler (`onBlock`,
-`onAttestation`, …) to the `Except` outcome `checkStepValidity` consumes. -/
-def runOn {ε σ : Type} (s : σ) (act : EStateM ε σ Unit) : Except ε σ :=
+store on success, the reject PAIRED WITH THE ERROR-TIME STORE on failure. The reference
+pyspec runner mutates the store in place and catches the expected raise, so mutations a
+handler made before rejecting persist there; keeping `EStateM`'s error-branch state is
+how this runner matches that. The bridge from a fork-choice handler (`onBlock`,
+`onAttestation`, …) to the outcome `checkStepValidity` consumes. -/
+def runOn {ε σ : Type} (s : σ) (act : EStateM ε σ Unit) : Except (ε × σ) σ :=
   match act.run s with
-  | .ok _ s' => .ok s'
-  | .error e _ => .error e
+  | .ok _ s'    => .ok s'
+  | .error e s' => .error (e, s')
 
 /-- Run a read-only `EStateM` query on `s` and project its *result* to `Except`: the query's
 value on success, the reject on failure. The value-returning sibling of `runOn`, for a
@@ -136,45 +139,69 @@ def runQuery {ε σ α : Type} (s : σ) (act : EStateM ε σ α) : Except ε α 
 
 open EthCLLib.Spec in
 /-- The runner's per-step valid/invalid check for a fork-choice step, fork-agnostic over
-the store type `σ`. `before` is the pre-step store (the snapshot, free here since stores
-are immutable values), `expectedValid` the step's wire flag, `outcome` the result of
-running the step.
+the store type `σ`. `expectedValid` is the step's wire flag; `outcome` the result of
+running the step, carrying the error-time store on a reject (`runOn`).
 
 The step itself never decides pass/fail; this does. A step expected valid that succeeds
-threads its new store; one expected invalid that is rejected rolls back to `before` and
-continues (the rejection is the expected result). The two mismatches, a valid step that is
-rejected and an invalid step that is accepted, are failures: the first returns the step's
-own error, the second a typed mismatch.
+threads its new store. One expected invalid that is rejected continues FROM THE
+ERROR-TIME STORE: the reference pyspec runner mutates in place and catches the raise, so
+mutations made before the reject (e.g. `on_attestation`'s target-checkpoint cache insert
+before the signature assert) persist there, and the handlers `set` at pyspec mutation
+points to reproduce exactly that. The two mismatches, a valid step that is rejected and
+an invalid step that is accepted, are failures: the first returns the step's own error,
+the second a typed mismatch.
 
-Which rejects count as "the expected rejection" mirrors the reference runner's catch set
-(`AssertionError` / `IndexError`): `.assert`, `.missingKey` (this codebase's image of the
-pinned membership asserts fused into `getOrThrow` reads), and a wrapped state-transition
-`.assert` / `.outOfBounds`. A `.todo` / `.outOfScope` (bare or wrapped) is OUR deferral,
-not the vector's expected reject: the spec assert the step encodes was never exercised,
-so it propagates and the case reports xfail / skip instead of falsely passing. -/
-def checkStepValidity {σ : Type} (before : σ) (expectedValid : Bool)
-    (outcome : Except StoreTransitionError σ) : Except StoreTransitionError σ :=
+Which rejects count as the expected rejection is `StoreTransitionError.isExpectedRejection`
+(`Spec/Errors.lean`), the one home for that policy: the reference runner (`context.py`'s
+`expect_assertion_error`) catches `AssertionError` and `IndexError`, so exactly `.assert` and
+`.transition (.outOfBounds …)` (the store machine's only index-miss shape, since
+`StoreTransitionError` has no bare `.outOfBounds`), bare and `.transition`-wrapped, thread the
+error-time store as faithful expected rejections. Everything else propagates as `.error`:
+`.todo` / `.outOfScope` (bare or wrapped) are our own deferral, reported xfail / skip at the
+server, and `.missingKey` or any other unexpected store error, which the reference does not
+catch and `classify` treats as a likely bug, now fails the step rather than passing it. -/
+def checkStepValidity {σ : Type} (expectedValid : Bool)
+    (outcome : Except (StoreTransitionError × σ) σ) : Except StoreTransitionError σ :=
   match outcome, expectedValid with
   | .ok after, true  => .ok after
   | .ok _,     false => .error (.assert "fork_choice: step accepted but expected invalid")
-  | .error e,  false =>
-    match e with
-    | .todo _ | .outOfScope _
-    | .transition (.todo _) | .transition (.outOfScope _) => .error e
-    | _ => .ok before
-  | .error e,  true  => .error e
+  | .error (e, errStore), false =>
+    if e.isExpectedRejection then .ok errStore else .error e
+  | .error (e, _), true  => .error e
+
+open EthCLLib.Spec in
+/-- `checkStepValidity` scores a `valid: false` step by the reference runner's caught set:
+`.assert` (bare and `.transition`-wrapped) and `.transition (.outOfBounds …)`, the store
+machine's only index-miss shape, are the expected rejection (pass, threading the error-time
+store). A `.missingKey` (a bare-`Dict` `KeyError`) or a `.transition (.arithmetic …)` (a
+`uint64` `ValueError`), neither of which the reference catches, propagates as a failure;
+`.todo` / `.outOfScope` stay deferrals. Each conjunct is a concrete evaluation, closed by `rfl`
+(`Except` carries no `DecidableEq`, so `decide` cannot run). -/
+example :
+    checkStepValidity (σ := Nat) false (.error (.assert "x", 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.assert "x"), 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.outOfBounds 3 2), 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) false (.error (.missingKey (Vector.replicate 32 0), 7))
+      = .error (.missingKey (Vector.replicate 32 0))
+  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.arithmetic "x"), 7))
+      = .error (.transition (.arithmetic "x"))
+  ∧ checkStepValidity (σ := Nat) false (.error (.todo "later", 7)) = .error (.todo "later")
+  ∧ checkStepValidity (σ := Nat) false (.error (.outOfScope "n/a", 7)) = .error (.outOfScope "n/a") :=
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 open EthCLLib.Spec in
 /-- Decode a fork-choice step's SSZ `bytes` to its typed value and run `f` on it, or
 short-circuit to the step's reject when the bytes do not deserialize. Factors the
 decode-or-reject the `block` / `attestation` / `attester_slashing` step arms repeat: each
 decodes its own wire type through the fork's `SSZRepr` and, on a parse failure, fails the
-step with a `<label> decode failed` assertion. `label` names the wire type in that message;
-`f` runs the handler over the decoded value (typically `runOn store …`). -/
+step with a `<label> decode failed` assertion paired with `before` (nothing ran, so the
+error-time store is the pre-step store). `label` names the wire type in that message;
+`f` runs the handler over the decoded value (typically `runOn before …`). -/
 def decodeStepOr {α σ : Type} [SizzLean.SSZRepr α] (bytes : ByteArray) (label : String)
-    (f : α → Except StoreTransitionError σ) : Except StoreTransitionError σ :=
+    (before : σ) (f : α → Except (StoreTransitionError × σ) σ) :
+    Except (StoreTransitionError × σ) σ :=
   match SizzLean.SSZ.deserialize (T := α) bytes with
-  | .error _    => .error (.assert s!"fork_choice: {label} decode failed")
+  | .error _    => .error (.assert s!"fork_choice: {label} decode failed", before)
   | .ok value   => f value
 
 /-- The `operations/<handler>` axis as a typed tag, one constructor per pyspec

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -125,6 +125,15 @@ def runOn {ε σ : Type} (s : σ) (act : EStateM ε σ Unit) : Except ε σ :=
   | .ok _ s' => .ok s'
   | .error e _ => .error e
 
+/-- Run a read-only `EStateM` query on `s` and project its *result* to `Except`: the query's
+value on success, the reject on failure. The value-returning sibling of `runOn`, for a
+fork-choice read such as `get_head` whose value (not the store) a check step inspects, now
+that those reads can throw. -/
+def runQuery {ε σ α : Type} (s : σ) (act : EStateM ε σ α) : Except ε α :=
+  match act.run s with
+  | .ok a _   => .ok a
+  | .error e _ => .error e
+
 open EthCLLib.Spec in
 /-- The runner's per-step valid/invalid check for a fork-choice step, fork-agnostic over
 the store type `σ`. `before` is the pre-step store (the snapshot, free here since stores
@@ -270,10 +279,11 @@ class ForkInterface where
   /-- Interpret a `fork_choice` vector: build the store from the anchor state /
   block, fold the `steps`, and verify each `checks` step. `.ok` ⇒ every check
   matched; `.error e` carries a `RunError StoreTransitionError` the harness
-  classifies: a `.decode` is a likely bug, and a wrapped `.spec` reject classifies
-  by its constructor (`.todo` an unmodeled-branch xfail, `.assert` an expected
-  rejection, `.missingKey` / a wrapped `.outOfBounds` a likely bug). Drives
-  `fork_choice/*`. -/
+  classifies: `.spec (.todo _)` an unmodeled-branch xfail, `.spec (.outOfScope _)`
+  a skip, and everything else (a `.decode`, an escaping `.assert`, a `.missingKey`,
+  a wrapped `.outOfBounds`) a likely bug. Expected per-step rejections are resolved
+  inside the interpreter by `checkStepValidity`, so an `.assert` that escapes this
+  far was not expected by any step. Drives `fork_choice/*`. -/
   runForkChoice : ByteArray → ByteArray → Array FcStep → Except (RunError StoreTransitionError) Unit
   /-- Build a genesis state from the eth1 inputs and return its root. Drives
   `genesis`. -/

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -138,9 +138,63 @@ def runQuery {ε σ α : Type} (s : σ) (act : EStateM ε σ α) : Except ε α 
   | .error e _ => .error e
 
 open EthCLLib.Spec in
+/-- Which fork-choice step is being scored, and so which reference wrapper defines its
+expected-rejection set.
+
+The reference does not catch one uniform set. `expect_assertion_error`
+(`context.py:424-435`) takes `AssertionError` and `IndexError`, and scores the attestation
+(`run_on_attestation:243-245`), attester-slashing (`run_on_attester_slashing:466-468`),
+envelope (`run_on_execution_payload_envelope:435-438`), and PTC-message
+(`run_on_payload_attestation_message:492-494`) steps. The block step never reaches it:
+`add_block` calls `run_on_block(valid=True)` inside its own
+`except (AssertionError, BlockNotFoundException)` (`fork_choice.py:387-395`), so an
+`IndexError` there escapes and fails the vector.
+
+`tick` carries no `valid` flag (`on_tick_and_append_step:312`), and the block's replayed
+attestations / attester-slashings run `valid = True` (`fork_choice.py:400-406`), so for those
+the admitted set is never consulted; they still name their kind so no call site hides which
+wrapper it stands for. -/
+inductive FcStepKind where
+  /-- `add_block`: `.assert` only, `IndexError` escapes. -/
+  | block
+  /-- `on_tick`, no `valid` flag. -/
+  | tick
+  | attestation
+  | attesterSlashing
+  | executionPayload
+  | payloadAttestationMessage
+  deriving DecidableEq, Repr
+
+open EthCLLib.Spec in
+/-- Whether this step kind's reference wrapper catches Python `IndexError`. Only the block
+step's does not (`add_block`'s `except (AssertionError, BlockNotFoundException)`,
+`fork_choice.py:387-395`); every other kind runs under `expect_assertion_error`
+(`context.py:424-435`), which catches it.
+
+Enumerated rather than closed on a wildcard, matching every other `FcStep` match in this file:
+Heze's spec already defines an `on_inclusion_list` fork-choice handler
+(`heze/fork-choice.md:256-267`) that the harness routes to `unsupported`, and wiring it adds a
+constructor. That must be a build error here, not a silent `true`. -/
+def FcStepKind.catchesIndexError : FcStepKind → Bool
+  | .block                     => false
+  | .tick                      => true
+  | .attestation               => true
+  | .attesterSlashing          => true
+  | .executionPayload          => true
+  | .payloadAttestationMessage => true
+
+open EthCLLib.Spec in
+/-- Whether `e` is the expected rejection of a `valid: false` step of this kind: the general
+caught set (`isExpectedRejection`) minus the index miss on the kinds whose wrapper lets an
+`IndexError` escape. -/
+def FcStepKind.admits (kind : FcStepKind) (e : StoreTransitionError) : Bool :=
+  e.isExpectedRejection && (kind.catchesIndexError || !e.isIndexMiss)
+
+open EthCLLib.Spec in
 /-- The runner's per-step valid/invalid check for a fork-choice step, fork-agnostic over
-the store type `σ`. `expectedValid` is the step's wire flag; `outcome` the result of
-running the step, carrying the error-time store on a reject (`runOn`).
+the store type `σ`. `kind` selects the reference wrapper whose caught set scores the step;
+`expectedValid` is the step's wire flag; `outcome` the result of running the step, carrying
+the error-time store on a reject (`runOn`).
 
 The step itself never decides pass/fail; this does. A step expected valid that succeeds
 threads its new store. One expected invalid that is rejected continues FROM THE
@@ -151,45 +205,50 @@ points to reproduce exactly that. The two mismatches, a valid step that is rejec
 an invalid step that is accepted, are failures: the first returns the step's own error,
 the second a typed mismatch.
 
-Which rejects count as the expected rejection is `StoreTransitionError.isExpectedRejection`
-(`Spec/Errors.lean`), the one home for that policy: the reference runner (`context.py`'s
-`expect_assertion_error`) catches `AssertionError` and `IndexError`, so exactly `.assert` and
-`.transition (.outOfBounds …)` (the store machine's only index-miss shape, since
-`StoreTransitionError` has no bare `.outOfBounds`), bare and `.transition`-wrapped, thread the
-error-time store as faithful expected rejections. Everything else propagates as `.error`:
-`.todo` / `.outOfScope` (bare or wrapped) are our own deferral, reported xfail / skip at the
-server, and `.missingKey` or any other unexpected store error, which the reference does not
-catch and `classify` treats as a likely bug, now fails the step rather than passing it. -/
-def checkStepValidity {σ : Type} (expectedValid : Bool)
+Which rejects count as the expected rejection is `FcStepKind.admits`: the caught set in
+`StoreTransitionError.isExpectedRejection` (`Spec/Errors.lean`, `.assert` and
+`.transition (.outOfBounds …)`, bare and wrapped), narrowed by the step's own reference
+wrapper. Those thread the error-time store as faithful expected rejections. Everything else
+propagates as `.error`: `.todo` / `.outOfScope` (bare or wrapped) are our own deferral,
+reported xfail / skip at the server, and `.missingKey` or any other unexpected store error,
+which the reference does not catch and `classify` treats as an `uncaughtFault`, fails the step
+rather than passing it, so the two policies agree. -/
+def checkStepValidity {σ : Type} (kind : FcStepKind) (expectedValid : Bool)
     (outcome : Except (StoreTransitionError × σ) σ) : Except StoreTransitionError σ :=
   match outcome, expectedValid with
   | .ok after, true  => .ok after
   | .ok _,     false => .error (.assert "fork_choice: step accepted but expected invalid")
   | .error (e, errStore), false =>
-    if e.isExpectedRejection then .ok errStore else .error e
+    if kind.admits e then .ok errStore else .error e
   | .error (e, _), true  => .error e
 
 open EthCLLib.Spec in
-/-- `checkStepValidity` scores a `valid: false` step by the reference runner's caught set:
-`.assert` (bare and `.transition`-wrapped) and `.transition (.outOfBounds …)`, the store
-machine's only index-miss shape, are the expected rejection (pass, threading the error-time
-store). A `.missingKey` (a bare-`Dict` `KeyError`), a `.transition (.arithmetic …)` (a `uint64`
-`ValueError`), or a `.decodeFailure` (a decoder / container bug, never a spec raise), none of
-which the reference catches, propagates as a failure; `.todo` / `.outOfScope` stay deferrals.
-Each conjunct is a concrete evaluation, closed by `rfl`
-(`Except` carries no `DecidableEq`, so `decide` cannot run). -/
+/-- `checkStepValidity` scores a `valid: false` step by its own reference wrapper's caught set:
+`.assert` (bare and `.transition`-wrapped) is the expected rejection everywhere (pass, threading
+the error-time store), and `.transition (.outOfBounds …)`, the store machine's only index-miss
+shape, joins it on every kind but `.block`. A `.missingKey` (a bare-`Dict` `KeyError`), a
+`.transition (.arithmetic …)` (a `uint64` `ValueError`), or a `.decodeFailure` (a decoder /
+container bug, never a spec raise), none of which the reference catches, propagates as a
+failure; `.todo` / `.outOfScope` stay deferrals. Each conjunct is a concrete evaluation, closed
+by `rfl` (`Except` carries no `DecidableEq`, so `decide` cannot run). -/
 example :
-    checkStepValidity (σ := Nat) false (.error (.assert "x", 7)) = .ok 7
-  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.assert "x"), 7)) = .ok 7
-  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.outOfBounds 3 2), 7)) = .ok 7
-  ∧ checkStepValidity (σ := Nat) false (.error (.missingKey (Vector.replicate 32 0), 7))
+    checkStepValidity (σ := Nat) .attestation false (.error (.assert "x", 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) .block false (.error (.assert "x", 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.transition (.assert "x"), 7)) = .ok 7
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.transition (.outOfBounds 3 2), 7)) = .ok 7
+  -- The block step's wrapper never catches `IndexError`, so the same reject fails there.
+  ∧ checkStepValidity (σ := Nat) .block false (.error (.transition (.outOfBounds 3 2), 7))
+      = .error (.transition (.outOfBounds 3 2))
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.missingKey (Vector.replicate 32 0), 7))
       = .error (.missingKey (Vector.replicate 32 0))
-  ∧ checkStepValidity (σ := Nat) false (.error (.transition (.arithmetic "x"), 7))
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.transition (.arithmetic "x"), 7))
       = .error (.transition (.arithmetic "x"))
-  ∧ checkStepValidity (σ := Nat) false (.error (.decodeFailure "x", 7)) = .error (.decodeFailure "x")
-  ∧ checkStepValidity (σ := Nat) false (.error (.todo "later", 7)) = .error (.todo "later")
-  ∧ checkStepValidity (σ := Nat) false (.error (.outOfScope "n/a", 7)) = .error (.outOfScope "n/a") :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.decodeFailure "x", 7))
+      = .error (.decodeFailure "x")
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.todo "later", 7)) = .error (.todo "later")
+  ∧ checkStepValidity (σ := Nat) .attestation false (.error (.outOfScope "n/a", 7))
+      = .error (.outOfScope "n/a") :=
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 open EthCLLib.Spec in
 /-- Decode a fork-choice step's SSZ `bytes` to its typed value and run `f` on it, or

--- a/packages/EthCLLib/EthCLLib/Spec.lean
+++ b/packages/EthCLLib/EthCLLib/Spec.lean
@@ -9,6 +9,7 @@ import EthCLLib.Spec.Assert
 import EthCLLib.Spec.Header
 import EthCLLib.Spec.Forms
 import EthCLLib.Spec.Crypto
+import EthCLLib.Spec.Engine
 
 /-!
 # `EthCLLib.Spec`: the author-facing surface

--- a/packages/EthCLLib/EthCLLib/Spec/Assert.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Assert.lean
@@ -57,6 +57,31 @@ the store machine runs the state machine, never the reverse. -/
   | .ok _ post => pure post
   | .error e _ => throw (ErrorConv.conv e : StoreTransitionError)
 
+/-- The value-returning sibling of `runStateTransition`: execute `act` on `pre` and hand back
+its *result*, discarding the post-state, or re-throw the inner failure wrapped as
+`StoreTransitionError.transition`.
+
+`runStateTransition` serves the state machine's *steps*, whose result is the new state. A store
+handler that needs a state-machine *query* wants the value instead, and `get_ptc` is the case:
+it is a state-file `forkdef`, so its rejects are `StateTransitionError`, and
+`on_payload_attestation_message` runs in the store machine and cannot call it directly. The
+bridge stays one-way, the store machine running the state machine and never the reverse. -/
+@[inline] def evalStateTransition {S α : Type} {m : Type → Type u} [Monad m]
+    [MonadExceptOf StoreTransitionError m] (pre : S)
+    (act : EStateM StateTransitionError S α) : m α :=
+  match act.run pre with
+  | .ok a _   => pure a
+  | .error e _ => throw (ErrorConv.conv e : StoreTransitionError)
+
+/-- The bridge carries a value out. -/
+example : (evalStateTransition (m := Except StoreTransitionError) (0 : Nat)
+    (pure 7 : EStateM StateTransitionError Nat Nat)) = .ok 7 := rfl
+
+/-- … and wraps an inner reject as `.transition`, exactly as `runStateTransition` does. -/
+example : (evalStateTransition (m := Except StoreTransitionError) (0 : Nat)
+    (throw (.assert "x") : EStateM StateTransitionError Nat Nat))
+    = .error (.transition (.assert "x")) := rfl
+
 /-- Collapse a reprinted condition to a single tab-free line. `reprint` keeps the
 trailing trivia after `cond` (whitespace and any following comment), which would
 embed newlines / the next line's text in the descriptor and break the

--- a/packages/EthCLLib/EthCLLib/Spec/Engine.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Engine.lean
@@ -1,0 +1,55 @@
+/-!
+# `EthCLLib.Spec.Engine`: the `[ExecutionEngine]` seam
+
+The spec's `ExecutionEngine` predicates are Engine-API calls answered by an
+external execution layer, so their verdicts are EL-implementation-defined and
+cannot be modeled as fixed values without hiding the trust boundary. Like
+`[CryptoBackend]` one file over, this seam lets a consumer swap the backend at
+the call boundary: the default instance below is the optimistic always-`true`
+mock (every conformance path stays on the accepting branch with no call-site
+change), and a test supplies a refuting local instance to drive the
+discriminating `false` branch.
+
+Unlike `CryptoBackend`, whose currency is raw `ByteArray` wire buffers, the
+engine predicates take the fork's own SSZ types. `ExecutionPayload` is a
+fork-namespaced twin (nominally distinct per fork); `Transaction` is today a
+single shared abbrev, parameterized here anyway so a fork that ever twins it
+needs no seam change. The class is generic over both; the optimistic instance
+is generic too, so every fork resolves it without per-fork glue, and a local
+`letI` at one fork's concrete types overrides it where a test needs the
+refuting branch.
+
+One deliberate difference from `CryptoBackend`: that seam ships named backends
+(`ffi` / `verifyOff` / `symbolic`) a consumer must inject, so a forgotten
+injection is a compile error; this one registers the optimistic mock as a
+global instance, so every conformance path works with zero wiring. The cost is
+that a consumer wiring a real EL verdict must remember the local override,
+nothing forces it.
+
+Heze's FOCIL gate (`is_inclusion_list_satisfied`) is the first consumer.
+Gloas's engine predicates (`verify_and_notify_new_payload`,
+`is_data_available`) are still modeled as inline constants and can migrate
+here as a follow-up.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Spec
+
+/-- The execution-layer seam: `ExecutionEngine` predicates whose verdict an
+external EL owns. Generic over the fork's payload / transaction types (they are
+fork-namespaced or shared types a framework class cannot name concretely). -/
+class ExecutionEngine (Payload : Type) (Tx : Type) where
+  /-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
+  (EIP-7805): whether the payload includes the required inclusion-list
+  transactions. Body is EL-implementation-defined. -/
+  isInclusionListSatisfied : Payload → Array Tx → Bool
+
+/-- The default engine: the optimistic always-`true` mock, the residual EL trust
+boundary of every engine-gated spec branch. Generic, so it serves every fork; a
+consumer wanting a real (or refuting) verdict overrides `[ExecutionEngine]`
+locally with a `letI` at the concrete fork types. -/
+instance instExecutionEngineOptimistic {Payload Tx : Type} : ExecutionEngine Payload Tx where
+  isInclusionListSatisfied _ _ := true
+
+end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/Engine.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Engine.lean
@@ -2,19 +2,20 @@
 # `EthCLLib.Spec.Engine`: the `[ExecutionEngine]` seam
 
 The spec's `ExecutionEngine` predicates are Engine-API calls answered by an
-external execution layer, so their verdicts are EL-implementation-defined and
-cannot be modeled as fixed values without hiding the trust boundary. Like
-`[CryptoBackend]` one file over, this seam lets a consumer swap the backend at
-the call boundary: the default instance below is the optimistic always-`true`
-mock (every conformance path stays on the accepting branch with no call-site
-change), and a test supplies a refuting local instance to drive the
-discriminating `false` branch.
+external execution layer (EL), so their verdicts are EL-implementation-defined
+and cannot be modeled as fixed values without hiding the trust boundary. Like
+`[CryptoBackend]` one file over, this is an injection seam, a typeclass
+boundary where the consumer picks the implementation (`FRAMEWORK_ARCHITECTURE.md`
+§1): the default instance below is the optimistic always-`true` mock (every
+conformance path stays on the accepting branch with no call-site change), and
+a test supplies a local instance returning `false` to exercise the rejecting
+branch.
 
-Unlike `CryptoBackend`, whose currency is raw `ByteArray` wire buffers, the
-engine predicates take the fork's own SSZ types. `ExecutionPayload` is a
-fork-namespaced twin (nominally distinct per fork); `Transaction` is today a
-single shared abbrev, parameterized here anyway so a fork that ever twins it
-needs no seam change. The class is generic over both; the optimistic instance
+`CryptoBackend` works on raw `ByteArray` wire buffers; the engine predicates
+instead take the fork's own SSZ types. `ExecutionPayload` is re-declared per
+fork namespace, each fork's copy a nominally distinct type; `Transaction` is
+today a single shared abbrev, parameterized here anyway so a fork that ever
+re-declares it needs no seam change. The class is generic over both; the optimistic instance
 is generic too, so every fork resolves it without per-fork glue, and a local
 `letI` at one fork's concrete types overrides it where a test needs the
 refuting branch.

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -43,12 +43,16 @@ inductive StateTransitionError where
   | outOfScope (what : String)
   /-- Indexed access past the end: index `idx` against bound `bound`. -/
   | outOfBounds (idx bound : Nat)
-  /-- A `uint64` arithmetic fault (over/underflow): the spec's `uintN` op raises Python
-  `ValueError`, which the reference runner's `expect_assertion_error` does NOT catch (it
-  catches only `AssertionError` and `IndexError`, `context.py:429-433`). So it is not an
-  expected rejection but a likely bug, distinct from a guarded `assert`. `descr` names the
-  faulting op, diagnostic only. The standing case is `get_balance_after_withdrawals`'
-  `state.balances[i] - withdrawn` (`capella/beacon-chain.md:378`), a bare subtraction. -/
+  /-- An uncaught arithmetic fault (a `uint64` over/underflow, or a `% 0`): the spec's `uintN`
+  op raises Python `ValueError` (a `ZeroDivisionError` for `% 0`), which the reference runner's
+  `expect_assertion_error` does NOT catch (it catches only `AssertionError` and `IndexError`,
+  `context.py:429-433`). So it is not an expected rejection but a genuine error, distinct from a
+  guarded `assert`: it `classify`s as `ClassifyBucket.uncaughtFault`, so an invalid vector that
+  rejects this way FAILS rather than passing. `descr` names the faulting op, diagnostic only. The
+  standing case is `get_balance_after_withdrawals`' `state.balances[i] - withdrawn`
+  (`capella/beacon-chain.md:378`), a bare subtraction. On the store machine the same fault rides
+  in wrapped as `.transition (.arithmetic …)`, e.g. Heze's `Slot(state.slot - 1)` underflow and
+  `get_inclusion_list_committee`'s `indices[i % len(indices)]` on an empty committee. -/
   | arithmetic (descr : String)
   deriving Inhabited, Repr, DecidableEq
 
@@ -67,6 +71,13 @@ inductive StoreTransitionError where
   | outOfScope (what : String)
   /-- An `FcMap` lookup found no entry for `key` (the 32-byte block root). -/
   | missingKey (key : Vector UInt8 32)
+  /-- A fork-choice step's SSZ input could not be deserialized; `what` names the input. A
+  decoder / container bug, never a spec rejection: fork-choice vectors are always well-formed
+  (malformed-wire testing lives in the `ssz_generic` suite), so a decode miss here is our bug,
+  not the invalid step's expected raise. Kept distinct from `.assert` so it is NOT an expected
+  rejection (`isExpectedRejection`), the mirror of the state-transition machine's
+  `RunError.decode`. -/
+  | decodeFailure (what : String)
   /-- A nested state-transition failure surfaced through `runStateTransition`. -/
   | transition (e : StateTransitionError)
   deriving Inhabited, Repr, DecidableEq
@@ -83,8 +94,17 @@ inductive ClassifyBucket where
   | todo
   /-- An `outOfScope` reject; a branch we deliberately do not model. Reported `skip`. -/
   | outOfScope
-  /-- An `outOfBounds` / `missingKey` reject; a likely framework or spec bug. -/
+  /-- An `outOfBounds` / `missingKey` / `decodeFailure` reject; a likely framework or spec bug.
+  For an invalid vector, an `outOfBounds` (`IndexError`) still counts as a rejection the
+  reference accepts, so the driver passes it (flagged). -/
   | likelyBug
+  /-- An uncaught Python fault the reference runner does NOT catch (a `uint64` `ValueError` from
+  `.arithmetic`, a `ZeroDivisionError`). Reports as a bug like `likelyBug`, but unlike
+  `likelyBug` it is never a valid rejection of an invalid vector: the reference would propagate
+  it as a genuine error, so the driver fails an invalid vector that rejects this way rather than
+  passing it. This is the reporting-side counterpart of `isExpectedRejection` excluding
+  `.transition (.arithmetic …)`. -/
+  | uncaughtFault
   deriving Inhabited, Repr, DecidableEq
 
 namespace ClassifyBucket
@@ -97,6 +117,7 @@ def tag : ClassifyBucket → String
   | .todo              => "todo"
   | .outOfScope        => "skip"
   | .likelyBug         => "bug"
+  | .uncaughtFault     => "bug"
 
 end ClassifyBucket
 
@@ -106,7 +127,7 @@ def StateTransitionError.classify : StateTransitionError → ClassifyBucket
   | .todo _          => .todo
   | .outOfScope _    => .outOfScope
   | .outOfBounds _ _ => .likelyBug
-  | .arithmetic _    => .likelyBug
+  | .arithmetic _    => .uncaughtFault
 
 /-- Classify a store-transition reject by its constructor. A wrapped nested
 state failure classifies by the inner reject. -/
@@ -115,6 +136,7 @@ def StoreTransitionError.classify : StoreTransitionError → ClassifyBucket
   | .todo _        => .todo
   | .outOfScope _  => .outOfScope
   | .missingKey _  => .likelyBug
+  | .decodeFailure _ => .likelyBug
   | .transition e  => e.classify
 
 /-- Whether a store reject is the expected rejection of a `valid: false` fork-choice step.

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -43,6 +43,13 @@ inductive StateTransitionError where
   | outOfScope (what : String)
   /-- Indexed access past the end: index `idx` against bound `bound`. -/
   | outOfBounds (idx bound : Nat)
+  /-- A `uint64` arithmetic fault (over/underflow): the spec's `uintN` op raises Python
+  `ValueError`, which the reference runner's `expect_assertion_error` does NOT catch (it
+  catches only `AssertionError` and `IndexError`, `context.py:429-433`). So it is not an
+  expected rejection but a likely bug, distinct from a guarded `assert`. `descr` names the
+  faulting op, diagnostic only. The standing case is `get_balance_after_withdrawals`'
+  `state.balances[i] - withdrawn` (`capella/beacon-chain.md:378`), a bare subtraction. -/
+  | arithmetic (descr : String)
   deriving Inhabited, Repr, DecidableEq
 
 /-- The fork-choice store machine's reject type.
@@ -99,6 +106,7 @@ def StateTransitionError.classify : StateTransitionError → ClassifyBucket
   | .todo _          => .todo
   | .outOfScope _    => .outOfScope
   | .outOfBounds _ _ => .likelyBug
+  | .arithmetic _    => .likelyBug
 
 /-- Classify a store-transition reject by its constructor. A wrapped nested
 state failure classifies by the inner reject. -/
@@ -108,6 +116,24 @@ def StoreTransitionError.classify : StoreTransitionError → ClassifyBucket
   | .outOfScope _  => .outOfScope
   | .missingKey _  => .likelyBug
   | .transition e  => e.classify
+
+/-- Whether a store reject is the expected rejection of a `valid: false` fork-choice step.
+The reference runner (`context.py:429-433`'s `expect_assertion_error`) catches `AssertionError`
+and `IndexError`, so exactly `.assert` (bare and `.transition`-wrapped) and the store machine's
+only index-miss shape, `.transition (.outOfBounds …)`, count; `.missingKey` (an uncaught
+`KeyError`), `.transition (.arithmetic …)` (an uncaught `uint64` `ValueError`), `.todo` /
+`.outOfScope` (our own deferrals), and anything else do not.
+
+This is a *different question* from `classify`, which buckets a reject for reporting (a
+`.transition (.outOfBounds)` is still a `likelyBug` there): `classify` answers "how do we
+report this reject", `isExpectedRejection` answers "does the reference accept it as the
+invalid step's expected raise". `checkStepValidity` is the sole caller; keeping the caught
+set here, next to `classify`, makes the two policies visibly distinct and edited in one
+place each. -/
+def StoreTransitionError.isExpectedRejection : StoreTransitionError → Bool
+  | .assert _
+  | .transition (.assert _) | .transition (.outOfBounds _ _) => true
+  | _ => false
 
 /-- Build the `assert` / `todo` reject of an error type from its diagnostic descriptor.
 The `assert` macro and the `todo` helper resolve `E` from the section's monad, so the

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -263,28 +263,39 @@ The spec's `uintN` arithmetic is *checked*: remerkleable reconstructs a `uint64`
 `ValueError` is not an `AssertionError`, so the reference runner does not catch it
 (`context.py`); it is the `.arithmetic` uncaught fault (`classify`s as `uncaughtFault`, never an
 expected rejection). Lean's raw `UInt64` ops wrap instead of raising, so a spec `a + b` / `a - b`
-/ `a * b` that can leave the `uint64` range is modeled with these, not the bare operator. Each
-emits `StateTransitionError.arithmetic`; the `[ErrorConv StateTransitionError E]` bound rides it
-in as `.arithmetic` on the state machine (identity) and `.transition (.arithmetic …)` on the store
-machine, so one definition serves both, exactly as `sszGetIdx` does for `IndexError`. `descr` names
-the faulting op, diagnostic only. -/
+/ `a * b` that can leave the `uint64` range is modeled with these, not the bare operator. All
+of them raise through `throwArithmetic` below, which is also where the spec's one non-operator
+arithmetic fault goes. `descr` names the faulting op, diagnostic only. -/
+
+/-- Raise the `.arithmetic` fault. The single place the reject is constructed, so no call site
+names the wrapper its context needs: the `[ErrorConv StateTransitionError E]` bound rides the
+fault in as `.arithmetic` on the state machine (identity) and `.transition (.arithmetic …)` on
+the store machine, so one definition serves both, exactly as `sszGetIdx` does for `IndexError`.
+
+Two kinds of site reach it. The three checked operators below are the `uint64` over/underflows.
+The other is `get_inclusion_list_committee`'s `indices[i % len(indices)]` on an empty committee
+(`heze/beacon-chain.md:108-110`), a `ZeroDivisionError` rather than a `uint64` op, which lands
+in the same uncaught-fault class because the reference runner propagates it just the same. -/
+@[inline] def throwArithmetic {m : Type → Type u} {α E : Type} [Monad m] [MonadExcept E m]
+    [ErrorConv StateTransitionError E] (descr : String) : m α :=
+  liftErr (E := StateTransitionError) (.error (.arithmetic descr))
 
 /-- Checked `uint64` addition: the sum, or the `.arithmetic` fault on overflow (`a + b` wraps below
 `a`, the unsigned carry test). Mirrors remerkleable's `uint64.__add__`. -/
 @[inline] def checkedAdd {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
     [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
-  liftErr (E := StateTransitionError) <| if a + b < a then .error (.arithmetic descr) else .ok (a + b)
+  if a + b < a then throwArithmetic descr else pure (a + b)
 
 /-- Checked `uint64` subtraction: the difference, or the `.arithmetic` fault on underflow
 (`b > a`). Mirrors remerkleable's `uint64.__sub__` (the standing `balances[i] - withdrawn` case). -/
 @[inline] def checkedSub {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
     [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
-  liftErr (E := StateTransitionError) <| if b > a then .error (.arithmetic descr) else .ok (a - b)
+  if b > a then throwArithmetic descr else pure (a - b)
 
 /-- Checked `uint64` multiplication: the product, or the `.arithmetic` fault on overflow (`a ≠ 0`
 and the truncating `a * b / a` fails to recover `b`). Mirrors remerkleable's `uint64.__mul__`. -/
 @[inline] def checkedMul {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
     [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
-  liftErr (E := StateTransitionError) <| if a != 0 && a * b / a != b then .error (.arithmetic descr) else .ok (a * b)
+  if a != 0 && a * b / a != b then throwArithmetic descr else pure (a * b)
 
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -47,7 +47,7 @@ inductive StateTransitionError where
   /-- An uncaught arithmetic fault (a `uint64` over/underflow, or a `% 0`): the spec's `uintN`
   op raises Python `ValueError` (a `ZeroDivisionError` for `% 0`), which the reference runner's
   `expect_assertion_error` does NOT catch (it catches only `AssertionError` and `IndexError`,
-  `context.py:429-433`). So it is not an expected rejection but a genuine error, distinct from a
+  `context.py:424-435`). So it is not an expected rejection but a genuine error, distinct from a
   guarded `assert`: it `classify`s as `ClassifyBucket.uncaughtFault`, so an invalid vector that
   rejects this way FAILS rather than passing. `descr` names the faulting op, diagnostic only. The
   standing case is `get_balance_after_withdrawals`' `state.balances[i] - withdrawn`

--- a/packages/EthCLLib/EthCLLib/Spec/Errors.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Errors.lean
@@ -17,7 +17,8 @@ the *constructor* (its classify mode), which is typed:
 | `assert` | an expected rejection; an invalid vector should hit one |
 | `todo` | an unimplemented branch we intend to fill; a work-queue item, reported `xfail` |
 | `outOfScope` | a branch we deliberately do not model; reported `skip`, not counted as work |
-| `outOfBounds` / `missingKey` | a smell; well-formed input should not hit these |
+| `outOfBounds` / `decodeFailure` | a smell; well-formed input should not hit these, though the reference catches `IndexError` |
+| `missingKey` / `arithmetic` | a fault the reference propagates rather than catches, so it never rejects a vector |
 
 `todo` and `outOfScope` both name a branch that does not run, the distinction is
 intent: a `todo` is expected to pass once the work-queue reaches it, an
@@ -94,16 +95,17 @@ inductive ClassifyBucket where
   | todo
   /-- An `outOfScope` reject; a branch we deliberately do not model. Reported `skip`. -/
   | outOfScope
-  /-- An `outOfBounds` / `missingKey` / `decodeFailure` reject; a likely framework or spec bug.
-  For an invalid vector, an `outOfBounds` (`IndexError`) still counts as a rejection the
-  reference accepts, so the driver passes it (flagged). -/
+  /-- An `outOfBounds` / `decodeFailure` reject; a likely framework or spec bug. For an invalid
+  vector, an `outOfBounds` (`IndexError`) still counts as a rejection the reference accepts
+  (`context.py`'s `expect_assertion_error` catches `IndexError`), so the driver passes it
+  (flagged). -/
   | likelyBug
   /-- An uncaught Python fault the reference runner does NOT catch (a `uint64` `ValueError` from
-  `.arithmetic`, a `ZeroDivisionError`). Reports as a bug like `likelyBug`, but unlike
-  `likelyBug` it is never a valid rejection of an invalid vector: the reference would propagate
-  it as a genuine error, so the driver fails an invalid vector that rejects this way rather than
-  passing it. This is the reporting-side counterpart of `isExpectedRejection` excluding
-  `.transition (.arithmetic …)`. -/
+  `.arithmetic`, a `ZeroDivisionError`, or a bare-`Dict` `KeyError` from `.missingKey`). Reports
+  as a bug like `likelyBug`, but unlike `likelyBug` it is never a valid rejection of an invalid
+  vector: the reference would propagate it as a genuine error, so the driver fails an invalid
+  vector that rejects this way rather than passing it. This is the reporting-side counterpart of
+  `isExpectedRejection` excluding `.missingKey` and `.transition (.arithmetic …)`. -/
   | uncaughtFault
   deriving Inhabited, Repr, DecidableEq
 
@@ -135,26 +137,39 @@ def StoreTransitionError.classify : StoreTransitionError → ClassifyBucket
   | .assert _      => .expectedRejection
   | .todo _        => .todo
   | .outOfScope _  => .outOfScope
-  | .missingKey _  => .likelyBug
+  | .missingKey _  => .uncaughtFault
   | .decodeFailure _ => .likelyBug
   | .transition e  => e.classify
 
-/-- Whether a store reject is the expected rejection of a `valid: false` fork-choice step.
-The reference runner (`context.py:429-433`'s `expect_assertion_error`) catches `AssertionError`
-and `IndexError`, so exactly `.assert` (bare and `.transition`-wrapped) and the store machine's
+/-- Whether a store reject is the expected rejection of a `valid: false` fork-choice step
+under `expect_assertion_error` (`context.py:424-435`), which catches `AssertionError` and
+`IndexError`. So exactly `.assert` (bare and `.transition`-wrapped) and the store machine's
 only index-miss shape, `.transition (.outOfBounds …)`, count; `.missingKey` (an uncaught
 `KeyError`), `.transition (.arithmetic …)` (an uncaught `uint64` `ValueError`), `.todo` /
 `.outOfScope` (our own deferrals), and anything else do not.
 
+That wrapper scores the attestation, attester-slashing, envelope, and PTC-message steps. The
+block step is scored by `add_block`'s own `except (AssertionError, BlockNotFoundException)`
+(`fork_choice.py:387-395`), which never catches `IndexError`, so its admitted set is this one
+minus the index miss. `FcStepKind.admits` applies that narrowing; `isIndexMiss` is the shape
+it subtracts.
+
 This is a *different question* from `classify`, which buckets a reject for reporting (a
 `.transition (.outOfBounds)` is still a `likelyBug` there): `classify` answers "how do we
 report this reject", `isExpectedRejection` answers "does the reference accept it as the
-invalid step's expected raise". `checkStepValidity` is the sole caller; keeping the caught
-set here, next to `classify`, makes the two policies visibly distinct and edited in one
-place each. -/
+invalid step's expected raise". Keeping the caught set here, next to `classify`, makes the two
+policies visibly distinct and edited in one place each. -/
 def StoreTransitionError.isExpectedRejection : StoreTransitionError → Bool
   | .assert _
   | .transition (.assert _) | .transition (.outOfBounds _ _) => true
+  | _ => false
+
+/-- The store machine's index-miss shape, the reject standing for the spec's `IndexError`.
+`StoreTransitionError` has no bare `.outOfBounds`, so it is always the wrapped one. Split out
+so the step kinds whose reference wrapper does not catch `IndexError` can subtract exactly
+this from `isExpectedRejection`. -/
+def StoreTransitionError.isIndexMiss : StoreTransitionError → Bool
+  | .transition (.outOfBounds _ _) => true
   | _ => false
 
 /-- Build the `assert` / `todo` reject of an error type from its diagnostic descriptor.
@@ -240,5 +255,36 @@ it; `ErrorConv` is just the per-pair conversion that stdlib leaves to the caller
 @[inline] def liftErr {m : Type → Type u} {α E F : Type} [Monad m] [MonadExcept F m]
     [ErrorConv E F] (x : Except E α) : m α :=
   MonadExcept.ofExcept (x.mapError ErrorConv.conv)
+
+/-! ## Checked `uint64` arithmetic
+
+The spec's `uintN` arithmetic is *checked*: remerkleable reconstructs a `uint64` after every
+`+` / `-` / `*` (`basic.py`), so an over- or underflow raises Python `ValueError`. That
+`ValueError` is not an `AssertionError`, so the reference runner does not catch it
+(`context.py`); it is the `.arithmetic` uncaught fault (`classify`s as `uncaughtFault`, never an
+expected rejection). Lean's raw `UInt64` ops wrap instead of raising, so a spec `a + b` / `a - b`
+/ `a * b` that can leave the `uint64` range is modeled with these, not the bare operator. Each
+emits `StateTransitionError.arithmetic`; the `[ErrorConv StateTransitionError E]` bound rides it
+in as `.arithmetic` on the state machine (identity) and `.transition (.arithmetic …)` on the store
+machine, so one definition serves both, exactly as `sszGetIdx` does for `IndexError`. `descr` names
+the faulting op, diagnostic only. -/
+
+/-- Checked `uint64` addition: the sum, or the `.arithmetic` fault on overflow (`a + b` wraps below
+`a`, the unsigned carry test). Mirrors remerkleable's `uint64.__add__`. -/
+@[inline] def checkedAdd {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
+    [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
+  liftErr (E := StateTransitionError) <| if a + b < a then .error (.arithmetic descr) else .ok (a + b)
+
+/-- Checked `uint64` subtraction: the difference, or the `.arithmetic` fault on underflow
+(`b > a`). Mirrors remerkleable's `uint64.__sub__` (the standing `balances[i] - withdrawn` case). -/
+@[inline] def checkedSub {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
+    [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
+  liftErr (E := StateTransitionError) <| if b > a then .error (.arithmetic descr) else .ok (a - b)
+
+/-- Checked `uint64` multiplication: the product, or the `.arithmetic` fault on overflow (`a ≠ 0`
+and the truncating `a * b / a` fails to recover `b`). Mirrors remerkleable's `uint64.__mul__`. -/
+@[inline] def checkedMul {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
+    [ErrorConv StateTransitionError E] (a b : UInt64) (descr : String) : m UInt64 :=
+  liftErr (E := StateTransitionError) <| if a != 0 && a * b / a != b then .error (.arithmetic descr) else .ok (a * b)
 
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/FiniteMap.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/FiniteMap.lean
@@ -113,4 +113,17 @@ store map is read (the `Ord` instance lives with the spec's fork-choice store). 
     (mp : map (Vector UInt8 32) V) (k : Vector UInt8 32) : m V :=
   FcMap.getOrThrowKey mp k k
 
+/-- Look up `k`, or throw the spec's `assert` reject. The fused form of the pyspec pair
+`assert k in d` followed by `d[k]`: the membership assert is the spec's own opening line, so
+a miss is an *expected rejection* (`.assert`), where `getOrThrow`'s bare-`d[k]` miss is
+`missingKey` (a bug-smell). Post-assert the key is present, so binding the value at the
+assert site is observably identical to the spec's later read. `descr` renders the asserted
+condition, diagnostic only. -/
+def FcMap.getOrAssert {map : MapKind} [FcMap map] {K V : Type} [Ord K] [BEq K] [Hashable K]
+    {m : Type → Type} [Monad m] [MonadExceptOf StoreTransitionError m]
+    (mp : map K V) (k : K) (descr : String) : m V :=
+  match FcMap.lookup mp k with
+  | some v => pure v
+  | none   => throw (StoreTransitionError.assert descr)
+
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/Loop.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Loop.lean
@@ -44,20 +44,35 @@ def fuelLoop {β α : Type} {m : Type → Type u} [Monad m]
     | .done a => return a
     | .next b => fuelLoop fuel' b exhausted step
 
-/-- The pure sibling of `fuelLoop`, for a total recursive *walk* whose result is the
-accumulator itself: run `step` from `a` up to `fuel` times, stopping at the first
-`Step.done`, and returning the current accumulator if the fuel runs out. The fuel-out case
-returns `a` (the partial accumulator), matching a hand-rolled `| 0, a => a` walk, so supply
-a `fuel` bound the walk cannot exceed (a store / block count) and exhaustion is unreachable.
-Structural on `fuel`, total and kernel-reducible. Suits a fork-choice DAG walk whose step
-has a single continuation (`get_ancestor`, the `get_head` descent); a walk that recurses
-over many children at once (`filter_block_tree`) is genuine tree recursion and keeps its
-own helper. -/
-def fuelIterate {α : Type} (fuel : Nat) (a : α) (step : α → Step α α) : α :=
+/-- A bounded *walk* whose result is the accumulator itself: run `step` from `a` up to `fuel`
+times, stopping at the first `Step.done`, and returning the current accumulator if the fuel runs
+out. `step` runs in `m`, so the per-iteration body may read the store and throw. Structural on
+`fuel`, total. Distinct from `fuelLoop`, whose fuel-out returns a fixed `exhausted` value rather
+than the live accumulator; supply a `fuel` bound the walk cannot exceed (a store or block count)
+so that case is unreachable, and reach for `fuelIterateM!` where it is not. -/
+def fuelIterateM {α : Type} {m : Type → Type u} [Monad m]
+    (fuel : Nat) (a : α) (step : α → m (Step α α)) : m α := do
   match fuel with
-  | 0         => a
-  | fuel' + 1 => match step a with
-    | .done b => b
-    | .next b => fuelIterate fuel' b step
+  | 0         => return a
+  | fuel' + 1 => match ← step a with
+    | .done b => return b
+    | .next b => fuelIterateM fuel' b step
+
+/-- `fuelIterateM` with no slack: exhausting the fuel throws instead of returning.
+
+`fuelIterateM` returns the live accumulator on fuel-out, which suits a walk whose bound is a
+store or block count that structurally cannot be exceeded. The `on_tick` catch-up is not that
+walk: its bound is `(tick_slot - current_slot) + 1`, exact only because `1000` divides
+`SLOT_DURATION_MS` (true at both pinned presets, 12000 and 6000, and asserted nowhere), so a
+config breaking that divisibility would return a store whose clock never reached `time` and
+surface later as an unrelated `checks: time` mismatch. Throw instead, so the failure names
+itself. -/
+def fuelIterateM! {α : Type} {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
+    [SpecReject E] (fuel : Nat) (a : α) (what : String) (step : α → m (Step α α)) : m α := do
+  match fuel with
+  | 0         => throw (SpecReject.assert s!"{what}: loop fuel exhausted")
+  | fuel' + 1 => match ← step a with
+    | .done b => return b
+    | .next b => fuelIterateM! fuel' b what step
 
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/Loop.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Loop.lean
@@ -66,11 +66,20 @@ walk: its bound is `(tick_slot - current_slot) + 1`, exact only because `1000` d
 `SLOT_DURATION_MS` (true at both pinned presets, 12000 and 6000, and asserted nowhere), so a
 config breaking that divisibility would return a store whose clock never reached `time` and
 surface later as an unrelated `checks: time` mismatch. Throw instead, so the failure names
-itself. -/
+itself.
+
+Fuel-out rejects as `todo`, never `assert`. The bound belongs to this model rather than to any
+spec text, so exhausting it is a work-queue item, and `todo` is the class that reports one
+(`xfail`). `assert` is the class a runner scores as a vector's *expected* rejection, so a
+fuel-out on a `valid: false` step would pass green on a bound we know is wrong. That is the
+same reason `decodeFailure` stays out of `StoreTransitionError.isExpectedRejection`. Both
+current call sites are `on_tick`, whose steps carry no `valid` flag and always run
+`expectedValid := true`, so no verdict rides on this today. The class keeps it that way for
+the next caller. -/
 def fuelIterateM! {α : Type} {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
     [SpecReject E] (fuel : Nat) (a : α) (what : String) (step : α → m (Step α α)) : m α := do
   match fuel with
-  | 0         => throw (SpecReject.assert s!"{what}: loop fuel exhausted")
+  | 0         => throw (SpecReject.todo s!"{what}: loop fuel exhausted")
   | fuel' + 1 => match ← step a with
     | .done b => return b
     | .next b => fuelIterateM! fuel' b what step

--- a/packages/EthCLLib/EthCLLib/Spec/State.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/State.lean
@@ -143,4 +143,15 @@ over-length read. Same shape as `sszGetIdx`, on `Bitlist`'s faithful `[i]?`. -/
     | some b => .ok b
     | none   => .error (IndexError.indexError i bs.val.size)
 
+/-- `sszGetIdx` for a plain `Array`: element `i`, or the typed reject `outOfBounds i size`. The
+monadic safe read for a spec `list[i]` over a non-SSZ `Array`, e.g. a fork-choice `Store` value
+such as `block_timeliness`'s `list[boolean]` (`gloas/fork-choice.md:503,960`), where `[i]!` /
+`?.getD` would mask an over-length read as a silent default. Same shape as `sszGetIdx`, on the
+`Array`'s own `[i]?`. -/
+@[inline] def arrGetIdx {α : Type} {m : Type → Type u} {E : Type} [Monad m]
+    [MonadExcept E m] [ErrorConv IndexError E] (xs : Array α) (i : Nat) : m α :=
+  liftErr <| match xs[i]? with
+    | some a => .ok a
+    | none   => .error (IndexError.indexError i xs.size)
+
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/State.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/State.lean
@@ -90,20 +90,6 @@ here. -/
   | .ok _ post => .ok (stateRoot! post)
   | .error e _ => .error e
 
-/-- Run a best-effort state-machine action and keep the input state on failure. The
-keep-input-on-error twin of `runToRoot`: a fork-choice helper (`store_target_checkpoint_state`'s
-slot advance) runs a nested `EStateM StateTransitionError` action whose failure should leave the
-surrounding store unchanged, so it discards the reject and returns the pre-state `s` rather than
-threading it out. Generic over the state `S` (the per-fork `State` is concrete only inside a fork
-section), with the error pinned to `StateTransitionError`: that argument type is what forces a
-polymorphic action passed in (e.g. `processSlots target`) to resolve its monad to
-`EStateM StateTransitionError S`, replacing the open-coded `match act.run s with | .ok _ s' => s'
-| .error _ _ => s` and the metavariable-pinning annotation it needed. -/
-@[inline] def runBestEffort {S : Type} (act : EStateM StateTransitionError S Unit) (s : S) : S :=
-  match act.run s with
-  | .ok _ s'   => s'
-  | .error _ _ => s
-
 -- Re-export `IndexError` onto the spec surface, so a pure query reading `validators[i]` can
 -- be typed `Except IndexError α` under the single `open EthCLLib.Spec`.
 export SizzLean.Cache (IndexError)

--- a/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
@@ -30,6 +30,22 @@ namespace EthCLLib.Tests.FrameworkUtils
 #guard le8 (uint64ToBytes 258) = 258
 #guard le8 (uintToBytes (258 : UInt64)) = 258
 
+/-! ## Checked `uint64` arithmetic: the faithful over/underflow faults
+
+`checkedAdd` / `checkedSub` / `checkedMul` mirror remerkleable's `uint64`, which raises on
+over/underflow rather than wrapping. In range they reduce to `.ok`; out of range they raise the
+uncaught `.arithmetic` fault (never an expected rejection). The same source fault rides in as
+`.arithmetic` on the state machine and, via `[ErrorConv …]`, as `.transition (.arithmetic …)` on
+the store machine, so both instantiations are pinned. Faults are unreachable on well-formed
+vectors, so these guards are the only thing exercising the throw. -/
+#guard (checkedAdd 2 3 "x" : Except StateTransitionError UInt64).toOption = some 5
+#guard (checkedSub 5 3 "x" : Except StateTransitionError UInt64).toOption = some 2
+#guard (checkedMul 6 7 "x" : Except StateTransitionError UInt64).toOption = some 42
+#guard (checkedSub 3 5 "u" : Except StateTransitionError UInt64) matches .error (.arithmetic _)
+#guard (checkedAdd 0xffffffffffffffff 1 "o" : Except StateTransitionError UInt64) matches .error (.arithmetic _)
+#guard (checkedMul 0x8000000000000000 4 "o" : Except StateTransitionError UInt64) matches .error (.arithmetic _)
+#guard (checkedSub 3 5 "u" : Except StoreTransitionError UInt64) matches .error (.transition (.arithmetic _))
+
 /-! ## Map-backing equivalence: `treeMap` and `hashMap` agree -/
 
 private def pairs : List (Nat × Nat) := [(3, 30), (1, 10), (2, 20), (1, 11), (5, 50)]

--- a/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
@@ -46,6 +46,23 @@ vectors, so these guards are the only thing exercising the throw. -/
 #guard (checkedMul 0x8000000000000000 4 "o" : Except StateTransitionError UInt64) matches .error (.arithmetic _)
 #guard (checkedSub 3 5 "u" : Except StoreTransitionError UInt64) matches .error (.transition (.arithmetic _))
 
+/-! ## Fuel exhaustion: a deferral, never an expected rejection
+
+`fuelIterateM!` throws when its bound runs out. That bound is a modeling artifact rather than
+spec text, so the reject is `todo` (a work-queue `xfail`) and stays outside the caught set a
+runner scores as a `valid: false` step's expected rejection. Pinned on the constructor: a
+regression to `.assert` would turn a wrong loop bound into a green step, and breaks the build
+here instead. -/
+private def fuelOut : Except StoreTransitionError Nat :=
+  fuelIterateM! 0 (0 : Nat) "pin" fun n => pure (.next (n + 1))
+
+#guard fuelOut matches .error (.todo _)
+#guard (match fuelOut with | .error e => !e.isExpectedRejection | .ok _ => false)
+-- A walk inside its bound still returns normally: fuel 3 reaches the `.done` at 2.
+#guard (fuelIterateM! 3 (0 : Nat) "pin" (fun n =>
+  pure (if n ≥ 2 then .done n else .next (n + 1))) : Except StoreTransitionError Nat).toOption
+    = some 2
+
 /-! ## Map-backing equivalence: `treeMap` and `hashMap` agree -/
 
 private def pairs : List (Nat × Nat) := [(3, 30), (1, 10), (2, 20), (1, 11), (5, 50)]

--- a/packages/EthCLSpecs/EthCLSpecs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs.lean
@@ -1,6 +1,7 @@
 import EthCLSpecs.Forms
 import EthCLSpecs.Fulu
 import EthCLSpecs.Gloas
+import EthCLSpecs.Heze
 import EthCLSpecs.Proofs
 
 /-!

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Accessors.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Accessors.lean
@@ -37,12 +37,18 @@ forkdef getUnslashedParticipatingIndices (state : State) (flagIndex : Nat) (epoc
     if hasFlag (part[idx]!) flagIndex && !(validators[idx]!).slashed then out := out.push i
   return out
 
-/-- `get_block_root_at_slot`. -/
-forkdef getBlockRootAtSlot (state : State) (s : Slot) : Root :=
-  vmodGet (sszGet state blockRoots) s Const.slotsPerHistoricalRoot
+/-- `get_block_root_at_slot`. The pinned `assert slot < state.slot <= slot +
+SLOTS_PER_HISTORICAL_ROOT` is a recency guard that raises for a stale or future
+slot; throwing (`StateTransition`), so callers bind it. Unreachable in normal epoch
+processing (`start_slot < state.slot` holds), fires only on degenerate epoch-boundary
+near-zero-stake states (the path that makes `compute_pulled_up_tip`'s pjf reject
+reachable). -/
+forkdef getBlockRootAtSlot (state : State) (s : Slot) : StateTransition Root := do
+  assert (s < (sszGet state slot) && (sszGet state slot) ≤ s + UInt64.ofNat Const.slotsPerHistoricalRoot)
+  pure (vmodGet (sszGet state blockRoots) s Const.slotsPerHistoricalRoot)
 
 /-- `get_block_root` (the epoch's first slot). -/
-forkdef getBlockRoot (state : State) (epoch : Epoch) : Root :=
+forkdef getBlockRoot (state : State) (epoch : Epoch) : StateTransition Root :=
   getBlockRootAtSlot state (epoch * UInt64.ofNat Const.slotsPerEpoch)
 
 /-- `get_pending_balance_to_withdraw`. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Accessors.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Accessors.lean
@@ -44,7 +44,14 @@ processing (`start_slot < state.slot` holds), fires only on degenerate epoch-bou
 near-zero-stake states (the path that makes `compute_pulled_up_tip`'s pjf reject
 reachable). -/
 forkdef getBlockRootAtSlot (state : State) (s : Slot) : StateTransition Root := do
-  assert (s < (sszGet state slot) && (sszGet state slot) ≤ s + UInt64.ofNat Const.slotsPerHistoricalRoot)
+  -- `assert slot < state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT`. Python's chained comparison
+  -- short-circuits: `slot < state.slot` is checked first (a caught `AssertionError`), and only then
+  -- is `slot + SPHR` formed. That `uint64` sum raises `ValueError` on overflow, an uncaught fault the
+  -- runner does not catch, so it is `checkedAdd`, not a bare `+`, sequenced after the first assert.
+  assert (s < sszGet state slot)
+  let bound ← checkedAdd s (UInt64.ofNat Const.slotsPerHistoricalRoot)
+    "get_block_root_at_slot: slot + SLOTS_PER_HISTORICAL_ROOT"
+  assert (sszGet state slot ≤ bound)
   pure (vmodGet (sszGet state blockRoots) s Const.slotsPerHistoricalRoot)
 
 /-- `get_block_root` (the epoch's first slot). -/

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Constants.lean
@@ -140,6 +140,10 @@ abbrev maxConsolidationRequestsPerPayload : Nat := 2
 -- EIP-8282 (Gloas builder deposits / exits): 2**8 and 2**4, identical across presets.
 abbrev maxBuilderDepositRequestsPerPayload : Nat := 256
 abbrev maxBuilderExitRequestsPerPayload : Nat := 16
+-- EIP-7805 (Heze FOCIL): inclusion-list committee members per slot. A preset-file
+-- value, identical across presets at v1.7.0-alpha.11 (both say 2**4); re-check at
+-- every re-pin, and promote to a `Preset` field (like `ptcSize`) if they diverge.
+abbrev inclusionListCommitteeSize : Nat := 16
 abbrev maxAttestationsElectra : Nat := 8
 abbrev maxAttesterSlashingsElectra : Nat := 1
 abbrev maxPendingDepositsPerEpoch : Nat := 16
@@ -243,6 +247,10 @@ abbrev domainPtcAttester : ByteArray := ⟨#[0x0C, 0, 0, 0]⟩
 -- EIP-8282 `DOMAIN_BUILDER_DEPOSIT` (`0x0E000000`). Consumed by the deferred
 -- builder-deposit signature check; recorded now alongside the other domain tags.
 abbrev domainBuilderDeposit : ByteArray := ⟨#[0x0E, 0, 0, 0]⟩
+-- EIP-7805 `DOMAIN_INCLUSION_LIST_COMMITTEE` (`0x10000000`). The FOCIL inclusion-list
+-- committee signature domain; consumed by `Heze.isValidInclusionListSignature`. Recorded
+-- here with the other domain tags (where every fork's domains live, Heze's included).
+abbrev domainInclusionListCommittee : ByteArray := ⟨#[0x10, 0, 0, 0]⟩
 /-- ePBS fork-choice payload statuses for a `ForkChoiceNode`. -/
 abbrev payloadStatusEmpty : UInt8 := 0
 abbrev payloadStatusFull : UInt8 := 1
@@ -270,6 +278,10 @@ abbrev kzgCommitmentsInclusionProofDepth : Nat := 4
 (`ATTESTATION_DUE_BPS_GLOAS`, `PAYLOAD_ATTESTATION_DUE_BPS`). -/
 abbrev attestationDueBpsGloas : UInt64 := 2500
 abbrev payloadAttestationDueBps : UInt64 := 7500
+/-- `INCLUSION_LIST_DUE_BPS` (Heze:EIP7805, ~67% of the slot): the timeliness deadline
+for an inclusion list, in basis points of the slot
+(`consensus-specs/specs/heze/fork-choice.md:38`). -/
+abbrev inclusionListDueBps : UInt64 := 6667
 /-- `PROPOSER_SCORE_BOOST` (percent of the per-slot committee weight). -/
 abbrev proposerScoreBoost : Nat := 40
 /-- `BASIS_POINTS` denominator for the slot-component durations. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/EpochProcessing.lean
@@ -31,10 +31,19 @@ state_section
 
 /-- The justification-bits + checkpoint update, given the three target balances. -/
 forkdef weighJustificationAndFinalization (totalActive prevTarget currTarget : Gwei) :
-    StateTransition Unit :=
+    StateTransition Unit := do
+  let state ← get
+  let prevEpoch := previousEpochOf state
+  let currEpoch := currentEpochOf state
+  let justifyPrev := prevTarget.toNat * 3 ≥ totalActive.toNat * 2
+  let justifyCurr := currTarget.toNat * 3 ≥ totalActive.toNat * 2
+  -- `get_block_root` is read ONLY inside its justify branch in the spec (lazy); read
+  -- each only when its branch fires, so the recency assert fires exactly where the
+  -- spec's read does. An unconditional read would assert on an epoch-boundary pull-up
+  -- state whose justify condition is false, a slot the spec never reads there.
+  let prevRoot ← if justifyPrev then getBlockRoot state prevEpoch else pure default
+  let currRoot ← if justifyCurr then getBlockRoot state currEpoch else pure default
   modifyState fun state => Id.run do
-    let prevEpoch := previousEpochOf state
-    let currEpoch := currentEpochOf state
     let oldPrev := sszGet state previousJustifiedCheckpoint
     let oldCurr := sszGet state currentJustifiedCheckpoint
     let mut state := state
@@ -44,13 +53,13 @@ forkdef weighJustificationAndFinalization (totalActive prevTarget currTarget : G
     state := sszUpdate state with
       previousJustifiedCheckpoint := oldCurr,
       justificationBits := { data := (sszGet state justificationBits).data <<< 1 }
-    if prevTarget.toNat * 3 ≥ totalActive.toNat * 2 then
+    if justifyPrev then
       state := sszUpdate state with
-        currentJustifiedCheckpoint := { epoch := prevEpoch, root := getBlockRoot state prevEpoch },
+        currentJustifiedCheckpoint := { epoch := prevEpoch, root := prevRoot },
         justificationBits := bitSet (sszGet state justificationBits) 1 true
-    if currTarget.toNat * 3 ≥ totalActive.toNat * 2 then
+    if justifyCurr then
       state := sszUpdate state with
-        currentJustifiedCheckpoint := { epoch := currEpoch, root := getBlockRoot state currEpoch },
+        currentJustifiedCheckpoint := { epoch := currEpoch, root := currRoot },
         justificationBits := bitSet (sszGet state justificationBits) 0 true
 
     -- Finalize on the four supermajority-link bit patterns.

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/EpochProcessing.lean
@@ -278,7 +278,7 @@ forkdef processPendingDeposits : StateTransition Unit := do
 stops the scan; otherwise the source's effective balance moves to the target. -/
 forkdef pcLoop (cons : Array PendingConsolidation) (nextEpoch : Epoch) : StateTransition Nat :=
   -- Threaded accumulator is the next-pending index `npc`; `fuelLoop` owns the counter. Fuel is
-  -- `cons.size + 1` (the `fuelIterate` `length + 1` idiom): the `npc ≥ cons.size` guard fires as
+  -- `cons.size + 1`: the `npc ≥ cons.size` guard fires as
   -- a `.done` one step before exhaustion, so the `exhausted` value is unreachable. A slashed
   -- source `.next`s; an unwithdrawable source `.done`s; a moved balance `.next`s.
   fuelLoop (cons.size + 1) (0 : Nat) (cons.size) fun npc => do

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -101,15 +101,19 @@ forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
 /-! ## DAG walks -/
 
 /-- `get_ancestor(store, root, slot)`: walk parent links until at/below `slot`.
-Fuel-bounded by the block count (the DAG is finite and acyclic). -/
-forkdef getAncestor (store : Store map) (root : Root) (slot : Slot) : Root :=
-  fuelIterate ((FcMap.keys store.blocks).length + 1) root fun r =>
-    match FcMap.lookup store.blocks r with
-    | some block => if block.slot > slot then .next block.parentRoot else .done r
-    | none       => .done r
+Fuel-bounded by the block count (the DAG is finite and acyclic). The spec's
+`store.blocks[node.root]` is a plain `Dict` read, so a missing root raises:
+`getOrThrow` in the monadic `fuelLoop` step (the fuel-out value is unreachable, so
+`root` doubles as the `exhausted` sentinel). -/
+forkdef getAncestor (store : Store map) (root : Root) (slot : Slot) : StoreTransition Root :=
+  fuelLoop ((FcMap.keys store.blocks).length + 1) root root fun r => do
+    let block ← FcMap.getOrThrow store.blocks r
+    if block.slot > slot then pure (.next block.parentRoot)
+    else pure (.done r)
 
 /-- `get_checkpoint_block`. -/
-forkdef getCheckpointBlock (store : Store map) (root : Root) (epoch : Epoch) : Root :=
+forkdef getCheckpointBlock (store : Store map) (root : Root) (epoch : Epoch) :
+    StoreTransition Root :=
   getAncestor store root (computeStartSlotAtEpoch epoch)
 
 /-! ## Weights and head -/
@@ -122,99 +126,108 @@ forkdef committeeWeight (state : State) : Gwei :=
   getTotalActiveBalance state / UInt64.ofNat Const.slotsPerEpoch
 
 /-- `get_proposer_score`. -/
-forkdef getProposerScore (store : Store map) : Gwei :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint with
-  | none => 0
-  | some state =>
-    committeeWeight state * UInt64.ofNat Const.proposerScoreBoost / 100
+forkdef getProposerScore (store : Store map) : StoreTransition Gwei := do
+  let state ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  pure (committeeWeight state * UInt64.ofNat Const.proposerScoreBoost / 100)
 
 /-- `get_weight(store, root)`: attestation balance for `root`, plus the proposer
-boost if `root` is an ancestor of the boosted block. -/
-forkdef getWeight (store : Store map) (root : Root) : Gwei :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint,
-        FcMap.lookup store.blocks root with
-  | some state, some block =>
-    let active := getActiveValidatorIndices state (currentEpochOf state)
-    let validators := sszGet state validators
-    let attestationScore : Gwei := active.foldl (init := 0) fun acc i =>
-      let idx := i.toNat
-      if (validators[idx]!).slashed then acc
-      else match FcMap.lookup store.latestMessages i with
-        | some lm =>
-          if store.equivocatingIndices.contains i then acc
-          else if getAncestor store lm.root block.slot == root then acc + (validators[idx]!).effectiveBalance
-          else acc
-        | none => acc
-
-    -- Add the proposer boost when `root` is an ancestor of the boosted block.
-    if store.proposerBoostRoot == fcZeroRoot then attestationScore
-    else if getAncestor store store.proposerBoostRoot block.slot == root then
-      attestationScore + getProposerScore store
-    else attestationScore
-  | _, _ => 0
+boost if `root` is an ancestor of the boosted block. The `checkpoint_states` /
+`blocks` reads and the inlined `is_ancestor` walks are plain `Dict` reads that
+raise, so the query is monadic; the active-validator folds turn `foldlM` to bind
+the throwing `getAncestor`. -/
+forkdef getWeight (store : Store map) (root : Root) : StoreTransition Gwei := do
+  let state ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  let block ← FcMap.getOrThrow store.blocks root
+  let active := getActiveValidatorIndices state (currentEpochOf state)
+  let validators := sszGet state validators
+  let attestationScore ← active.foldlM (init := (0 : Gwei)) fun acc i => do
+    let idx := i.toNat
+    if (validators[idx]!).slashed then pure acc
+    else match FcMap.lookup store.latestMessages i with
+      | none => pure acc
+      | some lm =>
+        if store.equivocatingIndices.contains i then pure acc
+        else
+          let anc ← getAncestor store lm.root block.slot
+          if anc == root then pure (acc + (validators[idx]!).effectiveBalance) else pure acc
+  if store.proposerBoostRoot == fcZeroRoot then pure attestationScore
+  else
+    let anc ← getAncestor store store.proposerBoostRoot block.slot
+    if anc == root then
+      let ps ← getProposerScore store
+      pure (attestationScore + ps)
+    else pure attestationScore
 
 /-- `filter_block_tree`: collect the viable branches into `acc` (a key set),
 returning whether `blockRoot` is viable. The recursion is fuel-bounded by the block
-count (the block DAG is finite and acyclic, so the depth cannot exceed it), keeping
-the function total, no `partial def`, per the framework's termination discipline. -/
+count. Monadic: the opening `store.blocks[block_root]` read and the `get_voting_source`
+reads are plain `Dict`s that raise. -/
 forkdef filterBlockTree (store : Store map) (blockRoot : Root) (acc : Array Root) :
-    Array Root × Bool :=
+    StoreTransition (Array Root × Bool) :=
   go ((FcMap.keys store.blocks).length + 1) blockRoot acc
 where
-  /-- `get_voting_source(store, block_root)`. -/
-  getVotingSource (store : Store map) (blockRoot : Root) : Checkpoint :=
-    match FcMap.lookup store.blocks blockRoot with
-    | none => store.justifiedCheckpoint
-    | some block =>
-      let currentEpoch := getCurrentStoreEpoch store
-      if currentEpoch > computeEpochAtSlot block.slot then
-        FcMap.lookupD store.unrealizedJustifications blockRoot
-      else match FcMap.lookup store.blockStates blockRoot with
-        | some hs => sszGet hs currentJustifiedCheckpoint
-        | none    => store.justifiedCheckpoint
+  /-- `get_voting_source(store, block_root)`: all three reads (`blocks`,
+  `unrealized_justifications`, `block_states`) are raising `Dict` reads. -/
+  getVotingSource (store : Store map) (blockRoot : Root) : StoreTransition Checkpoint := do
+    let block ← FcMap.getOrThrow store.blocks blockRoot
+    let currentEpoch := getCurrentStoreEpoch store
+    if currentEpoch > computeEpochAtSlot block.slot then
+      FcMap.getOrThrow store.unrealizedJustifications blockRoot
+    else
+      let hs ← FcMap.getOrThrow store.blockStates blockRoot
+      pure (sszGet hs currentJustifiedCheckpoint)
   /-- The viability walk; `fuel` bounds the parent-to-child descent. -/
-  go : Nat → Root → Array Root → Array Root × Bool
-  | 0,        _,         acc => (acc, false)
-  | fuel + 1, blockRoot, acc =>
+  go : Nat → Root → Array Root → StoreTransition (Array Root × Bool)
+  | 0,        _,         acc => pure (acc, false)
+  | fuel + 1, blockRoot, acc => do
+    let _ ← FcMap.getOrThrow store.blocks blockRoot
     let children := FcMap.filterKeys store.blocks (fun _ b => b.parentRoot == blockRoot)
     if children.isEmpty then
       let currentEpoch := getCurrentStoreEpoch store
-      let votingSource := getVotingSource store blockRoot
+      let votingSource ← getVotingSource store blockRoot
       let correctJustified :=
         store.justifiedCheckpoint.epoch == Const.genesisEpoch
           || votingSource.epoch == store.justifiedCheckpoint.epoch
           || votingSource.epoch + 2 ≥ currentEpoch
-      let finalizedBlock := getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch
+      let finalizedBlock ← getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch
       let correctFinalized :=
         store.finalizedCheckpoint.epoch == Const.genesisEpoch
           || store.finalizedCheckpoint.root == finalizedBlock
-      if correctJustified && correctFinalized then (acc.push blockRoot, true) else (acc, false)
+      if correctJustified && correctFinalized then pure (acc.push blockRoot, true) else pure (acc, false)
     else
-      let (acc', anyViable) := children.foldl (init := (acc, false)) fun (a, viable) child =>
-        let (a', v) := go fuel child a
-        (a', viable || v)
-      if anyViable then (acc'.push blockRoot, true) else (acc', false)
+      let (acc', anyViable) ← children.foldlM (init := (acc, false)) fun (a, viable) child => do
+        let (a', v) ← go fuel child a
+        pure (a', viable || v)
+      if anyViable then pure (acc'.push blockRoot, true) else pure (acc', false)
 
 /-- `get_head`: the filtered-block-tree LMD-GHOST walk, ties broken by the
-lexicographically-greater root. Fuel-bounded by the block count. -/
-forkdef getHead (store : Store map) : Root :=
-  let (viable, _) := filterBlockTree store store.justifiedCheckpoint.root #[]
-  fuelIterate ((FcMap.keys store.blocks).length + 1) store.justifiedCheckpoint.root fun head =>
+lexicographically-greater root. Fuel-bounded. Monadic `fuelLoop`; the `max` fold is
+`foldlM` over the now-throwing `betterOf`. -/
+forkdef getHead (store : Store map) : StoreTransition Root := do
+  let (viable, _) ← filterBlockTree store store.justifiedCheckpoint.root #[]
+  fuelLoop ((FcMap.keys store.blocks).length + 1) store.justifiedCheckpoint.root
+      store.justifiedCheckpoint.root fun head => do
     let children := viable.filter fun r =>
       match FcMap.lookup store.blocks r with
       | some b => b.parentRoot == head
       | none   => false
-    if children.isEmpty then .done head
-    else .next (children.foldl (init := children[0]!) (betterOf store))
+    if children.isEmpty then pure (.done head)
+    else
+      let best ← children.foldlM (init := children[0]!) (betterOf store)
+      pure (.next best)
 where
-  /-- The better of two candidate heads under the `(weight, root)` ordering: greater
-  weight wins, ties broken by the greater root. -/
-  betterOf (store : Store map) (a b : Root) : Root :=
-    let weightA := getWeight store a
-    let weightB := getWeight store b
-    if weightA > weightB then a
-    else if weightB > weightA then b
-    else if compare a b == Ordering.gt then a else b
+  /-- The better of two candidate heads under the phase0 `(weight, root)` ordering:
+  greater weight wins, ties by greater root. Phase0 `get_head`'s sort key is the
+  2-tuple `(get_weight, child.root)`. The payload-status tiebreaker is a Gloas
+  addition, so only the two weights bind here. -/
+  betterOf (store : Store map) (a b : Root) : StoreTransition Root := do
+    let weightA ← getWeight store a
+    let weightB ← getWeight store b
+    if weightA > weightB then pure a
+    else if weightB > weightA then pure b
+    else if compare a b == Ordering.gt then pure a else pure b
 
 /-! ## Proposer-head reorg logic (`get_proposer_head`) -/
 
@@ -222,15 +235,21 @@ where
 forkdef calculateCommitteeFraction (state : State) (committeePercent : UInt64) : Gwei :=
   committeeWeight state * committeePercent / 100
 
-/-- `is_head_late`: the head block did not arrive before the attestation deadline. -/
-forkdef isHeadLate (store : Store map) (headRoot : Root) : Bool := !(FcMap.lookupD store.blockTimeliness headRoot)
+/-- `is_head_late`: the head block did not arrive before the attestation deadline.
+`store.block_timeliness[head_root]` is a raising `Dict` read. -/
+forkdef isHeadLate (store : Store map) (headRoot : Root) : StoreTransition Bool := do
+  let timely ← FcMap.getOrThrow store.blockTimeliness headRoot
+  pure (!timely)
 
 /-- `is_shuffling_stable`: not on an epoch boundary (where the shuffling could flip). -/
 forkdef isShufflingStable (slot : Slot) : Bool := slot % UInt64.ofNat Const.slotsPerEpoch != 0
 
-/-- `is_ffg_competitive`: head and parent carry the same unrealized justification. -/
-forkdef isFfgCompetitive (store : Store map) (headRoot parentRoot : Root) : Bool :=
-  FcMap.lookup store.unrealizedJustifications headRoot == FcMap.lookup store.unrealizedJustifications parentRoot
+/-- `is_ffg_competitive`: head and parent carry the same unrealized justification.
+Both `store.unrealized_justifications[...]` reads raise on a miss. -/
+forkdef isFfgCompetitive (store : Store map) (headRoot parentRoot : Root) : StoreTransition Bool := do
+  let h ← FcMap.getOrThrow store.unrealizedJustifications headRoot
+  let p ← FcMap.getOrThrow store.unrealizedJustifications parentRoot
+  pure (h == p)
 
 /-- `is_finalization_ok`: the chain is finalizing within `REORG_MAX_EPOCHS_SINCE_FINALIZATION`. -/
 forkdef isFinalizationOk (store : Store map) (slot : Slot) : Bool :=
@@ -242,49 +261,57 @@ forkdef isProposingOnTime (store : Store map) : Bool :=
   timeIntoSlotMs store ≤ bpsDeadlineMs Const.proposerReorgCutoffBps
 
 /-- `is_head_weak`: the head's weight is below the reorg-head threshold. -/
-forkdef isHeadWeak (store : Store map) (headRoot : Root) : Bool :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint with
-  | some js => getWeight store headRoot < calculateCommitteeFraction js Const.reorgHeadWeightThreshold
-  | none    => false
+forkdef isHeadWeak (store : Store map) (headRoot : Root) : StoreTransition Bool := do
+  let js ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  let hw ← getWeight store headRoot
+  pure (hw < calculateCommitteeFraction js Const.reorgHeadWeightThreshold)
 
-/-- `is_parent_strong`: the head's parent weight exceeds the reorg-parent threshold. -/
-forkdef isParentStrong (store : Store map) (root : Root) : Bool :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint, FcMap.lookup store.blocks root with
-  | some js, some b => getWeight store b.parentRoot > calculateCommitteeFraction js Const.reorgParentWeightThreshold
-  | _, _            => false
+/-- `is_parent_strong`: the head's parent weight exceeds the reorg-parent threshold.
+Phase0 `is_parent_strong` reads `store.blocks[root].parent_root` (raising) and scores
+the bare parent node, so the block read is faithful here. Gloas scores its parent at a
+synthetic PENDING node with no block read, so no throw belongs on that path. -/
+forkdef isParentStrong (store : Store map) (root : Root) : StoreTransition Bool := do
+  let js ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  let b ← FcMap.getOrThrow store.blocks root
+  let pw ← getWeight store b.parentRoot
+  pure (pw > calculateCommitteeFraction js Const.reorgParentWeightThreshold)
 
-/-- `is_proposer_equivocation`: more than one block from the head's proposer at its slot. -/
-forkdef isProposerEquivocation (store : Store map) (root : Root) : Bool :=
-  match FcMap.lookup store.blocks root with
-  | none       => false
-  | some block =>
-    ((FcMap.values store.blocks).filter
-      (fun b => b.proposerIndex == block.proposerIndex && b.slot == block.slot)).length > 1
+/-- `is_proposer_equivocation`: more than one block from the head's proposer at its
+slot. `store.blocks[root]` raises on a miss. -/
+forkdef isProposerEquivocation (store : Store map) (root : Root) : StoreTransition Bool := do
+  let block ← FcMap.getOrThrow store.blocks root
+  pure (((FcMap.values store.blocks).filter
+    (fun b => b.proposerIndex == block.proposerIndex && b.slot == block.slot)).length > 1)
 
 /-- `get_proposer_head`: whether a proposer at `slot` should reorg the current head
 (`head_root`) by building on its parent. Reorg the head when it is late, weak, on a
 stable shuffling, FFG-competitive, finalizing, proposed on time, exactly one slot
 back, and its parent is strong; or, more aggressively, when the head is weak and the
 previous slot had a proposer equivocation. Otherwise keep the head. -/
-forkdef getProposerHead (store : Store map) (headRoot : Root) (slot : Slot) : Root :=
+forkdef getProposerHead (store : Store map) (headRoot : Root) (slot : Slot) : StoreTransition Root := do
   match FcMap.lookup store.blocks headRoot with
-  | none => headRoot
+  | none => pure headRoot
   | some headBlock =>
     let parentRoot := headBlock.parentRoot
     match FcMap.lookup store.blocks parentRoot with
-    | none => headRoot
+    | none => pure headRoot
     | some parentBlock =>
       let currentTimeOk := headBlock.slot + 1 == slot
       let singleSlotReorg := parentBlock.slot + 1 == headBlock.slot && currentTimeOk
-      let headWeak := isHeadWeak store headRoot
+      let headWeak ← isHeadWeak store headRoot
       -- The spec asserts `proposer_boost_root != head_root` (boost has worn off);
-      -- model defensively as keeping the head rather than a panic.
-      if store.proposerBoostRoot == headRoot then headRoot
-      else if isHeadLate store headRoot && isShufflingStable slot && isFfgCompetitive store headRoot parentRoot
+      -- modeled defensively as keeping the head rather than a raise (an optional
+      -- helper; deliberate deviation, see the LANDED note). Only the Dict reads
+      -- above convert to throwing.
+      if store.proposerBoostRoot == headRoot then pure headRoot
+      else if (← isHeadLate store headRoot) && isShufflingStable slot
+          && (← isFfgCompetitive store headRoot parentRoot)
           && isFinalizationOk store slot && isProposingOnTime store && singleSlotReorg
-          && headWeak && isParentStrong store headRoot then parentRoot
-      else if headWeak && currentTimeOk && isProposerEquivocation store headRoot then parentRoot
-      else headRoot
+          && headWeak && (← isParentStrong store headRoot) then pure parentRoot
+      else if headWeak && currentTimeOk && (← isProposerEquivocation store headRoot) then pure parentRoot
+      else pure headRoot
 
 /-! ## Checkpoint updates -/
 
@@ -298,21 +325,21 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
 
 /-- `compute_pulled_up_tip`: pull up the block's post-state through
 `process_justification_and_finalization`, record the unrealized justification, and
-(for a prior-epoch block) realize it. The pull-up is best-effort (an inner failure
-leaves the store unchanged), so it stays an `EStateM.run`, not `runStateTransition`. -/
-forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : Store map :=
-  match FcMap.lookup store.blockStates blockRoot, FcMap.lookup store.blocks blockRoot with
-  | some state, some block =>
-    let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
-    match act.run state with
-    | .ok _ pulled =>
-      let cj := sszGet pulled currentJustifiedCheckpoint
-      let fz := sszGet pulled finalizedCheckpoint
-      let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-      let store := updateUnrealizedCheckpoints store cj fz
-      if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store
-    | .error _ _ => store
-  | _, _ => store
+(for a prior-epoch block) realize it. The `block_states` / `blocks` reads are raising
+`Dict`s, so monadic. The inner pull-up stays best-effort here — that swallow is a
+separate discrepancy (F8) removed in its own commit. -/
+forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
+  let state ← FcMap.getOrThrow store.blockStates blockRoot
+  let block ← FcMap.getOrThrow store.blocks blockRoot
+  let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
+  match act.run state with
+  | .ok _ pulled =>
+    let cj := sszGet pulled currentJustifiedCheckpoint
+    let fz := sszGet pulled finalizedCheckpoint
+    let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+    let store := updateUnrealizedCheckpoints store cj fz
+    pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
+  | .error _ _ => pure store
 
 /-! ## on_tick -/
 
@@ -344,11 +371,10 @@ forkdef onTick (time : UInt64) : StoreTransition Unit := do
 /-! ## on_block -/
 
 /-- `get_dependent_root` (v1.7): the block root that determined the current epoch's
-proposer shuffling. Used by the proposer-boost gate so a block on a different
-shuffling lineage than the current head is not boosted. -/
-forkdef getDependentRoot (store : Store map) (root : Root) : Root :=
+proposer shuffling. Monadic to bind the throwing `getAncestor`. -/
+forkdef getDependentRoot (store : Store map) (root : Root) : StoreTransition Root := do
   let epoch := getCurrentStoreEpoch store
-  if epoch ≤ Const.minSeedLookahead then fcZeroRoot
+  if epoch ≤ Const.minSeedLookahead then pure fcZeroRoot
   else getAncestor store root (computeStartSlotAtEpoch (epoch - Const.minSeedLookahead) - 1)
 
 /-! ## Data availability (PeerDAS, EIP-7594) -/
@@ -380,7 +406,7 @@ so an empty set rejects (the spec raises when columns are missing). -/
 forkdef isDataAvailable (cols : Array DataColumnSidecar) : Bool :=
   !cols.isEmpty && cols.all (fun sidecar => verifyDataColumnSidecar sidecar && verifyDataColumnSidecarKzgProofs sidecar)
 
-/-- `on_block`. Rejects (via `assert` / `missingKey`) an unknown parent, a future
+/-- `on_block`. Rejects (via `assert`) an unknown parent, a future
 block, a finality conflict, or unavailable blob data, and propagates a failed
 `state_transition` through `runStateTransition`. `columns` are the block's PeerDAS
 data-column sidecars (EIP-7594); the runner supplies exactly those the step lists. -/
@@ -388,11 +414,12 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) (columns : Array DataColumnSid
     StoreTransition Unit := do
   let store ← get
   let block := signedBlock.message
-  let parentState ← FcMap.getOrThrow store.blockStates block.parentRoot
+  let parentState ← FcMap.getOrAssert store.blockStates block.parentRoot
+    "block.parent_root in store.block_states"
   assert (getCurrentSlot store ≥ block.slot)
   let finalizedSlot := computeStartSlotAtEpoch store.finalizedCheckpoint.epoch
   assert (block.slot > finalizedSlot)
-  assert (store.finalizedCheckpoint.root == getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch)
+  assert (store.finalizedCheckpoint.root == (← getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch))
   -- Data availability (EIP-7594): only blocks carrying blob commitments need their
   -- columns sampled; a block with no blobs is trivially available.
   assert (block.body.blobKzgCommitments.toArray.isEmpty || isDataAvailable columns)
@@ -400,37 +427,49 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) (columns : Array DataColumnSid
   let postState ← runStateTransition parentState (stateTransition signedBlock)
   let blockRoot := htr block
   -- The head is taken BEFORE the new block is added (v1.7 `update_proposer_boost_root`).
-  let head := getHead store
+  let head ← getHead store
   let isTimely := getCurrentSlot store == block.slot && timeIntoSlotMs store < bpsDeadlineMs Const.attestationDueBps
 
-  let store := { store with
+  -- Insert the block, its post-state, and the timeliness flag. `set` before the boost
+  -- computation: `update_proposer_boost_root`'s dependent-root walks can raise, and so
+  -- does `compute_pulled_up_tip`'s pull-up, so each completed write must persist
+  -- (in-place runner semantics).
+  set { store with
     blocks := FcMap.insert store.blocks blockRoot block
     blockStates := FcMap.insert store.blockStates blockRoot postState
     blockTimeliness := FcMap.insert store.blockTimeliness blockRoot isTimely }
+  let store ← get
 
   -- Boost only a timely first block on the same proposer-shuffling lineage as the
-  -- pre-insertion head (v1.7 adds the `is_same_dependent_root` gate).
-  let isSameDependentRoot := getDependentRoot store blockRoot == getDependentRoot store head
-  let store := if isTimely && store.proposerBoostRoot == fcZeroRoot && isSameDependentRoot then
+  -- pre-insertion head (v1.7 `is_same_dependent_root`). Root-then-head evaluation
+  -- matches the pinned `get_dependent_root(store, root) == get_dependent_root(store, head)`.
+  let depRoot ← getDependentRoot store blockRoot
+  let depHead ← getDependentRoot store head
+  let store := if isTimely && store.proposerBoostRoot == fcZeroRoot && depHead == depRoot then
     { store with proposerBoostRoot := blockRoot } else store
+  set store
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
-  set (computePulledUpTip store blockRoot)
+  set store
+  set (← computePulledUpTip store blockRoot)
 
 /-! ## on_attestation -/
 
 /-- `store_target_checkpoint_state`: cache the target's state, advancing to the
-target epoch start if needed (best-effort, so `EStateM.run`). -/
-forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) : Store map :=
-  if FcMap.contains store.checkpointStates target then store
-  else match FcMap.lookup store.blockStates target.root with
-    | none => store
-    | some base =>
-      let targetSlot := computeStartSlotAtEpoch target.epoch
-      let advanced :=
-        if (sszGet base slot) < targetSlot then
-          runBestEffort (processSlots targetSlot) base
-        else base
-      { store with checkpointStates := FcMap.insert store.checkpointStates target advanced }
+target epoch start if needed. The pinned `process_slots` is unguarded, so a rejected
+advance propagates (wrapped `.transition`) and nothing is cached, aborting
+`on_attestation` with the store unchanged. The pre-conversion `runBestEffort` cached
+the UNADVANCED base state, a wrong-slot entry later reads would consume. -/
+forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
+    StoreTransition (Store map) := do
+  if FcMap.contains store.checkpointStates target then pure store
+  else
+    let base ← FcMap.getOrThrow store.blockStates target.root
+    let targetSlot := computeStartSlotAtEpoch target.epoch
+    let advanced ←
+      if (sszGet base slot) < targetSlot then
+        runStateTransition base (processSlots targetSlot)
+      else pure base
+    pure { store with checkpointStates := FcMap.insert store.checkpointStates target advanced }
 
 /-- `validate_on_attestation`. The epoch-scope check is skipped for a block-implied
 attestation (`is_from_block = true`); the rest always apply. -/
@@ -444,7 +483,7 @@ forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlo
   assert (FcMap.contains store.blocks att.data.beaconBlockRoot)
   let b ← FcMap.getOrThrow store.blocks att.data.beaconBlockRoot
   assert (b.slot ≤ att.data.slot)
-  assert (target.root == getCheckpointBlock store att.data.beaconBlockRoot target.epoch)
+  assert (target.root == (← getCheckpointBlock store att.data.beaconBlockRoot target.epoch))
   assert (getCurrentSlot store ≥ att.data.slot + 1)
 
 /-- `update_latest_messages` for the attesting indices (skipping equivocators). -/
@@ -464,7 +503,11 @@ forkdef updateLatestMessages (store : Store map) (attestingIndices : Array Valid
 forkdef onAttestation (att : Attestation) (isFromBlock : Bool) : StoreTransition Unit := do
   validateOnAttestation (← get) att isFromBlock
 
-  let store := storeTargetCheckpointState (← get) att.data.target
+  -- `store_target_checkpoint_state` mutates `checkpoint_states` before the
+  -- indexed-attestation assert below can reject; `set` at the pyspec statement
+  -- boundary so an expected rejection keeps the cache (in-place runner semantics).
+  let store ← storeTargetCheckpointState (← get) att.data.target
+  set store
   let targetState ← FcMap.getOrThrowKey store.checkpointStates att.data.target att.data.target.root
   let attesting := (← liftErr (getAttestingIndices targetState att)).qsort (· < ·)
   let indexedAttestation : IndexedAttestation := { attestingIndices := sszOfArray attesting, data := att.data, signature := att.signature }
@@ -521,5 +564,81 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
       unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp }
 
 end
+
+/-! ### Build-enforced pins (vectorless): the Fulu fork-choice throws
+
+These throw conversions' reject branches are unreachable by conformance vectors, so they
+are locked here, the same pattern as the Gloas pins. `pinStore` mirrors the
+`getForkchoiceStore` literal with every map empty. -/
+
+/-- The pins' concrete fork-choice monad: the minimal preset over `treeMap` + FFI hasher. -/
+private abbrev PinM := EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag)
+
+private def pinRoot : Root := Vector.replicate 32 9
+
+/-- A minimal empty Fulu `Store`. -/
+private def pinStore : @Store minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { time := 0, genesisTime := 0
+    justifiedCheckpoint := default, finalizedCheckpoint := default
+    unrealizedJustifiedCheckpoint := default, unrealizedFinalizedCheckpoint := default
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.empty
+    blockStates := FcMap.empty
+    blockTimeliness := FcMap.empty
+    checkpointStates := FcMap.empty
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.empty }
+
+/-- `getAncestor` rejects (`missingKey`) when the walk root is not in `store.blocks`,
+the pinned plain-`Dict` read; the pre-conversion `fuelIterate` returned the root as a
+silent `.done`. `FcMap`/hash-free, so kernel `#guard`. -/
+private def pinGetAncestorThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  match (getAncestor (map := treeMap) pinStore pinRoot 0 : PinM Root).run pinStore with
+  | .error (.missingKey _) _ => true
+  | _ => false
+#guard pinGetAncestorThrows = true
+
+/-- `getHead` rejects end-to-end when the justified-checkpoint root is unknown: the
+`filter_block_tree` opening read misses. Locks the whole `getHead` monadic path.
+`State`-free here (no checkpoint state read reached before the block miss), so `FcMap`
+kernel `#guard`. -/
+private def pinGetHeadThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let store := { pinStore with justifiedCheckpoint := { epoch := 0, root := pinRoot } }
+  match (getHead (map := treeMap) store : PinM Root).run store with
+  | .error (.missingKey _) _ => true
+  | _ => false
+#guard pinGetHeadThrows = true
+
+/-- `storeTargetCheckpointState` propagates a `process_slots` reject. The fixture
+state is `default` (zero validators, slot 0) carrying one queued `PendingConsolidation`:
+advancing to epoch 1 reaches `process_pending_consolidations`, whose plain-list read
+rejects (`outOfBounds`), and the unguarded pinned `process_slots` means the helper
+re-throws it (`.transition`) with nothing cached. The consolidation carrier is
+deliberate. A bare zero-validator advance grinds `cbwsAux`'s 10M fuel instead of
+rejecting. `State` is FFI-backed, so `native_decide`. -/
+private def pinTargetAdvanceRejects : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let bs : @EthCLSpecs.Fulu.BeaconState minimal :=
+    { (default : @EthCLSpecs.Fulu.BeaconState minimal) with
+      pendingConsolidations := sszOfArray #[{ sourceIndex := 0, targetIndex := 0 }] }
+  let state : State := SSZ.FastBox bs
+  let store := { pinStore with blockStates := FcMap.insert FcMap.empty pinRoot state }
+  let target : Checkpoint := { epoch := 1, root := pinRoot }
+  match (storeTargetCheckpointState (map := treeMap) store target : PinM (Store treeMap)).run store with
+  | .error (.transition _) _ => true
+  | _ => false
+example : pinTargetAdvanceRejects = true := by native_decide
 
 end EthCLSpecs.Fulu

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -339,22 +339,21 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
   if uf.epoch > store.unrealizedFinalizedCheckpoint.epoch then { store with unrealizedFinalizedCheckpoint := uf } else store
 
 /-- `compute_pulled_up_tip`: pull up the block's post-state through
-`process_justification_and_finalization`, record the unrealized justification, and
-(for a prior-epoch block) realize it. The `block_states` / `blocks` reads are raising
-`Dict`s, so monadic. The inner pull-up stays best-effort here — that swallow is a
-separate discrepancy (F8) removed in its own commit. -/
+`process_justification_and_finalization`, record its unrealized justification, and
+(for a prior-epoch block) realize it. The `block_states` / `blocks` reads raise on a
+miss, and the pull-up itself propagates: pyspec runs `process_justification_and_finalization`
+unguarded, so a reject (e.g. the restored `get_block_root_at_slot` recency assert on a
+degenerate epoch-boundary state) aborts the surrounding `on_block`, matching the Gloas
+and Heze twins. -/
 forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
   let state ← FcMap.getOrThrow store.blockStates blockRoot
   let block ← FcMap.getOrThrow store.blocks blockRoot
-  let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
-  match act.run state with
-  | .ok _ pulled =>
-    let cj := sszGet pulled currentJustifiedCheckpoint
-    let fz := sszGet pulled finalizedCheckpoint
-    let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-    let store := updateUnrealizedCheckpoints store cj fz
-    pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
-  | .error _ _ => pure store
+  let pulled ← runStateTransition state processJustificationAndFinalization
+  let cj := sszGet pulled currentJustifiedCheckpoint
+  let fz := sszGet pulled finalizedCheckpoint
+  let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+  let store := updateUnrealizedCheckpoints store cj fz
+  pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
 
 /-! ## on_tick -/
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -306,27 +306,36 @@ stable shuffling, FFG-competitive, finalizing, proposed on time, exactly one slo
 back, and its parent is strong; or, more aggressively, when the head is weak and the
 previous slot had a proposer equivocation. Otherwise keep the head. -/
 forkdef getProposerHead (store : Store map) (headRoot : Root) (slot : Slot) : StoreTransition Root := do
-  match FcMap.lookup store.blocks headRoot with
-  | none => pure headRoot
-  | some headBlock =>
-    let parentRoot := headBlock.parentRoot
-    match FcMap.lookup store.blocks parentRoot with
-    | none => pure headRoot
-    | some parentBlock =>
-      let currentTimeOk := headBlock.slot + 1 == slot
-      let singleSlotReorg := parentBlock.slot + 1 == headBlock.slot && currentTimeOk
-      let headWeak ← isHeadWeak store headRoot
-      -- The spec asserts `proposer_boost_root != head_root` (boost has worn off);
-      -- modeled defensively as keeping the head rather than a raise (an optional
-      -- helper; deliberate deviation, see the LANDED note). Only the Dict reads
-      -- above convert to throwing.
-      if store.proposerBoostRoot == headRoot then pure headRoot
-      else if (← isHeadLate store headRoot) && isShufflingStable slot
-          && (← isFfgCompetitive store headRoot parentRoot)
-          && isFinalizationOk store slot && isProposingOnTime store && singleSlotReorg
-          && headWeak && (← isParentStrong store headRoot) then pure parentRoot
-      else if headWeak && currentTimeOk && (← isProposerEquivocation store headRoot) then pure parentRoot
-      else pure headRoot
+  -- `store.blocks[head_root]` / `store.blocks[parent_root]` are plain `Dict` reads that
+  -- raise on a miss (phase0 `get_proposer_head`).
+  let headBlock ← FcMap.getOrThrow store.blocks headRoot
+  let parentRoot := headBlock.parentRoot
+  let parentBlock ← FcMap.getOrThrow store.blocks parentRoot
+  -- pyspec binds every predicate to a local before the two `all([...])` checks, so each
+  -- (throwing) read runs unconditionally and in this order. A lazy `&&` would skip a raise
+  -- the spec performs (e.g. `is_ffg_competitive`'s `unrealized_justifications` reads when
+  -- `is_head_late` is already false), so bind them all eagerly to reject exactly where
+  -- pyspec does. `isShufflingStable` is the pinned `is_epoch_boundary` (identical formula,
+  -- `slot % SLOTS_PER_EPOCH != 0`).
+  let headLate ← isHeadLate store headRoot
+  let epochBoundary := isShufflingStable slot
+  let ffgCompetitive ← isFfgCompetitive store headRoot parentRoot
+  let finalizationOk := isFinalizationOk store slot
+  let proposingOnTime := isProposingOnTime store
+  let currentTimeOk := headBlock.slot + 1 == slot
+  let singleSlotReorg := parentBlock.slot + 1 == headBlock.slot && currentTimeOk
+  -- `assert proposer_boost_root != head_root` (the boost has worn off): a faithful raise,
+  -- where this was previously modeled defensively as keeping the head. Placed after the
+  -- timing predicates and before the weight ones (`is_head_weak` / `is_parent_strong` /
+  -- `is_proposer_equivocation`), matching the spec's statement order. Vectorless.
+  assert (store.proposerBoostRoot != headRoot)
+  let headWeak ← isHeadWeak store headRoot
+  let parentStrong ← isParentStrong store headRoot
+  let proposerEquivocation ← isProposerEquivocation store headRoot
+  if headLate && epochBoundary && ffgCompetitive && finalizationOk && proposingOnTime
+      && singleSlotReorg && headWeak && parentStrong then pure parentRoot
+  else if headWeak && currentTimeOk && proposerEquivocation then pure parentRoot
+  else pure headRoot
 
 /-! ## Checkpoint updates -/
 
@@ -688,4 +697,31 @@ private def pinBalanceUnderflowThrows : Bool :=
   | .error (.arithmetic _) _ => true
   | _ => false
 example : pinBalanceUnderflowThrows = true := by native_decide
+
+/-- `getProposerHead` rejects (`.assert`) the restored `proposer_boost_root != head_root`
+guard: with the head and its parent present in `store.blocks`, the reads that precede the
+assert seeded (`blockTimeliness[head]` for `is_head_late`, `unrealizedJustifications` for
+head and parent for `is_ffg_competitive`), and the boost root equal to the head, the assert
+is the first reject, exactly as on a well-formed store handed in by `get_head`. Vectorless
+(a valid `get_proposer_head` is only reached once the boost has worn off). `native_decide`
+to keep the `BeaconBlock` reduction out of the kernel. -/
+private def pinProposerHeadBoostRejects : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let headBlock : @EthCLSpecs.Fulu.BeaconBlock minimal := default
+  let blocks := FcMap.insert (FcMap.insert FcMap.empty pinRoot headBlock) headBlock.parentRoot headBlock
+  let timeliness := FcMap.insert FcMap.empty pinRoot true
+  let uj := FcMap.insert (FcMap.insert FcMap.empty pinRoot (default : Checkpoint))
+    headBlock.parentRoot (default : Checkpoint)
+  let store := { pinStore with
+      blocks := blocks
+      blockTimeliness := timeliness
+      unrealizedJustifications := uj
+      proposerBoostRoot := pinRoot }
+  match (getProposerHead (map := treeMap) store pinRoot 0 : PinM Root).run store with
+  | .error (.assert _) _ => true
+  | _ => false
+example : pinProposerHeadBoostRejects = true := by native_decide
+
 end EthCLSpecs.Fulu

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -641,4 +641,37 @@ private def pinTargetAdvanceRejects : Bool :=
   | _ => false
 example : pinTargetAdvanceRejects = true := by native_decide
 
+/-- `balanceAfterWithdrawals` rejects (`outOfBounds`) on an out-of-range validator
+index: the pinned bare `state.balances[vi]` list read. A `default` state has zero
+validators, so index 99 misses, where the pre-conversion `def` clamped
+(`balances[vi]!` defaulting, `0` on underflow). `State` is FFI-backed, so
+`native_decide`. -/
+private def pinBalanceAfterWithdrawalsThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Fulu.BeaconState minimal)
+  match (balanceAfterWithdrawals state 99 #[] : EStateM StateTransitionError State Gwei).run state with
+  | .error (.outOfBounds _ _) _ => true
+  | _ => false
+example : pinBalanceAfterWithdrawalsThrows = true := by native_decide
+
+/-- `balanceAfterWithdrawals` rejects (`.arithmetic`) a `uint64` underflow: a validator whose
+queued withdrawals exceed its balance drives `balances[vi] - withdrawn` negative
+(`capella/beacon-chain.md:378`), which pyspec raises as `ValueError`, uncaught by the reference
+runner (`context.py:429-433`), so the Lean throws the uncaught `.arithmetic` reject rather than a
+caught `.assert`. Fixture: balance 5 at index 0, a queued withdrawal of 10. `State` is FFI-backed,
+so `native_decide`. -/
+private def pinBalanceUnderflowThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let bs : @EthCLSpecs.Fulu.BeaconState minimal :=
+    { (default : @EthCLSpecs.Fulu.BeaconState minimal) with balances := sszOfArray #[(5 : Gwei)] }
+  let state : State := SSZ.FastBox bs
+  let w : Withdrawal := { (default : Withdrawal) with validatorIndex := 0, amount := 10 }
+  match (balanceAfterWithdrawals state 0 #[w] : EStateM StateTransitionError State Gwei).run state with
+  | .error (.arithmetic _) _ => true
+  | _ => false
+example : pinBalanceUnderflowThrows = true := by native_decide
 end EthCLSpecs.Fulu

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -490,24 +490,35 @@ forkdef onAttesterSlashing (asl : AttesterSlashing) : StoreTransition Unit := do
 
 /-! ## get_forkchoice_store -/
 
-/-- `get_forkchoice_store(anchor_state, anchor_block)`. The anchor block's root is
-computed from the (state-root-filled) anchor block. -/
-forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
+/-- `get_forkchoice_store(anchor_state, anchor_block)`
+(`consensus-specs/specs/phase0/fork-choice.md:215-216`). The pyspec opens with
+`assert anchor_block.state_root == hash_tree_root(anchor_state)`, the anchor's
+self-consistency check, so the seed is a throwing `Except StoreTransitionError` action rather
+than a total store literal. The reject branch is vectorless (the harness derives the anchor
+block and state from one vector, so `state_root` always matches); Heze's `pinAnchorRejects`
+locks the identical assert, and this Fulu constructor carries it verbatim. The anchor block's
+root is computed from the (state-root-filled) anchor block. -/
+forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
+    Except StoreTransitionError (Store map) := do
+  -- `anchor_block.state_root == hash_tree_root(anchor_state)`: the boxed state hashes
+  -- through `stateRoot` (the cached-tree path), not `htr` (which wants a bare `SSZRepr`).
+  assert (anchorBlock.stateRoot == bytesToRoot (stateRoot anchorState).1)
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
-  { time := (sszGet anchorState genesisTime) + Const.secondsPerSlot * (sszGet anchorState slot)
-    genesisTime := sszGet anchorState genesisTime
-    justifiedCheckpoint := cp, finalizedCheckpoint := cp
-    unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
-    proposerBoostRoot := fcZeroRoot
-    equivocatingIndices := #[]
-    blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
-    blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
-    blockTimeliness := FcMap.empty
-    checkpointStates := FcMap.insert FcMap.empty cp anchorState
-    latestMessages := FcMap.empty
-    unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp }
+  pure
+    { time := (sszGet anchorState genesisTime) + Const.secondsPerSlot * (sszGet anchorState slot)
+      genesisTime := sszGet anchorState genesisTime
+      justifiedCheckpoint := cp, finalizedCheckpoint := cp
+      unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
+      proposerBoostRoot := fcZeroRoot
+      equivocatingIndices := #[]
+      blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
+      blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
+      blockTimeliness := FcMap.empty
+      checkpointStates := FcMap.insert FcMap.empty cp anchorState
+      latestMessages := FcMap.empty
+      unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp }
 
 end
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -82,15 +82,30 @@ forkdef fcZeroRoot : Root := Vector.replicate 32 0
 
 /-! ## Time / slot accessors -/
 
+/-- `seconds_to_milliseconds` (phase0 fork-choice.md): convert seconds to
+milliseconds, clamping to `UINT64_MAX` on overflow. The clamp is unreachable at
+realistic slot counts (`seconds` stays far below `UINT64_MAX // 1000`); modeled to
+mirror the pinned helper exactly. The spec calls it only from `time_into_slot`, so it
+backs `timeIntoSlotMs` alone; the other clock sites use the raw `* 1000` form the spec
+uses there. Shared with Gloas (`Fulu.secondsToMilliseconds`). -/
+def secondsToMilliseconds (seconds : UInt64) : UInt64 :=
+  if seconds > (0xffffffffffffffff : UInt64) / 1000 then (0xffffffffffffffff : UInt64)
+  else seconds * 1000
+
+/-- `get_slots_since_genesis`, ms-based: `(time - genesis) * 1000 // SLOT_DURATION_MS`
+(phase0 fork-choice.md:242). Raw `* 1000`, not `seconds_to_milliseconds` (the spec
+clamps only `time_into_slot`). Value-equivalent to the prior `/ secondsPerSlot` form
+since `slotDurationMs == secondsPerSlot * 1000`. -/
 forkdef getSlotsSinceGenesis (store : Store map) : UInt64 :=
-  (store.time - store.genesisTime) / Const.secondsPerSlot
+  ((store.time - store.genesisTime) * 1000) / Const.slotDurationMs
 forkdef getCurrentSlot (store : Store map) : Slot := Const.genesisSlot + getSlotsSinceGenesis store
 forkdef getCurrentStoreEpoch (store : Store map) : Epoch := computeEpochAtSlot (getCurrentSlot store)
 
-/-- `time_into_slot`, in milliseconds: wall-clock elapsed since the slot start, modulo the
-slot length. The store clock is in seconds, converted with `* 1000`. -/
+/-- `time_into_slot`, in milliseconds: wall-clock elapsed since the slot start, modulo
+the slot length, via the overflow-guarded `seconds_to_milliseconds` (the one spec site
+that clamps). -/
 forkdef timeIntoSlotMs (store : Store map) : UInt64 :=
-  ((store.time - store.genesisTime) * 1000) % Const.slotDurationMs
+  secondsToMilliseconds (store.time - store.genesisTime) % Const.slotDurationMs
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full
@@ -357,10 +372,10 @@ where
 /-- `advance_store_time`: catch up slot-by-slot, then set the exact time (the pure
 core of `on_tick`). Fuel-bounded by the number of slots to advance. -/
 forkdef advanceStoreTime (store : Store map) (time : UInt64) : Store map :=
-  fuelIterate ((((time - store.genesisTime) / Const.secondsPerSlot) - getCurrentSlot store).toNat + 1) store fun store =>
-    let tickSlot := (time - store.genesisTime) / Const.secondsPerSlot
+  fuelIterate ((((time - store.genesisTime) * 1000 / Const.slotDurationMs) - getCurrentSlot store).toNat + 1) store fun store =>
+    let tickSlot := (time - store.genesisTime) * 1000 / Const.slotDurationMs
     if getCurrentSlot store < tickSlot then
-      let previousTime := store.genesisTime + (getCurrentSlot store + 1) * Const.secondsPerSlot
+      let previousTime := store.genesisTime + (getCurrentSlot store + 1) * Const.slotDurationMs / 1000
       .next (onTickPerSlot store previousTime)
     else .done (onTickPerSlot store time)
 
@@ -550,7 +565,7 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
   pure
-    { time := (sszGet anchorState genesisTime) + Const.secondsPerSlot * (sszGet anchorState slot)
+    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
       genesisTime := sszGet anchorState genesisTime
       justifiedCheckpoint := cp, finalizedCheckpoint := cp
       unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -181,6 +181,13 @@ forkdef getWeight (store : Store map) (root : Root) : StoreTransition Gwei := do
   -- branch outright on a zero boost root. Hoisting the read made an empty-`latest_messages`
   -- store, exactly what `get_forkchoice_store` hands back, raise `.missingKey` where the
   -- reference returns `Gwei(0)`. The Gloas twin already defers it.
+  -- Two non-conversions here are deliberate, since the reads and sums around them did convert.
+  -- `validators[idx]!` stays unchecked: `idx` comes from `getActiveValidatorIndices` on the same
+  -- `state` the array belongs to, so it is in range by construction, and the Gloas
+  -- `getAttestationScore` fold keeps it for that reason too. The two `Gwei` sums below stay bare
+  -- `+` rather than `checkedAdd` because they are operands of the weight path, which converts as
+  -- one piece: `getTotalBalance` underneath still wraps, so checking these alone would move a
+  -- wrong number around instead of catching it.
   let active := getActiveValidatorIndices state (currentEpochOf state)
   let validators := sszGet state validators
   let attestationScore ← active.foldlM (init := (0 : Gwei)) fun acc i => do

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -300,11 +300,11 @@ forkdef isFfgCompetitive (store : Store map) (headRoot parentRoot : Root) : Stor
 
 /-- `is_finalization_ok`: the chain is finalizing within `REORG_MAX_EPOCHS_SINCE_FINALIZATION`.
 pyspec (`phase0/fork-choice.md:609-611`) computes the epoch gap as a checked `uint64`
-subtraction that raises `ValueError`. `on_tick` sets `store.time` for any `time` with no
-monotonicity assert, so a tick moving the clock back below the finalized epoch's start slot is
-reachable for conforming input: the bare `-` wrapped to `2^64-1`, compared `≤ 2` as false, and
-returned a fabricated `finalizationOk := false` where the reference errors. Throwing, so the
-caller binds it. -/
+subtraction that raises `ValueError`. `on_tick_per_slot` sets `store.time = time` with no
+monotonicity assert (`phase0/fork-choice.md:750-754`), so the spec permits a tick that moves
+the clock back below the finalized epoch's start slot, where the subtraction underflows.
+`checkedSub` rejects there. No conformance vector emits a backwards tick, so the path is
+unreachable in the corpus and carries no pin. Throwing, so the caller binds it. -/
 forkdef isFinalizationOk (store : Store map) (slot : Slot) : StoreTransition Bool := do
   let gap ← checkedSub (computeEpochAtSlot slot) store.finalizedCheckpoint.epoch
     "is_finalization_ok: compute_epoch_at_slot(slot) - finalized_checkpoint.epoch"
@@ -790,7 +790,7 @@ example : pinBalanceAfterWithdrawalsThrows = true := by native_decide
 /-- `balanceAfterWithdrawals` rejects (`.arithmetic`) a `uint64` underflow: a validator whose
 queued withdrawals exceed its balance drives `balances[vi] - withdrawn` negative
 (`capella/beacon-chain.md:378`), which pyspec raises as `ValueError`, uncaught by the reference
-runner (`context.py:429-433`), so the Lean throws the uncaught `.arithmetic` reject rather than a
+runner (`context.py:424-435`), so the Lean throws the uncaught `.arithmetic` reject rather than a
 caught `.assert`. Fixture: balance 5 at index 0, a queued withdrawal of 10. `State` is FFI-backed,
 so `native_decide`. -/
 private def pinBalanceUnderflowThrows : Bool :=

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -94,18 +94,30 @@ def secondsToMilliseconds (seconds : UInt64) : UInt64 :=
 
 /-- `get_slots_since_genesis`, ms-based: `(time - genesis) * 1000 // SLOT_DURATION_MS`
 (phase0 fork-choice.md:242). Raw `* 1000`, not `seconds_to_milliseconds` (the spec
-clamps only `time_into_slot`). Value-equivalent to the prior `/ secondsPerSlot` form
-since `slotDurationMs == secondsPerSlot * 1000`. -/
-forkdef getSlotsSinceGenesis (store : Store map) : UInt64 :=
-  ((store.time - store.genesisTime) * 1000) / Const.slotDurationMs
-forkdef getCurrentSlot (store : Store map) : Slot := Const.genesisSlot + getSlotsSinceGenesis store
-forkdef getCurrentStoreEpoch (store : Store map) : Epoch := computeEpochAtSlot (getCurrentSlot store)
+clamps only `time_into_slot`). Throwing (`StoreTransition`): both `time - genesis_time`
+(underflow when a tick predates genesis) and `* 1000` (overflow) are `uint64` ops that raise
+`ValueError`, which the reference runner does not catch, so they are `checkedSub` / `checkedMul`
+faults (`.transition (.arithmetic …)`), not the bare wrapping operators. The `// SLOT_DURATION_MS`
+divide by the positive constant never faults. -/
+forkdef getSlotsSinceGenesis (store : Store map) : StoreTransition UInt64 := do
+  let elapsed ← checkedSub store.time store.genesisTime "get_slots_since_genesis: time - genesis_time"
+  let ms ← checkedMul elapsed 1000 "get_slots_since_genesis: (time - genesis_time) * 1000"
+  pure (ms / Const.slotDurationMs)
+/-- `get_current_slot`. `GENESIS_SLOT` is `0`, so the `+` cannot overflow; the throw rides up from
+`getSlotsSinceGenesis`. -/
+forkdef getCurrentSlot (store : Store map) : StoreTransition Slot := do
+  pure (Const.genesisSlot + (← getSlotsSinceGenesis store))
+forkdef getCurrentStoreEpoch (store : Store map) : StoreTransition Epoch := do
+  pure (computeEpochAtSlot (← getCurrentSlot store))
 
 /-- `time_into_slot`, in milliseconds: wall-clock elapsed since the slot start, modulo
 the slot length, via the overflow-guarded `seconds_to_milliseconds` (the one spec site
-that clamps). -/
-forkdef timeIntoSlotMs (store : Store map) : UInt64 :=
-  secondsToMilliseconds (store.time - store.genesisTime) % Const.slotDurationMs
+that clamps). Throwing (`StoreTransition`): the `store.time - genesis_time` seconds are a
+`uint64` subtraction that raises on underflow (`checkedSub`); `seconds_to_milliseconds` clamps
+its own `* 1000`, so no further fault rides after it. -/
+forkdef timeIntoSlotMs (store : Store map) : StoreTransition UInt64 := do
+  let seconds ← checkedSub store.time store.genesisTime "time_into_slot: time - genesis_time"
+  pure (secondsToMilliseconds seconds % Const.slotDurationMs)
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full
@@ -113,7 +125,14 @@ BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor land
 forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
   bps * Const.slotDurationMs / Const.basisPoints
 
-/-! ## DAG walks -/
+/-! ## DAG walks
+
+Every walk below is `fuelLoop`-bounded rather than closed by `termination_by`, which
+`SPECS_ARCHITECTURE.md` §7.2 asks each loop to justify. The reason is the same at all of
+them: the reads raise, so the walk is monadic, and a measure would have to be carried
+through a step that can reject. The bounds are honest counts (the block count on a finite
+acyclic DAG), so fuel-out is unreachable and each site names the sentinel it would return.
+-/
 
 /-- `get_ancestor(store, root, slot)`: walk parent links until at/below `slot`.
 Fuel-bounded by the block count (the DAG is finite and acyclic). The spec's
@@ -154,7 +173,11 @@ the throwing `getAncestor`. -/
 forkdef getWeight (store : Store map) (root : Root) : StoreTransition Gwei := do
   let state ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
     store.justifiedCheckpoint.root
-  let block ← FcMap.getOrThrow store.blocks root
+  -- pyspec reads `store.blocks[...]` only inside `is_ancestor`, which the generator reaches only
+  -- for a validator carrying a latest message that is not equivocating, and it skips the boost
+  -- branch outright on a zero boost root. Hoisting the read made an empty-`latest_messages`
+  -- store, exactly what `get_forkchoice_store` hands back, raise `.missingKey` where the
+  -- reference returns `Gwei(0)`. The Gloas twin already defers it.
   let active := getActiveValidatorIndices state (currentEpochOf state)
   let validators := sszGet state validators
   let attestationScore ← active.foldlM (init := (0 : Gwei)) fun acc i => do
@@ -165,10 +188,12 @@ forkdef getWeight (store : Store map) (root : Root) : StoreTransition Gwei := do
       | some lm =>
         if store.equivocatingIndices.contains i then pure acc
         else
+          let block ← FcMap.getOrThrow store.blocks root
           let anc ← getAncestor store lm.root block.slot
           if anc == root then pure (acc + (validators[idx]!).effectiveBalance) else pure acc
   if store.proposerBoostRoot == fcZeroRoot then pure attestationScore
   else
+    let block ← FcMap.getOrThrow store.blocks root
     let anc ← getAncestor store store.proposerBoostRoot block.slot
     if anc == root then
       let ps ← getProposerScore store
@@ -187,7 +212,7 @@ where
   `unrealized_justifications`, `block_states`) are raising `Dict` reads. -/
   getVotingSource (store : Store map) (blockRoot : Root) : StoreTransition Checkpoint := do
     let block ← FcMap.getOrThrow store.blocks blockRoot
-    let currentEpoch := getCurrentStoreEpoch store
+    let currentEpoch ← getCurrentStoreEpoch store
     if currentEpoch > computeEpochAtSlot block.slot then
       FcMap.getOrThrow store.unrealizedJustifications blockRoot
     else
@@ -200,12 +225,19 @@ where
     let _ ← FcMap.getOrThrow store.blocks blockRoot
     let children := FcMap.filterKeys store.blocks (fun _ b => b.parentRoot == blockRoot)
     if children.isEmpty then
-      let currentEpoch := getCurrentStoreEpoch store
+      let currentEpoch ← getCurrentStoreEpoch store
       let votingSource ← getVotingSource store blockRoot
-      let correctJustified :=
+      let justifiedWithoutHorizon :=
         store.justifiedCheckpoint.epoch == Const.genesisEpoch
           || votingSource.epoch == store.justifiedCheckpoint.epoch
-          || votingSource.epoch + 2 ≥ currentEpoch
+      -- Python's `or` short-circuits, so it forms `voting_source.epoch + 2` only once the two
+      -- earlier disjuncts fail. Bind it in that branch alone: an eager checked add would raise
+      -- on a sum the reference never evaluates.
+      -- `decide` because `≥` on `UInt64` is a `Prop`: in the original the comparison sat inside
+      -- a `Bool` `||` chain, which drove the coercion; standalone under `pure` it needs saying.
+      let correctJustified ← if justifiedWithoutHorizon then pure true else do
+        let horizon ← checkedAdd votingSource.epoch 2 "filter_block_tree: voting_source.epoch + 2"
+        pure (decide (horizon ≥ currentEpoch))
       let finalizedBlock ← getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch
       let correctFinalized :=
         store.finalizedCheckpoint.epoch == Const.genesisEpoch
@@ -219,7 +251,7 @@ where
 
 /-- `get_head`: the filtered-block-tree LMD-GHOST walk, ties broken by the
 lexicographically-greater root. Fuel-bounded. Monadic `fuelLoop`; the `max` fold is
-`foldlM` over the now-throwing `betterOf`. -/
+`foldlM`, since `betterOf` can reject. -/
 forkdef getHead (store : Store map) : StoreTransition Root := do
   let (viable, _) ← filterBlockTree store store.justifiedCheckpoint.root #[]
   fuelLoop ((FcMap.keys store.blocks).length + 1) store.justifiedCheckpoint.root
@@ -266,14 +298,22 @@ forkdef isFfgCompetitive (store : Store map) (headRoot parentRoot : Root) : Stor
   let p ← FcMap.getOrThrow store.unrealizedJustifications parentRoot
   pure (h == p)
 
-/-- `is_finalization_ok`: the chain is finalizing within `REORG_MAX_EPOCHS_SINCE_FINALIZATION`. -/
-forkdef isFinalizationOk (store : Store map) (slot : Slot) : Bool :=
-  computeEpochAtSlot slot - store.finalizedCheckpoint.epoch ≤ Const.reorgMaxEpochsSinceFinalization
+/-- `is_finalization_ok`: the chain is finalizing within `REORG_MAX_EPOCHS_SINCE_FINALIZATION`.
+pyspec (`phase0/fork-choice.md:609-611`) computes the epoch gap as a checked `uint64`
+subtraction that raises `ValueError`. `on_tick` sets `store.time` for any `time` with no
+monotonicity assert, so a tick moving the clock back below the finalized epoch's start slot is
+reachable for conforming input: the bare `-` wrapped to `2^64-1`, compared `≤ 2` as false, and
+returned a fabricated `finalizationOk := false` where the reference errors. Throwing, so the
+caller binds it. -/
+forkdef isFinalizationOk (store : Store map) (slot : Slot) : StoreTransition Bool := do
+  let gap ← checkedSub (computeEpochAtSlot slot) store.finalizedCheckpoint.epoch
+    "is_finalization_ok: compute_epoch_at_slot(slot) - finalized_checkpoint.epoch"
+  pure (gap ≤ Const.reorgMaxEpochsSinceFinalization)
 
 /-- `is_proposing_on_time`: within the reorg cutoff of the slot start (ms timing; the
-store clock is seconds, converted via `* 1000`). -/
-forkdef isProposingOnTime (store : Store map) : Bool :=
-  timeIntoSlotMs store ≤ bpsDeadlineMs Const.proposerReorgCutoffBps
+store clock is seconds, converted via `* 1000`). Throwing only to bind `timeIntoSlotMs`. -/
+forkdef isProposingOnTime (store : Store map) : StoreTransition Bool := do
+  pure ((← timeIntoSlotMs store) ≤ bpsDeadlineMs Const.proposerReorgCutoffBps)
 
 /-- `is_head_weak`: the head's weight is below the reorg-head threshold. -/
 forkdef isHeadWeak (store : Store map) (headRoot : Root) : StoreTransition Bool := do
@@ -320,12 +360,13 @@ forkdef getProposerHead (store : Store map) (headRoot : Root) (slot : Slot) : St
   let headLate ← isHeadLate store headRoot
   let epochBoundary := isShufflingStable slot
   let ffgCompetitive ← isFfgCompetitive store headRoot parentRoot
-  let finalizationOk := isFinalizationOk store slot
-  let proposingOnTime := isProposingOnTime store
-  let currentTimeOk := headBlock.slot + 1 == slot
-  let singleSlotReorg := parentBlock.slot + 1 == headBlock.slot && currentTimeOk
-  -- `assert proposer_boost_root != head_root` (the boost has worn off): a faithful raise,
-  -- where this was previously modeled defensively as keeping the head. Placed after the
+  let finalizationOk ← isFinalizationOk store slot
+  let proposingOnTime ← isProposingOnTime store
+  let headNextSlot ← checkedAdd headBlock.slot 1 "get_proposer_head: head_block.slot + 1"
+  let currentTimeOk := headNextSlot == slot
+  let parentNextSlot ← checkedAdd parentBlock.slot 1 "get_proposer_head: parent_block.slot + 1"
+  let singleSlotReorg := parentNextSlot == headBlock.slot && currentTimeOk
+  -- `assert proposer_boost_root != head_root` (the boost has worn off). Placed after the
   -- timing predicates and before the weight ones (`is_head_weak` / `is_parent_strong` /
   -- `is_proposer_equivocation`), matching the spec's statement order. Vectorless.
   assert (store.proposerBoostRoot != headRoot)
@@ -353,50 +394,77 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
 miss, and the pull-up itself propagates: pyspec runs `process_justification_and_finalization`
 unguarded, so a reject (e.g. the restored `get_block_root_at_slot` recency assert on a
 degenerate epoch-boundary state) aborts the surrounding `on_block`, matching the Gloas
-and Heze twins. -/
-forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
+and Heze twins.
+
+Each pyspec statement boundary gets its own `set`, the rule `aed053b` established for
+`on_attestation` and `on_block`: the reference runner mutates in place and the harness
+continues an expected rejection from the error-time store, so a write pyspec has already
+applied must survive a later raise. One `set` at the end rolled back the
+`unrealized_justifications` insert and the `update_unrealized_checkpoints` writes whenever
+`get_current_store_epoch` rejected. The `store.blocks[block_root]` read moves below the
+pull-up too, where pyspec performs it. -/
+forkdef computePulledUpTip (blockRoot : Root) : StoreTransition Unit := do
+  let store ← get
   let state ← FcMap.getOrThrow store.blockStates blockRoot
-  let block ← FcMap.getOrThrow store.blocks blockRoot
   let pulled ← runStateTransition state processJustificationAndFinalization
   let cj := sszGet pulled currentJustifiedCheckpoint
   let fz := sszGet pulled finalizedCheckpoint
-  let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-  let store := updateUnrealizedCheckpoints store cj fz
-  pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
+  set { store with
+    unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+  set (updateUnrealizedCheckpoints (← get) cj fz)
+  -- Only now does pyspec read the block and the store clock.
+  let block ← FcMap.getOrThrow (← get).blocks blockRoot
+  let currentEpoch ← getCurrentStoreEpoch (← get)
+  if computeEpochAtSlot block.slot < currentEpoch then
+    set (updateCheckpoints (← get) cj fz)
 
 /-! ## on_tick -/
 
-forkdef onTickPerSlot (store : Store map) (time : UInt64) : Store map :=
-  let previousSlot := getCurrentSlot store
+forkdef onTickPerSlot (store : Store map) (time : UInt64) : StoreTransition (Store map) := do
+  let previousSlot ← getCurrentSlot store
   let store := { store with time := time }
-  let currentSlot := getCurrentSlot store
+  let currentSlot ← getCurrentSlot store
   let store := if currentSlot > previousSlot then { store with proposerBoostRoot := fcZeroRoot } else store
-  if currentSlot > previousSlot && computeSlotsSinceEpochStart currentSlot == 0 then
+  pure <| if currentSlot > previousSlot && computeSlotsSinceEpochStart currentSlot == 0 then
     updateCheckpoints store store.unrealizedJustifiedCheckpoint store.unrealizedFinalizedCheckpoint
   else store
 where
+  -- `slot - compute_start_slot_at_epoch(compute_epoch_at_slot(slot))`: the epoch-start slot is
+  -- always `≤ slot`, so this `uint64` subtraction cannot underflow; a bare `-`, not `checkedSub`.
   computeSlotsSinceEpochStart (slot : Slot) : UInt64 := slot - computeStartSlotAtEpoch (computeEpochAtSlot slot)
 
-/-- `advance_store_time`: catch up slot-by-slot, then set the exact time (the pure
-core of `on_tick`). Fuel-bounded by the number of slots to advance. -/
-forkdef advanceStoreTime (store : Store map) (time : UInt64) : Store map :=
-  fuelIterate ((((time - store.genesisTime) * 1000 / Const.slotDurationMs) - getCurrentSlot store).toNat + 1) store fun store =>
-    let tickSlot := (time - store.genesisTime) * 1000 / Const.slotDurationMs
-    if getCurrentSlot store < tickSlot then
-      let previousTime := store.genesisTime + (getCurrentSlot store + 1) * Const.slotDurationMs / 1000
-      .next (onTickPerSlot store previousTime)
-    else .done (onTickPerSlot store time)
-
-/-- `on_tick`: advance the store clock to `time`. -/
+/-- `on_tick`: advance the store clock to `time`. Each `on_tick_per_slot` commits before the
+next iteration, because pyspec calls it against the live store and a raise partway through the
+catch-up leaves the earlier per-slot boost resets and checkpoint updates applied. Threading a
+local and committing once discarded them. Same rule as `aed053b`'s, at the site it did not
+reach; the loop body can now throw, so the divergence is live in principle. -/
 forkdef onTick (time : UInt64) : StoreTransition Unit := do
-  modify fun store => advanceStoreTime store time
+  let store ← get
+  let elapsed ← checkedSub time store.genesisTime "on_tick: time - genesis_time"
+  let tickMs ← checkedMul elapsed 1000 "on_tick: (time - genesis_time) * 1000"
+  let tickSlot := tickMs / Const.slotDurationMs
+  let cur ← getCurrentSlot store
+  -- The fuel bound is a Lean artifact, not a spec op: a raw `-` here can only underflow to a huge
+  -- ceiling when `tickSlot < cur`, and then the step `.done`s on its first iteration anyway.
+  fuelIterateM! ((tickSlot - cur).toNat + 1) () "on_tick: per-slot catch-up" fun _ => do
+    let cs ← getCurrentSlot (← get)
+    if cs < tickSlot then
+      let bumped ← checkedAdd cs 1 "on_tick: get_current_slot + 1"
+      let scaled ← checkedMul bumped Const.slotDurationMs
+        "on_tick: (get_current_slot + 1) * SLOT_DURATION_MS"
+      let previousTime ← checkedAdd store.genesisTime (scaled / 1000) "on_tick: genesis_time + …"
+      set (← onTickPerSlot (← get) previousTime)
+      pure (.next ())
+    else
+      set (← onTickPerSlot (← get) time)
+      pure (.done ())
 
 /-! ## on_block -/
 
 /-- `get_dependent_root` (v1.7): the block root that determined the current epoch's
 proposer shuffling. Monadic to bind the throwing `getAncestor`. -/
 forkdef getDependentRoot (store : Store map) (root : Root) : StoreTransition Root := do
-  let epoch := getCurrentStoreEpoch store
+  let epoch ← getCurrentStoreEpoch store
   if epoch ≤ Const.minSeedLookahead then pure fcZeroRoot
   else getAncestor store root (computeStartSlotAtEpoch (epoch - Const.minSeedLookahead) - 1)
 
@@ -424,8 +492,16 @@ forkdef verifyDataColumnSidecarKzgProofs (sidecar : DataColumnSidecar) : Bool :=
     (sidecar.kzgProofs.map vecToBytes)
 
 /-- `is_data_available`: every supplied column sidecar passes both gates. The runner
-feeds exactly the columns the step lists (mirroring the spec's `retrieve_column_sidecars`),
-so an empty set rejects (the spec raises when columns are missing). -/
+feeds exactly the columns the step lists, mirroring the spec's
+`retrieve_column_sidecars`.
+
+The non-emptiness guard tracks the **test helper**, not the spec function. The spec's
+`is_data_available` (`fulu/fork-choice.md:22-33`) returns `all([]) = True` on an empty
+column set, because `retrieve_column_sidecars` is declared implementation-dependent and
+left unmodeled. The pyspec harness monkeypatches it to raise
+`AssertionError("Simulation: not all required columns have been sampled")` on an empty
+set (`helpers/fork_choice.py:90-94`), which is the behaviour every vector observes, so
+the guard reproduces the helper. -/
 forkdef isDataAvailable (cols : Array DataColumnSidecar) : Bool :=
   !cols.isEmpty && cols.all (fun sidecar => verifyDataColumnSidecar sidecar && verifyDataColumnSidecarKzgProofs sidecar)
 
@@ -439,19 +515,27 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) (columns : Array DataColumnSid
   let block := signedBlock.message
   let parentState ← FcMap.getOrAssert store.blockStates block.parentRoot
     "block.parent_root in store.block_states"
-  assert (getCurrentSlot store ≥ block.slot)
+  let currentSlot ← getCurrentSlot store
+  assert (currentSlot ≥ block.slot)
   let finalizedSlot := computeStartSlotAtEpoch store.finalizedCheckpoint.epoch
   assert (block.slot > finalizedSlot)
   assert (store.finalizedCheckpoint.root == (← getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch))
-  -- Data availability (EIP-7594): only blocks carrying blob commitments need their
-  -- columns sampled; a block with no blobs is trivially available.
+  -- Data availability (EIP-7594). The spec's `on_block` (`fulu/fork-choice.md:70`) calls
+  -- `is_data_available(hash_tree_root(block))` unconditionally; the commitments
+  -- short-circuit is ours, and it pairs with `isDataAvailable`'s non-emptiness guard. That
+  -- guard reproduces the test helper, which raises on an empty column set, so without this
+  -- clause a blob-free block would reject on a set the spec calls available. The one input
+  -- shape that would tell the two apart is a block carrying blob commitments with no
+  -- `columns` key in its step; the generator emits `columns` for every such block, so no
+  -- vector produces it.
   assert (block.body.blobKzgCommitments.toArray.isEmpty || isDataAvailable columns)
 
   let postState ← runStateTransition parentState (stateTransition signedBlock)
   let blockRoot := htr block
   -- The head is taken BEFORE the new block is added (v1.7 `update_proposer_boost_root`).
   let head ← getHead store
-  let isTimely := getCurrentSlot store == block.slot && timeIntoSlotMs store < bpsDeadlineMs Const.attestationDueBps
+  let beforeAttesting ← timeIntoSlotMs store
+  let isTimely := currentSlot == block.slot && beforeAttesting < bpsDeadlineMs Const.attestationDueBps
 
   -- Insert the block, its post-state, and the timeliness flag. `set` before the boost
   -- computation: `update_proposer_boost_root`'s dependent-root walks can raise, and so
@@ -473,15 +557,17 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) (columns : Array DataColumnSid
   set store
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
   set store
-  set (← computePulledUpTip store blockRoot)
+  -- `(map := map)`: no store argument, so the section's map backing is undetermined here
+  -- (the ambient `get`/`set` constraint alone leaves it a stuck metavariable); name it.
+  computePulledUpTip (map := map) blockRoot
 
 /-! ## on_attestation -/
 
 /-- `store_target_checkpoint_state`: cache the target's state, advancing to the
 target epoch start if needed. The pinned `process_slots` is unguarded, so a rejected
 advance propagates (wrapped `.transition`) and nothing is cached, aborting
-`on_attestation` with the store unchanged. The pre-conversion `runBestEffort` cached
-the UNADVANCED base state, a wrong-slot entry later reads would consume. -/
+`on_attestation` with the store unchanged. Caching the unadvanced base state instead
+would leave a wrong-slot entry for later reads to consume. -/
 forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
     StoreTransition (Store map) := do
   if FcMap.contains store.checkpointStates target then pure store
@@ -498,7 +584,7 @@ forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
 attestation (`is_from_block = true`); the rest always apply. -/
 forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlock : Bool) : StoreTransition Unit := do
   let target := att.data.target
-  let currentEpoch := getCurrentStoreEpoch store
+  let currentEpoch ← getCurrentStoreEpoch store
   let previousEpoch := if currentEpoch > Const.genesisEpoch then currentEpoch - 1 else Const.genesisEpoch
   assert (isFromBlock || target.epoch == currentEpoch || target.epoch == previousEpoch)
   assert (target.epoch == computeEpochAtSlot att.data.slot)
@@ -507,7 +593,17 @@ forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlo
   let b ← FcMap.getOrThrow store.blocks att.data.beaconBlockRoot
   assert (b.slot ≤ att.data.slot)
   assert (target.root == (← getCheckpointBlock store att.data.beaconBlockRoot target.epoch))
-  assert (getCurrentSlot store ≥ att.data.slot + 1)
+  let currentSlot ← getCurrentSlot store
+  -- `att.data.slot` is wire-controlled and the epoch-scope guard above is skipped when
+  -- `is_from_block`, so a block-implied attestation reaches here with an arbitrary slot. The
+  -- bare `+` wraps `0xFFFF…FFFF + 1` to `0`, `currentSlot ≥ 0` holds for every store, and the
+  -- attestation is ACCEPTED into `latest_messages`, corrupting the head walk. pyspec
+  -- (`phase0/fork-choice.md:813`) forms a checked `uint64` sum that raises `ValueError`, which
+  -- `expect_assertion_error` does not catch. Sequenced after every preceding assert, matching
+  -- Python's evaluation order.
+  let attestationDeadline ← checkedAdd att.data.slot 1
+    "on_attestation: attestation.data.slot + 1"
+  assert (currentSlot ≥ attestationDeadline)
 
 /-- `update_latest_messages` for the attesting indices (skipping equivocators). -/
 forkdef updateLatestMessages (store : Store map) (attestingIndices : Array ValidatorIndex)
@@ -572,8 +668,16 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
+  -- `uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000)`
+  -- (`phase0/fork-choice.md:223`): both the product and the sum are checked. `anchor_state`
+  -- comes straight off the wire, so a slot at or above `2^64 / SLOT_DURATION_MS` wraps and
+  -- seeds the store with a wrong clock where pyspec errors.
+  let elapsedMs ← checkedMul Const.slotDurationMs (sszGet anchorState slot)
+    "get_forkchoice_store: SLOT_DURATION_MS * anchor_state.slot"
+  let storeTime ← checkedAdd (sszGet anchorState genesisTime) (elapsedMs / 1000)
+    "get_forkchoice_store: genesis_time + SLOT_DURATION_MS * slot // 1000"
   pure
-    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+    { time := storeTime
       genesisTime := sszGet anchorState genesisTime
       justifiedCheckpoint := cp, finalizedCheckpoint := cp
       unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
@@ -616,8 +720,9 @@ private def pinStore : @Store minimal treeMap fastHasherTag :=
     unrealizedJustifications := FcMap.empty }
 
 /-- `getAncestor` rejects (`missingKey`) when the walk root is not in `store.blocks`,
-the pinned plain-`Dict` read; the pre-conversion `fuelIterate` returned the root as a
-silent `.done`. `FcMap`/hash-free, so kernel `#guard`. -/
+the pinned plain-`Dict` read. Returning the root as a silent `.done` instead would hand
+the caller a walk result indistinguishable from a real ancestor. `FcMap`/hash-free, so
+kernel `#guard`. -/
 private def pinGetAncestorThrows : Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
@@ -660,7 +765,10 @@ private def pinTargetAdvanceRejects : Bool :=
   let store := { pinStore with blockStates := FcMap.insert FcMap.empty pinRoot state }
   let target : Checkpoint := { epoch := 1, root := pinRoot }
   match (storeTargetCheckpointState (map := treeMap) store target : PinM (Store treeMap)).run store with
-  | .error (.transition _) _ => true
+  -- Match the constructor, not the wrapper: `.transition` also spans `.arithmetic`, an uncaught
+  -- fault that would fail the very step this fixture pins as an expected rejection. The pin has
+  -- to break when the reject class changes, which is what Leo's note 3 asked for.
+  | .error (.transition (.outOfBounds _ _)) _ => true
   | _ => false
 example : pinTargetAdvanceRejects = true := by native_decide
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -121,7 +121,10 @@ forkdef timeIntoSlotMs (store : Store map) : StoreTransition UInt64 := do
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full
-`bps * SLOT_DURATION_MS` product. -/
+`bps * SLOT_DURATION_MS` product. The product is bare rather than `checkedMul`, and stays
+that way: both factors are constants (`bps ≤ BASIS_POINTS = 10000`, `SLOT_DURATION_MS` is
+12000 at mainnet and 6000 at minimal), so it peaks near `1.2e8` and cannot reach the `uint64`
+bound at any preset. -/
 forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
   bps * Const.slotDurationMs / Const.basisPoints
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/ForkChoice.lean
@@ -271,7 +271,12 @@ where
   /-- The better of two candidate heads under the phase0 `(weight, root)` ordering:
   greater weight wins, ties by greater root. Phase0 `get_head`'s sort key is the
   2-tuple `(get_weight, child.root)`. The payload-status tiebreaker is a Gloas
-  addition, so only the two weights bind here. -/
+  addition, so only the two weights bind here.
+
+  The `foldlM` re-evaluates the accumulator's weight on every step, where `max` evaluates each
+  child's key once, and the reject that surfaces is the same either way. An accumulator got
+  there by surviving an earlier step, so its `getWeight` already succeeded and cannot throw on
+  the re-run. See the Gloas twin, where the key carries a second throwing component. -/
   betterOf (store : Store map) (a b : Root) : StoreTransition Root := do
     let weightA ← getWeight store a
     let weightB ← getWeight store b

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -232,7 +232,7 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
         let cols := columns.filterMap (fun cb => (SSZ.deserialize (T := @DataColumnSidecar P) cb).toOption)
         store := (← checkStepValidity valid

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -201,41 +201,48 @@ step. A `block` step also feeds the block's own attestations / attester-slashing
 into the store (`is_from_block = true`). -/
 private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
     (P : Preset) (store0 : Store hashMap) (steps : Array FcStep) : Except StoreTransitionError Unit := do
-  -- Each step runs to an `Except StoreTransitionError (Store hashMap)` outcome (the new
-  -- store, or the handler's reject), which `checkStepValidity` resolves against the step's
-  -- `valid` flag over the pre-step `store` snapshot: an expected rejection rolls back to it
-  -- and continues, a valid-vs-actual mismatch is returned as the run's failure. The
-  -- per-step valid/invalid policy lives in the framework `checkStepValidity`, not here; this
-  -- loop only runs steps and threads the store. Steps with no `valid` flag (`tick`, the
-  -- block's own `is_from_block` sub-attestations) are implicitly `valid := true`, so any
-  -- reject on them propagates. The handler type annotation pins the abstract `StoreTransition`
-  -- monad at `EStateM StoreTransitionError (Store hashMap)`.
+  -- Each step runs to an `Except` outcome (the new store, or the handler's reject paired
+  -- with the error-time store), which `checkStepValidity` resolves against the step's
+  -- `valid` flag: an expected rejection continues from the error-time store (the in-place
+  -- reference-runner semantics), a valid-vs-actual mismatch is returned as the run's
+  -- failure. The per-step valid/invalid policy lives in the framework `checkStepValidity`,
+  -- not here; this loop only runs steps and threads the store. Steps with no `valid` flag
+  -- (`tick`, the block's own `is_from_block` sub-attestations) are implicitly
+  -- `valid := true`, so any reject on them propagates. The handler type annotation pins the
+  -- abstract `StoreTransition` monad at `EStateM StoreTransitionError (Store hashMap)`.
   let mut store : Store hashMap := store0
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity store true
+      store := (← checkStepValidity true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes columns valid =>
-      let outcome := decodeStepOr (α := @SignedBeaconBlock P) bytes "block" fun sb =>
+      -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
+      -- invalid block returns right after `on_block` rejects (`:393`), so its own attestations /
+      -- attester-slashings replay only on the valid path (`:400-406`), each `valid = True`. So
+      -- check `on_block` against `valid`, then replay the sub-steps only when the block was
+      -- accepted. (Combining them would let a sub-attestation reject stand in for `on_block`'s on
+      -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
+      match SizzLean.SSZ.deserialize (T := @SignedBeaconBlock P) bytes with
+      | .error _ =>
+        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+      | .ok sb =>
         let cols := columns.filterMap (fun cb => (SSZ.deserialize (T := @DataColumnSidecar P) cb).toOption)
-        -- `on_block`, then the block's own attestations / attester-slashings, as one
-        -- action: a reject anywhere is the step's reject (and `on_block` rejecting
-        -- short-circuits the sub-steps, as the spec requires).
-        let action : EStateM StoreTransitionError (Store hashMap) Unit := do
-          onBlock (map := hashMap) sb cols
-          for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
-          for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-        runOn store action
-      store := (← checkStepValidity store valid outcome)
+        store := (← checkStepValidity valid
+          (runOn store (onBlock (map := hashMap) sb cols : EStateM StoreTransitionError (Store hashMap) Unit)))
+        if valid then
+          let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
+            for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+            for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+          store := (← checkStepValidity true (runOn store subAction))
     | .attestation bytes valid =>
-      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" fun a =>
+      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .attesterSlashing bytes valid =>
-      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" fun a =>
+      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .checkHead root slot =>
       let head := getHead store
       assert (head == root)

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -255,9 +255,20 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
       let proposerHead := getProposerHead store (getHead store) (getCurrentSlot store)
       assert (proposerHead == root)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
-    -- ePBS-only steps (envelope, PTC message, payload-status / vote checks) never
-    -- appear in Fulu vectors; ignore them so the shared `FcStep` stays exhaustive.
-    | _ => pure ()
+    -- ePBS-only steps (Gloas, EIP-7732): impossible in a well-formed fulu vector, so
+    -- surface one as `todo` (an xfail) rather than passing it vacuously. Explicit arms
+    -- keep the match exhaustive over `FcStep`, so a newly added constructor is a build
+    -- error here too, not just in the Gloas / Heze interpreters.
+    | .executionPayload _ _ =>
+      throw (StoreTransitionError.todo "execution_payload step: ePBS-only, not applicable to fulu")
+    | .payloadAttestationMessage _ _ =>
+      throw (StoreTransitionError.todo "payload_attestation_message step: ePBS-only, not applicable to fulu")
+    | .checkHeadPayloadStatus _ =>
+      throw (StoreTransitionError.todo "head.payload_status check: ePBS-only, not applicable to fulu")
+    | .checkPayloadTimelinessVote _ _ =>
+      throw (StoreTransitionError.todo "payload_timeliness_vote check: ePBS-only, not applicable to fulu")
+    | .checkPayloadDataAvailabilityVote _ _ =>
+      throw (StoreTransitionError.todo "payload_data_availability_vote check: ePBS-only, not applicable to fulu")
   pure ()
 
 /-- `runForkChoice`: decode the anchor state / block, build the store, and run the

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -196,6 +196,13 @@ private def runBlocksImpl (P : Preset) (C : Config) (preBytes : ByteArray)
     for sb in signedBlocks do stateTransition sb
   RunError.ofSpec (runToRoot box0 action)
 
+/-- Run `getHead` over the snapshot store as a pure query (`runQuery` discards the final
+store). Shared by the `checkHead` / `checkProposerHead` arms. -/
+private def queryHead [Preset] [Config] [HasherTag] (store : Store hashMap) :
+    Except StoreTransitionError Root :=
+  runQuery store (getHead (map := hashMap) store :
+    EStateM StoreTransitionError (Store hashMap) Root)
+
 /-- Fold the decoded `steps` over the store from `store0`, verifying each `checks`
 step. A `block` step also feeds the block's own attestations / attester-slashings
 into the store (`is_from_block = true`). -/
@@ -244,10 +251,10 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
       store := (← checkStepValidity valid outcome)
     | .checkHead root slot =>
-      let head := getHead store
+      let head ← queryHead store
       assert (head == root)
-      let headSlot := match FcMap.lookup store.blocks head with | some b => b.slot.toNat | none => 0
-      assert (headSlot == slot)
+      let headBlock ← FcMap.getOrThrow store.blocks head
+      assert (headBlock.slot.toNat == slot)
     | .checkJustified epoch root =>
       assert (store.justifiedCheckpoint.epoch.toNat == epoch)
       assert (store.justifiedCheckpoint.root == root)
@@ -259,7 +266,9 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
     | .checkTime t => assert (store.time.toNat == t)
     | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
     | .checkProposerHead root =>
-      let proposerHead := getProposerHead store (getHead store) (getCurrentSlot store)
+      let head ← queryHead store
+      let proposerHead ← runQuery store (getProposerHead (map := hashMap) store head (getCurrentSlot store) :
+        EStateM StoreTransitionError (Store hashMap) Root)
       assert (proposerHead == root)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
     -- ePBS-only steps (Gloas, EIP-7732): impossible in a well-formed fulu vector, so

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -285,7 +285,9 @@ private def runForkChoiceImpl (P : Preset) (C : Config) (anchorStateBytes anchor
   | .error _, _ => .error (.decode "fork_choice anchor state")
   | _, .error _ => .error (.decode "fork_choice anchor block")
   | .ok anchorState, .ok anchorBlock =>
-    RunError.ofSpec (fcInterpret P (getForkchoiceStore anchorState anchorBlock) steps)
+    RunError.ofSpec (do
+      let store ← getForkchoiceStore anchorState anchorBlock
+      fcInterpret P store steps)
 
 /-- The `ssz_static` per-type kernel: decode `bytes` as the container `T`, and on
 success return its hash-tree-root paired with whether re-serializing reproduces

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -221,7 +221,7 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity true
+      store := (← checkStepValidity .tick true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes columns valid =>
       -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
@@ -232,24 +232,36 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity .block valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
-        let cols := columns.filterMap (fun cb => (SSZ.deserialize (T := @DataColumnSidecar P) cb).toOption)
-        store := (← checkStepValidity valid
-          (runOn store (onBlock (map := hashMap) sb cols : EStateM StoreTransitionError (Store hashMap) Unit)))
-        if valid then
-          let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
-            for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
-            for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-          store := (← checkStepValidity true (runOn store subAction))
+        -- A column sidecar the runner cannot deserialize is our decoder's bug, exactly as the
+        -- block decode two lines above: route it through the same `.decodeFailure` rather than
+        -- dropping it from the list. `filterMap` discarded the error, and a dropped column is
+        -- indistinguishable from a column that was never listed, so an unavailable block either
+        -- rejected for the wrong reason (all columns dropped ⇒ `is_data_available` false ⇒ the
+        -- availability assert fires ⇒ the `valid: false` step PASSES on a broken decoder) or was
+        -- accepted outright (some columns dropped ⇒ the survivors all verify). `mapM` in
+        -- `Except` keeps the first error instead.
+        match columns.mapM (fun cb => SSZ.deserialize (T := @DataColumnSidecar P) cb) with
+        | .error _ =>
+          store := (← checkStepValidity .block valid
+            (.error (.decodeFailure "fork_choice: data column sidecar decode failed", store)))
+        | .ok cols =>
+          store := (← checkStepValidity .block valid
+            (runOn store (onBlock (map := hashMap) sb cols : EStateM StoreTransitionError (Store hashMap) Unit)))
+          if valid then
+            let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
+              for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+              for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+            store := (← checkStepValidity .attestation true (runOn store subAction))
     | .attestation bytes valid =>
       let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attestation valid outcome)
     | .attesterSlashing bytes valid =>
       let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attesterSlashing valid outcome)
     | .checkHead root slot =>
       let head ← queryHead store
       assert (head == root)
@@ -267,7 +279,9 @@ private def fcInterpret [Preset] [Config] [HasherTag] [CryptoBackend]
     | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
     | .checkProposerHead root =>
       let head ← queryHead store
-      let proposerHead ← runQuery store (getProposerHead (map := hashMap) store head (getCurrentSlot store) :
+      let proposerHead ← runQuery store (do
+        let currentSlot ← getCurrentSlot store
+        getProposerHead (map := hashMap) store head currentSlot :
         EStateM StoreTransitionError (Store hashMap) Root)
       assert (proposerHead == root)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
@@ -320,8 +334,8 @@ private def runStatic (T : Type) [SSZRepr T] (typeName : String) (bytes : ByteAr
 /-- `sszStatic`: dispatch an `ssz_static/<TypeName>` directory name to the Fulu
 container it names and run it through `runStatic`. The consensus containers Fulu
 models are covered; the light-client, networking, and gossip-aggregation types the
-spec does not declare (`AggregateAndProof`, `LightClient*`, `PowBlock`, …) fall to
-the `todo` default, so they xfail as out of scope rather than failing. -/
+spec does not declare (`AggregateAndProof`, `LightClient*`, `PowBlock`, …) fall to the
+`.outOfScope` default, so they report `skip` rather than failing. -/
 private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
     Except (RunError StateTransitionError) (ByteArray × Bool) :=
   match typeName with

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Operations.lean
@@ -101,13 +101,15 @@ forkdef processAttesterSlashing (asl : AttesterSlashing) : StateTransition Unit 
 `is_matching_source` assertion (a valid attestation always matches source), so the
 caller rejects; `some flags` otherwise. -/
 forkdef getAttestationParticipationFlagIndices (state : State) (data : AttestationData)
-    (inclusionDelay : UInt64) : Option (Array Nat) := Id.run do
+    (inclusionDelay : UInt64) : StateTransition (Option (Array Nat)) := do
   let justified := if data.target.epoch == currentEpochOf state then sszGet state currentJustifiedCheckpoint
                    else sszGet state previousJustifiedCheckpoint
   let isMatchingSource := data.source.epoch == justified.epoch && data.source.root == justified.root
   if !isMatchingSource then return none
-  let isMatchingTarget := data.target.root == getBlockRoot state data.target.epoch
-  let isMatchingHead := isMatchingTarget && data.beaconBlockRoot == getBlockRootAtSlot state data.slot
+  let targetRoot ← getBlockRoot state data.target.epoch
+  let isMatchingTarget := data.target.root == targetRoot
+  let headRoot ← getBlockRootAtSlot state data.slot
+  let isMatchingHead := isMatchingTarget && data.beaconBlockRoot == headRoot
 
   let mut flags : Array Nat := #[]
   if inclusionDelay ≤ UInt64.ofNat (isqrt Const.slotsPerEpoch) then flags := flags.push Const.timelySourceFlagIndex
@@ -148,7 +150,7 @@ forkdef processAttestation (att : Attestation) : StateTransition Unit := do
   assert (att.aggregationBits.size == offset)
 
   -- Resolve the participation flags, then validate the aggregate signature.
-  let flagIndices ← match getAttestationParticipationFlagIndices state data ((sszGet state slot) - data.slot) with
+  let flagIndices ← match ← getAttestationParticipationFlagIndices state data ((sszGet state slot) - data.slot) with
     | some f => pure f
     | none   => throw (StateTransitionError.assert "is_matching_source")
   let indexedAttestation : IndexedAttestation :=

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Operations.lean
@@ -139,7 +139,14 @@ forkdef processAttestation (att : Attestation) : StateTransition Unit := do
   -- Reject on shape: target epoch, slot timing, and the committee index bound.
   assert (data.target.epoch == previousEpochOf state || data.target.epoch == currentEpochOf state)
   assert (data.target.epoch == computeEpochAtSlot data.slot)
-  assert (data.slot + Const.minAttestationInclusionDelay ≤ sszGet state slot)
+  -- `data.slot` is wire-controlled and `MIN_ATTESTATION_INCLUSION_DELAY` is 1, so the bare `+`
+  -- wraps `0xFFFF…FFFF + 1` to `0` and `0 ≤ state.slot` bypasses the guard for every state: a
+  -- false ACCEPT, the state-transition twin of `on_attestation`'s. pyspec's checked `uint64` add
+  -- raises `ValueError`, which `process_attestation` does not catch, so the driver scores it
+  -- `uncaughtFault`. Sequenced after the two epoch asserts above, matching Python's order.
+  let inclusionSlot ← checkedAdd data.slot Const.minAttestationInclusionDelay
+    "process_attestation: data.slot + MIN_ATTESTATION_INCLUSION_DELAY"
+  assert (inclusionSlot ≤ sszGet state slot)
   assert (data.index == 0)
 
   -- Every committee index is valid and contributes at least one attester; the

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Transition.lean
@@ -141,7 +141,8 @@ forkdef processSyncAggregate (agg : SyncAggregate) : StateTransition Unit := do
   let participantKeys : Array BLSPubkey :=
     (Bitvector.trueIndices bits).map (fun i => syncCommittee.pubkeys[i]!)
   let previousSlot := (umax (sszGet state slot) 1) - 1
-  let signingRoot := computeSigningRoot (getBlockRootAtSlot state previousSlot)
+  let previousBlockRoot ← getBlockRootAtSlot state previousSlot
+  let signingRoot := computeSigningRoot previousBlockRoot
     (getDomain state Const.domainSyncCommittee (computeEpochAtSlot previousSlot))
   assert (blsEthFastAggregateVerify participantKeys signingRoot agg.syncCommitteeSignature)
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Transition.lean
@@ -183,7 +183,12 @@ forkdef processExecutionPayload (body : BeaconBlockBody) : StateTransition Unit 
   let epoch := currentEpochOf state
   let mix := vmodGet (sszGet state randaoMixes) epoch Const.epochsPerHistoricalVector
   assert (payload.prevRandao == mix)
-  assert (payload.timestamp == (sszGet state genesisTime) + (sszGet state slot) * Const.secondsPerSlot)
+  -- Both the product and the sum are checked `uint64` ops in the pyspec.
+  let elapsed ← checkedMul (sszGet state slot) Const.secondsPerSlot
+    "process_execution_payload: state.slot * SECONDS_PER_SLOT"
+  let expectedTimestamp ← checkedAdd (sszGet state genesisTime) elapsed
+    "process_execution_payload: genesis_time + state.slot * SECONDS_PER_SLOT"
+  assert (payload.timestamp == expectedTimestamp)
 
   let header : ExecutionPayloadHeader :=
     { parentHash := payload.parentHash, feeRecipient := payload.feeRecipient,

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
@@ -43,17 +43,26 @@ forkdef isEligibleForPartialWithdrawals (v : Validator) (balance : Gwei) : Bool 
 
 /-! ## Expected withdrawals -/
 
-/-- `get_balance_after_withdrawals`: the balance net of any already-queued
-withdrawals for that validator (the sweep reads draining balances). -/
-def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) : Gwei :=
+/-- `get_balance_after_withdrawals` (`capella/beacon-chain.md:378`): the balance net of any
+already-queued withdrawals for that validator. Throwing (`StateTransition`): the spec's
+`state.balances[validator_index]` is a bare list index (`IndexError`, via `sszGetIdx` →
+`outOfBounds`), and `- withdrawn` is a bare `uint64` subtraction whose underflow raises Python
+`ValueError`, which the reference runner does NOT catch (`context.py:429-433` catches only
+`AssertionError` / `IndexError`), so it throws the uncaught `.arithmetic` reject rather than a
+caught `.assert`. Both unreachable on a well-formed state, modeled faithfully rather than clamped. -/
+def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
+    StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
-  let bal := sszGet state balances[vi.toNat]!
-  if withdrawn > bal then 0 else bal - withdrawn
+  let bal ← sszGetIdx (sszGet state balances) vi.toNat
+  if withdrawn > bal then
+    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
+  return bal - withdrawn
 
-/-- `get_expected_withdrawals`: the pending-partial queue (bounded) then the
-validator sweep (bounded), returning the withdrawal list and the count of pending
-partials consumed. -/
-forkdef getExpectedWithdrawals (state : State) : Array Withdrawal × Nat := Id.run do
+/-- `get_expected_withdrawals`: the pending-partial queue then the validator sweep.
+Throwing: the two `validators[i]` reads are bare list indices (`IndexError`, via
+`sszGetIdx` → `outOfBounds`, the same faithful class as the balance read); `balanceAfterWithdrawals`
+raises on the balance read / underflow. Both unreachable on a well-formed state. -/
+forkdef getExpectedWithdrawals (state : State) : StateTransition (Array Withdrawal × Nat) := do
   let epoch := currentEpochOf state
   let validators := (sszGet state validators).toArray
   let nvals := validators.size
@@ -66,8 +75,8 @@ forkdef getExpectedWithdrawals (state : State) : Array Withdrawal × Nat := Id.r
   for w in (sszGet state pendingPartialWithdrawals) do
     if !(w.withdrawableEpoch ≤ epoch) || withdrawals.size ≥ partialLimit then break
     let vi := w.validatorIndex
-    let validator := validators[vi.toNat]?.getD default
-    let bal := balanceAfterWithdrawals state vi withdrawals
+    let validator ← sszGetIdx (sszGet state validators) vi.toNat
+    let bal ← balanceAfterWithdrawals state vi withdrawals
     if isEligibleForPartialWithdrawals validator bal then
       withdrawals := withdrawals.push
         { index := withdrawalIndex, validatorIndex := vi, address := addressOf validator,
@@ -80,8 +89,8 @@ forkdef getExpectedWithdrawals (state : State) : Array Withdrawal × Nat := Id.r
   let mut vIdx := (sszGet state nextWithdrawalValidatorIndex).toNat
   for _ in [0:validatorsLimit] do
     if withdrawals.size ≥ Const.maxWithdrawalsPerPayload then break
-    let validator := validators[vIdx]?.getD default
-    let bal := balanceAfterWithdrawals state (UInt64.ofNat vIdx) withdrawals
+    let validator ← sszGetIdx (sszGet state validators) vIdx
+    let bal ← balanceAfterWithdrawals state (UInt64.ofNat vIdx) withdrawals
     if isFullyWithdrawable validator bal epoch then
       withdrawals := withdrawals.push
         { index := withdrawalIndex, validatorIndex := UInt64.ofNat vIdx, address := addressOf validator, amount := bal }
@@ -101,7 +110,7 @@ apply them, then advance `next_withdrawal_index`, drop the consumed pending
 partials, and advance the sweep cursor. -/
 forkdef processWithdrawals (payload : ExecutionPayload) : StateTransition Unit := do
   let state ← get
-  let (expected, processedPartial) := getExpectedWithdrawals state
+  let (expected, processedPartial) ← getExpectedWithdrawals state
   let expectedList : SSZList Withdrawal Const.maxWithdrawalsPerPayload := sszOfArray expected
   assert (htr expectedList == htr payload.withdrawals)
 

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
@@ -66,9 +66,7 @@ def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Wi
       checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
     else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
-  if withdrawn > bal then
-    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
-  return bal - withdrawn
+  checkedSub bal withdrawn "get_balance_after_withdrawals: balances[i] - withdrawn"
 
 /-- `get_expected_withdrawals`: the pending-partial queue then the validator sweep.
 Throwing: the two `validators[i]` reads are bare list indices (`IndexError`, via

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
@@ -52,15 +52,19 @@ already-queued withdrawals for that validator. Throwing (`StateTransition`): the
 caught `.assert`. Both reads are unreachable on a well-formed state and modeled rather than
 clamped.
 
-The `withdrawn` accumulator above them is a known divergence, deferred: pyspec's `sum(...)`
-adds unbounded ints, so its underflow fires against the true sum, while this fold wraps on
-`UInt64`. A true sum ≥ 2^64 wraps to a small value, passes the `withdrawn > bal` guard, and
-returns a wrong balance where pyspec raises. Unreachable while a validator's queued
-withdrawals stay under its balance, which no vector violates. `checkedAdd` (`Spec/Errors.lean`)
-is the fix when it is taken up. -/
+The `withdrawn` accumulator folds through `checkedAdd`, which is where pyspec faults too.
+`sum(...)` looks like it widens to a Python `int`, but `Gwei` subclasses `int` and defines
+`__radd__`, so Python's reflected-operand rule makes the accumulator a `Gwei` from the first
+element on, and every add re-runs the bound check in `uint.__new__`
+(`remerkleable/basic.py:88-107`). A running sum past `2^64` therefore raises `ValueError`
+during the accumulation, not at the later subtraction. Verified against the pinned
+remerkleable. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
-  let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
+  let withdrawn ← ws.foldlM (init := (0 : Gwei)) fun acc w =>
+    if w.validatorIndex == vi then
+      checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
+    else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
   if withdrawn > bal then
     throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Withdrawals.lean
@@ -47,9 +47,17 @@ forkdef isEligibleForPartialWithdrawals (v : Validator) (balance : Gwei) : Bool 
 already-queued withdrawals for that validator. Throwing (`StateTransition`): the spec's
 `state.balances[validator_index]` is a bare list index (`IndexError`, via `sszGetIdx` →
 `outOfBounds`), and `- withdrawn` is a bare `uint64` subtraction whose underflow raises Python
-`ValueError`, which the reference runner does NOT catch (`context.py:429-433` catches only
+`ValueError`, which the reference runner does NOT catch (`context.py:424-435` catches only
 `AssertionError` / `IndexError`), so it throws the uncaught `.arithmetic` reject rather than a
-caught `.assert`. Both unreachable on a well-formed state, modeled faithfully rather than clamped. -/
+caught `.assert`. Both reads are unreachable on a well-formed state and modeled rather than
+clamped.
+
+The `withdrawn` accumulator above them is a known divergence, deferred: pyspec's `sum(...)`
+adds unbounded ints, so its underflow fires against the true sum, while this fold wraps on
+`UInt64`. A true sum ≥ 2^64 wraps to a small value, passes the `withdrawn > bal` guard, and
+returns a wrong balance where pyspec raises. Unreachable while a validator's queued
+withdrawals stay under its balance, which no vector violates. `checkedAdd` (`Spec/Errors.lean`)
+is the fix when it is taken up. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
@@ -64,8 +72,7 @@ Throwing: the two `validators[i]` reads are bare list indices (`IndexError`, via
 raises on the balance read / underflow. Both unreachable on a well-formed state. -/
 forkdef getExpectedWithdrawals (state : State) : StateTransition (Array Withdrawal × Nat) := do
   let epoch := currentEpochOf state
-  let validators := (sszGet state validators).toArray
-  let nvals := validators.size
+  let nvals := (sszGet state validators).size
   let mut withdrawals : Array Withdrawal := #[]
   let mut withdrawalIndex := sszGet state nextWithdrawalIndex
   let mut processedPartial := 0

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -124,9 +124,10 @@ forkdef getCurrentSlot (store : Store map) : Slot := Const.genesisSlot + getSlot
 forkdef getCurrentStoreEpoch (store : Store map) : Epoch := computeEpochAtSlot (getCurrentSlot store)
 
 /-- `time_into_slot`, in milliseconds: wall-clock elapsed since the slot start, modulo the slot
-length. -/
+length, via the overflow-guarded `seconds_to_milliseconds` (shared with Fulu). The prior form
+was a raw `* 1000`, missing the pinned clamp; value-identical at realistic slots. Heze inherits. -/
 forkdef timeIntoSlotMs (store : Store map) : UInt64 :=
-  ((store.time - store.genesisTime) * 1000) % Const.slotDurationMs
+  Fulu.secondsToMilliseconds (store.time - store.genesisTime) % Const.slotDurationMs
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -735,9 +735,15 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   -- itself: no store argument determines the backing.
   notifyPtcMessages (map := map) postState block.body.payloadAttestations.toArray
   let store ← get
+  -- `set` at each pyspec statement boundary below: `update_proposer_boost_root`'s
+  -- dependent-root walks can raise, and so does `compute_pulled_up_tip`'s pull-up, so
+  -- each completed write must persist (in-place runner semantics).
   let store ← recordBlockTimeliness store blockRoot
+  set store
   let store ← updateProposerBoostRoot store head.root blockRoot
+  set store
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
+  set store
   set (← computePulledUpTip store blockRoot)
 
 /-! ## on_execution_payload_envelope -/
@@ -884,7 +890,11 @@ block-implied one. -/
 forkdef onAttestation (att : Attestation) (isFromBlock : Bool) : StoreTransition Unit := do
   validateOnAttestation (← get) att isFromBlock
 
+  -- `store_target_checkpoint_state` mutates `checkpoint_states` before the
+  -- indexed-attestation assert below can reject; `set` at the pyspec statement
+  -- boundary so an expected rejection keeps the cache (in-place runner semantics).
   let store ← storeTargetCheckpointState (← get) att.data.target
+  set store
   let targetState ← FcMap.getOrThrowKey store.checkpointStates att.data.target att.data.target.root
   let attesting := (← liftErr (getAttestingIndices targetState att)).qsort (· < ·)
   let indexedAttestation : IndexedAttestation := { attestingIndices := sszOfArray attesting, data := att.data, signature := att.signature }

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -1054,4 +1054,21 @@ private def pinTargetAdvanceRejects : Bool :=
   | _ => false
 example : pinTargetAdvanceRejects = true := by native_decide
 
+/-- `getBlockRootAtSlot` rejects (`.assert`) the restored recency guard `slot <
+state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT`: a `default` state has slot 0, so
+`get_block_root_at_slot(state, 0)` fails `0 < 0` where the pre-restore accessor
+mod-indexed silently. This locks the assert itself; the end-to-end
+`compute_pulled_up_tip` pjf reachability it opens up is conformance-gated rather than
+pinned (the epoch-boundary near-zero-stake fixture is finicky to construct). `State` is
+FFI-backed, so `native_decide`. -/
+private def pinBlockRootRecencyRejects : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Gloas.BeaconState minimal)
+  match (getBlockRootAtSlot state 0 : EStateM StateTransitionError State Root).run state with
+  | .error (.assert _) _ => true
+  | _ => false
+example : pinBlockRootRecencyRejects = true := by native_decide
+
 end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -138,69 +138,72 @@ forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
 /-- `get_parent_payload_status(store, block)`: the parent edge is FULL when the
 block's committed parent block hash matches the parent's own bid block hash, else
 EMPTY. -/
-forkdef getParentPayloadStatus (store : Store map) (block : BeaconBlock) : UInt8 :=
-  match FcMap.lookup store.blocks block.parentRoot with
-  | none => Const.payloadStatusEmpty
-  | some parent =>
-    let parentBlockHash := block.body.signedExecutionPayloadBid.message.parentBlockHash
-    let messageBlockHash := parent.body.signedExecutionPayloadBid.message.blockHash
-    if parentBlockHash == messageBlockHash then Const.payloadStatusFull else Const.payloadStatusEmpty
+forkdef getParentPayloadStatus (store : Store map) (block : BeaconBlock) : StoreTransition UInt8 := do
+  -- The spec reads `store.blocks[block.parent_root]` (a plain `Dict`); a missing parent
+  -- raises `KeyError`, so `getOrThrow` rather than the old default-EMPTY.
+  let parent ← FcMap.getOrThrow store.blocks block.parentRoot
+  let parentBlockHash := block.body.signedExecutionPayloadBid.message.parentBlockHash
+  let messageBlockHash := parent.body.signedExecutionPayloadBid.message.blockHash
+  pure (if parentBlockHash == messageBlockHash then Const.payloadStatusFull else Const.payloadStatusEmpty)
 
 /-- `is_parent_node_full`: the parent edge of `block` is FULL. -/
-forkdef isParentNodeFull (store : Store map) (block : BeaconBlock) : Bool :=
-  getParentPayloadStatus store block == Const.payloadStatusFull
+forkdef isParentNodeFull (store : Store map) (block : BeaconBlock) : StoreTransition Bool := do
+  let status ← getParentPayloadStatus store block
+  pure (status == Const.payloadStatusFull)
 
 /-- `get_ancestor(store, node, slot)`: walk parent edges (each edge carrying the
 parent's payload status) until at/below `slot`. Fuel-bounded by the block count
-(the DAG is finite and acyclic). -/
-forkdef getAncestor (store : Store map) (node : ForkChoiceNode) (slot : Slot) : ForkChoiceNode :=
-  fuelIterate ((FcMap.keys store.blocks).length + 1) node fun n =>
-    match FcMap.lookup store.blocks n.root with
-    | some block =>
-      if block.slot > slot then
-        .next { root := block.parentRoot, payloadStatus := getParentPayloadStatus store block }
-      else .done n
-    | none => .done n
+(the DAG is finite and acyclic). The spec's `store.blocks[node.root]` is a plain `Dict`
+read, so a missing root raises: `getOrThrow` in the monadic `fuelLoop` step (the fuel-out
+value is unreachable, so `node` doubles as the `exhausted` sentinel). -/
+forkdef getAncestor (store : Store map) (node : ForkChoiceNode) (slot : Slot) :
+    StoreTransition ForkChoiceNode :=
+  fuelLoop ((FcMap.keys store.blocks).length + 1) node node fun n => do
+    let block ← FcMap.getOrThrow store.blocks n.root
+    if block.slot > slot then
+      let status ← getParentPayloadStatus store block
+      pure (.next { root := block.parentRoot, payloadStatus := status })
+    else pure (.done n)
 
 /-- `is_ancestor(store, node, ancestor)`: `ancestor` is an ancestor of `node` when
 the walk to the ancestor's slot lands on the ancestor's root with a matching payload
 status (or the ancestor is PENDING, which matches either realisation). -/
-forkdef isAncestor (store : Store map) (node ancestor : ForkChoiceNode) : Bool :=
-  match FcMap.lookup store.blocks ancestor.root with
-  | none => false
-  | some block =>
-    let nodeAncestor := getAncestor store node block.slot
-    if nodeAncestor.root != ancestor.root then false
-    else nodeAncestor.payloadStatus == ancestor.payloadStatus
-      || ancestor.payloadStatus == Const.payloadStatusPending
+forkdef isAncestor (store : Store map) (node ancestor : ForkChoiceNode) : StoreTransition Bool := do
+  let block ← FcMap.getOrThrow store.blocks ancestor.root
+  let nodeAncestor ← getAncestor store node block.slot
+  if nodeAncestor.root != ancestor.root then pure false
+  else pure (nodeAncestor.payloadStatus == ancestor.payloadStatus
+    || ancestor.payloadStatus == Const.payloadStatusPending)
 
 /-- `get_checkpoint_block(store, root, epoch)`: the root of the block at the epoch's
 first slot, walking from a PENDING node. -/
-forkdef getCheckpointBlock (store : Store map) (root : Root) (epoch : Epoch) : Root :=
+forkdef getCheckpointBlock (store : Store map) (root : Root) (epoch : Epoch) :
+    StoreTransition Root := do
   let node : ForkChoiceNode := .pending root
-  (getAncestor store node (computeStartSlotAtEpoch epoch)).root
+  let ancestor ← getAncestor store node (computeStartSlotAtEpoch epoch)
+  pure ancestor.root
 
 /-- `get_supported_node(store, message)`: the node a latest message supports. A
 message for a strictly-earlier block slot decides the payload (full iff
 `payload_present`); a same-slot message is PENDING. -/
-forkdef getSupportedNode (store : Store map) (message : LatestMessage) : ForkChoiceNode :=
-  match FcMap.lookup store.blocks message.root with
-  | none => ForkChoiceNode.pending message.root
-  | some block =>
-    let payloadStatus :=
-      if block.slot < message.slot then
-        if message.payloadPresent then Const.payloadStatusFull else Const.payloadStatusEmpty
-      else Const.payloadStatusPending
-    { root := message.root, payloadStatus := payloadStatus }
+forkdef getSupportedNode (store : Store map) (message : LatestMessage) :
+    StoreTransition ForkChoiceNode := do
+  let block ← FcMap.getOrThrow store.blocks message.root
+  let payloadStatus :=
+    if block.slot < message.slot then
+      if message.payloadPresent then Const.payloadStatusFull else Const.payloadStatusEmpty
+    else Const.payloadStatusPending
+  pure { root := message.root, payloadStatus := payloadStatus }
 
 /-- `get_dependent_root` (Gloas, node-based): the block root that determined the
 current epoch's proposer shuffling. -/
-forkdef getDependentRoot (store : Store map) (root : Root) : Root :=
+forkdef getDependentRoot (store : Store map) (root : Root) : StoreTransition Root := do
   let epoch := getCurrentStoreEpoch store
-  if epoch ≤ Const.minSeedLookahead then fcZeroRoot
+  if epoch ≤ Const.minSeedLookahead then pure fcZeroRoot
   else
     let node : ForkChoiceNode := .pending root
-    (getAncestor store node (computeStartSlotAtEpoch (epoch - Const.minSeedLookahead) - 1)).root
+    let ancestor ← getAncestor store node (computeStartSlotAtEpoch (epoch - Const.minSeedLookahead) - 1)
+    pure ancestor.root
 
 /-! ## Payload-vote predicates -/
 
@@ -216,52 +219,68 @@ forkdef voteCount (votes : Array (Option Bool)) (flag : Bool) : Nat :=
 
 /-- `payload_timeliness(store, root, timely)`: with no revealed payload the vote is
 `not timely`; otherwise a majority of the PTC voted `timely`. -/
-forkdef payloadTimeliness (store : Store map) (root : Root) (timely : Bool) : Bool :=
-  if !isPayloadVerified store root then !timely
-  else
-    let votes := FcMap.lookupD store.payloadTimelinessVote root
-    voteCount votes timely > Const.payloadTimelyThreshold
+forkdef payloadTimeliness (store : Store map) (root : Root) (timely : Bool) : StoreTransition Bool := do
+  -- The spec opens with `assert root in store.payload_timeliness_vote`, which fires even on
+  -- the unverified early-return path, so it precedes the `is_payload_verified` branch. The
+  -- later `[root]` read is then over a present key, so assert and read fuse into one
+  -- `getOrAssert` (an `.assert` reject on a miss, the spec's own membership assert).
+  let votes ← FcMap.getOrAssert store.payloadTimelinessVote root
+    "root in store.payload_timeliness_vote"
+  if !isPayloadVerified store root then pure (!timely)
+  else pure (voteCount votes timely > Const.payloadTimelyThreshold)
 
 /-- `payload_data_availability(store, root, available)`: the data-availability
-counterpart of `payload_timeliness`. -/
-forkdef payloadDataAvailability (store : Store map) (root : Root) (available : Bool) : Bool :=
-  if !isPayloadVerified store root then !available
-  else
-    let votes := FcMap.lookupD store.payloadDataAvailabilityVote root
-    voteCount votes available > Const.dataAvailabilityTimelyThreshold
+counterpart of `payload_timeliness` (same fused assert-and-read, see there). -/
+forkdef payloadDataAvailability (store : Store map) (root : Root) (available : Bool) :
+    StoreTransition Bool := do
+  let votes ← FcMap.getOrAssert store.payloadDataAvailabilityVote root
+    "root in store.payload_data_availability_vote"
+  if !isPayloadVerified store root then pure (!available)
+  else pure (voteCount votes available > Const.dataAvailabilityTimelyThreshold)
 
 /-- `is_previous_slot_payload_decision(store, node)`: the node is the previous
 slot's block and carries a decided (EMPTY or FULL) payload status. -/
-forkdef isPreviousSlotPayloadDecision (store : Store map) (node : ForkChoiceNode) : Bool :=
-  match FcMap.lookup store.blocks node.root with
-  | none => false
-  | some block =>
-    let isPreviousSlot := block.slot + 1 == getCurrentSlot store
-    let isPayloadDecision :=
-      node.payloadStatus == Const.payloadStatusEmpty || node.payloadStatus == Const.payloadStatusFull
-    isPreviousSlot && isPayloadDecision
+forkdef isPreviousSlotPayloadDecision (store : Store map) (node : ForkChoiceNode) :
+    StoreTransition Bool := do
+  -- The spec reads `store.blocks[node.root].slot` (plain `Dict`), raising on a missing root.
+  let block ← FcMap.getOrThrow store.blocks node.root
+  let isPreviousSlot := block.slot + 1 == getCurrentSlot store
+  let isPayloadDecision :=
+    node.payloadStatus == Const.payloadStatusEmpty || node.payloadStatus == Const.payloadStatusFull
+  pure (isPreviousSlot && isPayloadDecision)
 
 /-- `should_extend_payload(store, root)`: whether the FULL realisation of `root`
 should win the payload-status tiebreak. -/
-forkdef shouldExtendPayload (store : Store map) (root : Root) : Bool :=
-  if !isPayloadVerified store root then false
+forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition Bool := do
+  -- The spec opens with `assert store.blocks[root].slot + 1 == get_current_slot(store)`:
+  -- read the block (raising on a missing root), then assert the slot equation.
+  let rootBlock ← FcMap.getOrThrow store.blocks root
+  assert (rootBlock.slot + 1 == getCurrentSlot store)
+  if !isPayloadVerified store root then pure false
   else
     let proposerRoot := store.proposerBoostRoot
-    let payloadIsTimely := payloadTimeliness store root true
-    let payloadDataIsAvailable := payloadDataAvailability store root true
-    (payloadIsTimely && payloadDataIsAvailable)
-      || proposerRoot == fcZeroRoot
-      || (match FcMap.lookup store.blocks proposerRoot with
-          | some pb => pb.parentRoot != root || isParentNodeFull store pb
-          | none    => true)
+    let payloadIsTimely ← payloadTimeliness store root true
+    let payloadDataIsAvailable ← payloadDataAvailability store root true
+    -- Python's `or` short-circuits before the two `store.blocks[proposer_root]` reads,
+    -- so those raise only when the boost root is set yet absent.
+    if (payloadIsTimely && payloadDataIsAvailable) || proposerRoot == fcZeroRoot then
+      pure true
+    else
+      let pb ← FcMap.getOrThrow store.blocks proposerRoot
+      -- The final `or` short-circuits too: `is_parent_node_full` (whose
+      -- `store.blocks[pb.parent_root]` read now throws) never runs when
+      -- `pb.parent_root != root` already decides the disjunction.
+      if pb.parentRoot != root then pure true
+      else isParentNodeFull store pb
 
 /-- `get_payload_status_tiebreaker(store, node)`: the third `get_head` sort key. -/
-forkdef getPayloadStatusTiebreaker (store : Store map) (node : ForkChoiceNode) : UInt8 :=
-  if isPreviousSlotPayloadDecision store node then
-    if node.payloadStatus == Const.payloadStatusEmpty then 1
-    else if shouldExtendPayload store node.root then 2
-    else 0
-  else node.payloadStatus
+forkdef getPayloadStatusTiebreaker (store : Store map) (node : ForkChoiceNode) :
+    StoreTransition UInt8 := do
+  if ← isPreviousSlotPayloadDecision store node then
+    if node.payloadStatus == Const.payloadStatusEmpty then pure 1
+    else if ← shouldExtendPayload store node.root then pure 2
+    else pure 0
+  else pure node.payloadStatus
 
 /-! ## Reorg / committee-fraction helpers -/
 
@@ -277,192 +296,237 @@ forkdef calculateCommitteeFraction (state : State) (committeePercent : UInt64) :
   committeeWeight state * committeePercent / 100
 
 /-- `get_proposer_score`. -/
-forkdef getProposerScore (store : Store map) : Gwei :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint with
-  | none => 0
-  | some state =>
-    committeeWeight state * UInt64.ofNat Const.proposerScoreBoost / 100
+forkdef getProposerScore (store : Store map) : StoreTransition Gwei := do
+  -- `checkpoint_states` is `Checkpoint`-keyed, so `getOrThrowKey` with the checkpoint's
+  -- own root as the (diagnostic) error key; the spec reads it as a plain `Dict`.
+  let state ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  pure (committeeWeight state * UInt64.ofNat Const.proposerScoreBoost / 100)
 
 /-- `get_attestation_score(store, node, state)`: the effective balance of the
-unslashed active validators whose supported node is an ancestor of `node`. -/
-forkdef getAttestationScore (store : Store map) (node : ForkChoiceNode) (state : State) : Gwei :=
+unslashed active validators whose supported node is an ancestor of `node`. The validator
+reads are at active-validator indices (in range by construction); this becomes monadic only
+to bind the now-throwing `getSupportedNode` / `isAncestor`. -/
+forkdef getAttestationScore (store : Store map) (node : ForkChoiceNode) (state : State) :
+    StoreTransition Gwei := do
   let active := getActiveValidatorIndices state (currentEpochOf state)
   let validators := sszGet state validators
-  active.foldl (init := 0) fun acc i =>
+  active.foldlM (init := 0) fun acc i => do
     let idx := i.toNat
-    if (validators[idx]!).slashed then acc
+    if (validators[idx]!).slashed then pure acc
     else match FcMap.lookup store.latestMessages i with
-      | none => acc
+      | none => pure acc
       | some lm =>
-        if store.equivocatingIndices.contains i then acc
-        else if isAncestor store (getSupportedNode store lm) node then acc + (validators[idx]!).effectiveBalance
-        else acc
+        if store.equivocatingIndices.contains i then pure acc
+        else
+          let supported ← getSupportedNode store lm
+          if ← isAncestor store supported node then pure (acc + (validators[idx]!).effectiveBalance)
+          else pure acc
 
 /-- `is_head_weak(store, head_root)`: the head's attestation weight, including the
 equivocator weight from its slot's committees, is below the reorg threshold. -/
-forkdef isHeadWeak (store : Store map) (headRoot : Root) : Bool :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint,
-        FcMap.lookup store.blockStates headRoot, FcMap.lookup store.blocks headRoot with
-  | some justifiedState, some headState, some headBlock =>
-    let reorgThreshold := calculateCommitteeFraction justifiedState Const.reorgHeadWeightThreshold
-    let epoch := computeEpochAtSlot headBlock.slot
-    let headNode : ForkChoiceNode := .pending headRoot
-    let baseWeight := getAttestationScore store headNode justifiedState
-    let validators := sszGet justifiedState validators
-    let headWeight := (List.range (getCommitteeCountPerSlot headState epoch)).foldl (init := baseWeight) fun acc index =>
-      let committee := getBeaconCommittee headState headBlock.slot index
-      committee.foldl (init := acc) fun a i =>
-        if store.equivocatingIndices.contains i then a + (validators[i.toNat]!).effectiveBalance else a
-    headWeight < reorgThreshold
-  | _, _, _ => false
+forkdef isHeadWeak (store : Store map) (headRoot : Root) : StoreTransition Bool := do
+  let justifiedState ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  let headState ← FcMap.getOrThrow store.blockStates headRoot
+  let headBlock ← FcMap.getOrThrow store.blocks headRoot
+  let reorgThreshold := calculateCommitteeFraction justifiedState Const.reorgHeadWeightThreshold
+  let epoch := computeEpochAtSlot headBlock.slot
+  let headNode : ForkChoiceNode := .pending headRoot
+  let baseWeight ← getAttestationScore store headNode justifiedState
+  let validators := sszGet justifiedState validators
+  -- The equivocator read is `justified_state.validators[i]` with `i` drawn from the *head*
+  -- state's committees, so a cross-branch registry skew can push it past the justified
+  -- registry's end; the spec raises `IndexError` there, hence `sszGetIdx` (the wrapped
+  -- `outOfBounds` reject) in place of the silent-default `[i.toNat]!`. The folds turn
+  -- monadic (`foldlM`) only to bind that throwing read.
+  let headWeight ← (List.range (getCommitteeCountPerSlot headState epoch)).foldlM (init := baseWeight) fun acc index => do
+    let committee := getBeaconCommittee headState headBlock.slot index
+    committee.foldlM (init := acc) fun a i =>
+      if store.equivocatingIndices.contains i then do
+        let v ← sszGetIdx validators i.toNat
+        pure (a + v.effectiveBalance)
+      else pure a
+  pure (headWeight < reorgThreshold)
 
 /-- `is_parent_strong(store, root)`: the parent node's attestation weight exceeds the
 reorg parent threshold. -/
-forkdef isParentStrong (store : Store map) (root : Root) : Bool :=
-  match FcMap.lookup store.checkpointStates store.justifiedCheckpoint,
-        FcMap.lookup store.blocks root with
-  | some justifiedState, some block =>
-    let parentThreshold := calculateCommitteeFraction justifiedState Const.reorgParentWeightThreshold
-    let parentPayloadStatus := getParentPayloadStatus store block
-    let parentNode : ForkChoiceNode := { root := block.parentRoot, payloadStatus := parentPayloadStatus }
-    getAttestationScore store parentNode justifiedState > parentThreshold
-  | _, _ => false
+forkdef isParentStrong (store : Store map) (root : Root) : StoreTransition Bool := do
+  let justifiedState ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+    store.justifiedCheckpoint.root
+  let block ← FcMap.getOrThrow store.blocks root
+  let parentThreshold := calculateCommitteeFraction justifiedState Const.reorgParentWeightThreshold
+  -- The spec scores the parent at PENDING "regardless of its payload status"
+  -- (`ForkChoiceNode(root=block.parent_root, payload_status=PAYLOAD_STATUS_PENDING)`);
+  -- it never calls `get_parent_payload_status` here, so no `blocks[parent_root]` read
+  -- (and no throw) belongs on this path.
+  let parentNode : ForkChoiceNode := .pending block.parentRoot
+  let score ← getAttestationScore store parentNode justifiedState
+  pure (score > parentThreshold)
 
 /-- `should_apply_proposer_boost(store)`: gate the proposer boost. With an unset
 boost root, no boost; with a far-enough-back parent or a non-weak parent head, boost;
 otherwise boost only when no equivocating same-proposer sibling competes. -/
-forkdef shouldApplyProposerBoost (store : Store map) : Bool :=
-  if store.proposerBoostRoot == fcZeroRoot then false
-  else match FcMap.lookup store.blocks store.proposerBoostRoot with
-    | none => false
-    | some block =>
-      let parentRoot := block.parentRoot
-      match FcMap.lookup store.blocks parentRoot with
-      | none => false
-      | some parent =>
-        let slot := block.slot
-        if parent.slot + 1 < slot then true
-        else if !isHeadWeak store parentRoot then true
-        else
-          let equivocations := FcMap.filterKeys store.blocks fun root b =>
-            match FcMap.lookup store.blockTimeliness root with
-            | some tl =>
-              (tl[Const.ptcTimelinessIndex]?.getD false)
-                && b.proposerIndex == parent.proposerIndex
-                && b.slot + 1 == slot
-                && root != parentRoot
-            | none => false
-          equivocations.isEmpty
+forkdef shouldApplyProposerBoost (store : Store map) : StoreTransition Bool := do
+  if store.proposerBoostRoot == fcZeroRoot then pure false
+  else
+    let block ← FcMap.getOrThrow store.blocks store.proposerBoostRoot
+    let parentRoot := block.parentRoot
+    let parent ← FcMap.getOrThrow store.blocks parentRoot
+    let slot := block.slot
+    if parent.slot + 1 < slot then pure true
+    else if !(← isHeadWeak store parentRoot) then pure true
+    else
+      -- The spec's equivocation comprehension iterates `store.blocks.items()`
+      -- (`gloas/fork-choice.md:501`), so the block comes from the iteration itself, not a
+      -- separate read; fold over the `(root, block)` entries in hand. It then reads
+      -- `store.block_timeliness[root][PTC_TIMELINESS_INDEX]` (`:503`): the outer `[root]` is a
+      -- plain `Dict` (raises `KeyError`, `getOrThrow`), the inner `[PTC_TIMELINESS_INDEX]` a
+      -- raising `list` index (`IndexError`, `arrGetIdx`). Both faithful throws.
+      let entries : Array (Root × BeaconBlock) :=
+        FcMap.fold (fun acc root b => acc.push (root, b)) #[] store.blocks
+      let equivExists ← entries.foldlM (init := false) fun found (root, b) => do
+        let tl ← FcMap.getOrThrow store.blockTimeliness root
+        let timely ← arrGetIdx tl Const.ptcTimelinessIndex
+        pure (found || (timely && b.proposerIndex == parent.proposerIndex
+          && b.slot + 1 == slot && root != parentRoot))
+      pure (!equivExists)
 
 /-- `get_weight(store, node)`: zero for an undecided previous-slot payload; otherwise
 the attestation score plus the (gated) proposer boost. -/
-forkdef getWeight (store : Store map) (node : ForkChoiceNode) : Gwei :=
-  if isPreviousSlotPayloadDecision store node then 0
-  else match FcMap.lookup store.checkpointStates store.justifiedCheckpoint with
-    | none => 0
-    | some state =>
-      let attestationScore := getAttestationScore store node state
-      if !shouldApplyProposerBoost store then attestationScore
-      else
-        let proposerBoostNode : ForkChoiceNode := .pending store.proposerBoostRoot
-        if isAncestor store proposerBoostNode node then attestationScore + getProposerScore store
-        else attestationScore
+forkdef getWeight (store : Store map) (node : ForkChoiceNode) : StoreTransition Gwei := do
+  if ← isPreviousSlotPayloadDecision store node then pure 0
+  else
+    let state ← FcMap.getOrThrowKey store.checkpointStates store.justifiedCheckpoint
+      store.justifiedCheckpoint.root
+    let attestationScore ← getAttestationScore store node state
+    if !(← shouldApplyProposerBoost store) then pure attestationScore
+    else
+      let proposerBoostNode : ForkChoiceNode := .pending store.proposerBoostRoot
+      if ← isAncestor store proposerBoostNode node then
+        let proposerScore ← getProposerScore store
+        pure (attestationScore + proposerScore)
+      else pure attestationScore
 
 /-! ## Filtered block tree + head -/
 
 /-- `get_voting_source(store, block_root)`. -/
-forkdef getVotingSource (store : Store map) (blockRoot : Root) : Checkpoint :=
-  match FcMap.lookup store.blocks blockRoot with
-  | none => store.justifiedCheckpoint
-  | some block =>
-    let currentEpoch := getCurrentStoreEpoch store
-    if currentEpoch > computeEpochAtSlot block.slot then
-      FcMap.lookupD store.unrealizedJustifications blockRoot
-    else match FcMap.lookup store.blockStates blockRoot with
-      | some hs => sszGet hs currentJustifiedCheckpoint
-      | none    => store.justifiedCheckpoint
+forkdef getVotingSource (store : Store map) (blockRoot : Root) : StoreTransition Checkpoint := do
+  -- The spec reads `store.blocks[block_root]`, then either
+  -- `store.unrealized_justifications[block_root]` or `store.block_states[block_root]`, all
+  -- plain `Dict`s that raise on a missing key.
+  let block ← FcMap.getOrThrow store.blocks blockRoot
+  let currentEpoch := getCurrentStoreEpoch store
+  if currentEpoch > computeEpochAtSlot block.slot then
+    FcMap.getOrThrow store.unrealizedJustifications blockRoot
+  else
+    let hs ← FcMap.getOrThrow store.blockStates blockRoot
+    pure (sszGet hs currentJustifiedCheckpoint)
 
 /-- `filter_block_tree`: collect the viable branches into `acc` (a root set),
 returning whether `blockRoot` is viable. Root-keyed (unchanged from phase0). The
 recursion is fuel-bounded by the block count (the DAG is finite and acyclic, so the
 depth cannot exceed it), keeping the function total, no `partial def`. -/
 forkdef filterBlockTree (store : Store map) (blockRoot : Root) (acc : Array Root) :
-    Array Root × Bool :=
+    StoreTransition (Array Root × Bool) :=
   go ((FcMap.keys store.blocks).length + 1) blockRoot acc
 where
   /-- The viability walk; `fuel` bounds the parent-to-child descent. -/
-  go : Nat → Root → Array Root → Array Root × Bool
-  | 0,        _,         acc => (acc, false)
-  | fuel + 1, blockRoot, acc =>
+  go : Nat → Root → Array Root → StoreTransition (Array Root × Bool)
+  | 0,        _,         acc => pure (acc, false)
+  | fuel + 1, blockRoot, acc => do
+    -- The spec opens with `block = store.blocks[block_root]`, a plain `Dict` read that
+    -- raises on a missing root; fetch it up front (the fields are reached via the helpers).
+    let _ ← FcMap.getOrThrow store.blocks blockRoot
     let children := FcMap.filterKeys store.blocks (fun _ b => b.parentRoot == blockRoot)
     if children.isEmpty then
       -- A leaf branch is viable when its voting source stays close to the justified
       -- checkpoint (genesis, the same epoch, or within two epochs of the current one).
       let currentEpoch := getCurrentStoreEpoch store
-      let votingSource := getVotingSource store blockRoot
+      let votingSource ← getVotingSource store blockRoot
       let correctJustified :=
         store.justifiedCheckpoint.epoch == Const.genesisEpoch
           || votingSource.epoch == store.justifiedCheckpoint.epoch
           || votingSource.epoch + 2 ≥ currentEpoch
 
       -- The finalized checkpoint must also lie on this branch.
-      let finalizedBlock := getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch
+      let finalizedBlock ← getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch
       let correctFinalized :=
         store.finalizedCheckpoint.epoch == Const.genesisEpoch
           || store.finalizedCheckpoint.root == finalizedBlock
-      if correctJustified && correctFinalized then (acc.push blockRoot, true) else (acc, false)
+      if correctJustified && correctFinalized then pure (acc.push blockRoot, true) else pure (acc, false)
     else
-      let (acc', anyViable) := children.foldl (init := (acc, false)) fun (a, viable) child =>
-        let (a', v) := go fuel child a
-        (a', viable || v)
-      if anyViable then (acc'.push blockRoot, true) else (acc', false)
+      let (acc', anyViable) ← children.foldlM (init := (acc, false)) fun (a, viable) child => do
+        let (a', v) ← go fuel child a
+        pure (a', viable || v)
+      if anyViable then pure (acc'.push blockRoot, true) else pure (acc', false)
 
 /-- `get_filtered_block_tree`: the viable-root set rooted at the justified checkpoint. -/
-forkdef getFilteredBlockTree (store : Store map) : Array Root :=
-  (filterBlockTree store store.justifiedCheckpoint.root #[]).1
+forkdef getFilteredBlockTree (store : Store map) : StoreTransition (Array Root) := do
+  let (roots, _) ← filterBlockTree store store.justifiedCheckpoint.root #[]
+  pure roots
 
 /-- `get_node_children(store, blocks, node)`: a pending node's children are its own
 empty (always) and full (when the payload is verified) realisations; a decided node's
 children are the pending nodes of the filtered child blocks whose parent edge matches
 this node's status. -/
 forkdef getNodeChildren (store : Store map) (blocks : Array Root) (node : ForkChoiceNode) :
-    Array ForkChoiceNode :=
+    StoreTransition (Array ForkChoiceNode) := do
   if node.payloadStatus == Const.payloadStatusPending then
     let empty : ForkChoiceNode := .empty node.root
     if isPayloadVerified store node.root then
-      #[empty, ForkChoiceNode.full node.root]
-    else #[empty]
+      pure #[empty, ForkChoiceNode.full node.root]
+    else pure #[empty]
   else
-    (blocks.filter fun root =>
-      match FcMap.lookup store.blocks root with
-      | some b => b.parentRoot == node.root && node.payloadStatus == getParentPayloadStatus store b
-      | none   => false).map fun root =>
-        ForkChoiceNode.pending root
+    let mut result : Array ForkChoiceNode := #[]
+    for root in blocks do
+      -- The spec's comprehension (`get_node_children`, `gloas/fork-choice.md:547,560-561`) reads
+      -- `blocks[root]` (a plain `Dict`), raising on a missing root; `getOrThrow` matches.
+      -- Unreachable: `blocks` is `getFilteredBlockTree` output, a subset of `store.blocks`.
+      let b ← FcMap.getOrThrow store.blocks root
+      -- `get_parent_payload_status(store, blocks[root])` runs only after
+      -- `blocks[root].parent_root == node.root` (Python `and` short-circuits), so guard the
+      -- now-throwing helper the same way. It never fires for an unrelated block.
+      if b.parentRoot == node.root then
+        let parentStatus ← getParentPayloadStatus store b
+        if node.payloadStatus == parentStatus then
+          result := result.push (ForkChoiceNode.pending root)
+    pure result
 
 /-- `get_head`: the LMD-GHOST walk over the node DAG. The max at each step compares
 `(get_weight, child.root, get_payload_status_tiebreaker)` in that priority order, ties
 broken by the greater root then the greater tiebreaker. Fuel-bounded: each step either
 descends to a new root or flips a pending node to a decided child. -/
-forkdef getHead (store : Store map) : ForkChoiceNode :=
-  let blocks := getFilteredBlockTree store
+forkdef getHead (store : Store map) : StoreTransition ForkChoiceNode := do
+  let blocks ← getFilteredBlockTree store
   let head : ForkChoiceNode := .pending store.justifiedCheckpoint.root
-  fuelIterate (2 * (FcMap.keys store.blocks).length + 2) head fun head =>
-    let children := getNodeChildren store blocks head
-    if children.isEmpty then .done head
-    else .next (children.foldl (init := children[0]!) (betterOf store))
+  -- Monadic `fuelLoop` (the `exhausted` sentinel `head` is unreachable, matching the old
+  -- `fuelIterate` fuel-out); the `max` fold becomes a `foldlM` over `betterOf`.
+  fuelLoop (2 * (FcMap.keys store.blocks).length + 2) head head fun head => do
+    let children ← getNodeChildren store blocks head
+    if children.isEmpty then pure (.done head)
+    else
+      let best ← children.foldlM (init := children[0]!) (betterOf store)
+      pure (.next best)
 where
   /-- The better of two candidate head nodes under the `(weight, root, tiebreaker)`
   ordering: greater weight wins, ties by greater root, further ties by the greater
-  payload-status tiebreaker. -/
-  betterOf (store : Store map) (a b : ForkChoiceNode) : ForkChoiceNode :=
-    let weightA := getWeight store a
-    let weightB := getWeight store b
-    if weightA > weightB then a
-    else if weightB > weightA then b
+  payload-status tiebreaker. The spec's `max(children, key=...)` builds the full key
+  3-tuple *eagerly for every child*, so `get_payload_status_tiebreaker` (whose
+  `payload_timeliness` membership assert throws) runs even when weight alone decides;
+  both tiebreakers are therefore bound before any comparison, keeping a losing child's
+  throw observable exactly where pyspec raises it. -/
+  betterOf (store : Store map) (a b : ForkChoiceNode) : StoreTransition ForkChoiceNode := do
+    let weightA ← getWeight store a
+    let weightB ← getWeight store b
+    let tieA ← getPayloadStatusTiebreaker store a
+    let tieB ← getPayloadStatusTiebreaker store b
+    if weightA > weightB then pure a
+    else if weightB > weightA then pure b
     else match compare a.root b.root with
-      | Ordering.gt => a
-      | Ordering.lt => b
-      | Ordering.eq => if getPayloadStatusTiebreaker store a > getPayloadStatusTiebreaker store b then a else b
+      | Ordering.gt => pure a
+      | Ordering.lt => pure b
+      | Ordering.eq => pure (if tieA > tieB then a else b)
 
 /-! ## Checkpoint updates -/
 
@@ -480,19 +544,21 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
 `process_justification_and_finalization`, record its unrealized justification, and
 (for a prior-epoch block) realize it. Best-effort, so `EStateM.run`, not
 `runStateTransition`. -/
-forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : Store map :=
-  match FcMap.lookup store.blockStates blockRoot, FcMap.lookup store.blocks blockRoot with
-  | some state, some block =>
-    let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
-    match act.run state with
-    | .ok _ pulled =>
-      let cj := sszGet pulled currentJustifiedCheckpoint
-      let fz := sszGet pulled finalizedCheckpoint
-      let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-      let store := updateUnrealizedCheckpoints store cj fz
-      if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store
-    | .error _ _ => store
-  | _, _ => store
+forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
+  -- The spec reads `store.block_states[block_root]` and `store.blocks[block_root]`, both
+  -- plain `Dict`s that raise on a miss. (The inner `processJustificationAndFinalization`
+  -- stays best-effort — a separate discrepancy from the missing-key throws this sweep fixes.)
+  let state ← FcMap.getOrThrow store.blockStates blockRoot
+  let block ← FcMap.getOrThrow store.blocks blockRoot
+  let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
+  match act.run state with
+  | .ok _ pulled =>
+    let cj := sszGet pulled currentJustifiedCheckpoint
+    let fz := sszGet pulled finalizedCheckpoint
+    let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+    let store := updateUnrealizedCheckpoints store cj fz
+    pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
+  | .error _ _ => pure store
 
 /-! ## on_tick -/
 
@@ -530,23 +596,33 @@ forkdef onTick (time : UInt64) : StoreTransition Unit := do
 
 /-- `record_block_timeliness(store, root)`: the two deadlines (attestation-due and
 PTC-due), each `is_current_slot ∧ time_into_slot_ms < threshold`. -/
-forkdef recordBlockTimeliness (store : Store map) (root : Root) : Store map :=
-  match FcMap.lookup store.blocks root with
-  | none => store
-  | some block =>
-    let tis := timeIntoSlotMs store
-    let isCurrentSlot := getCurrentSlot store == block.slot
-    let timeliness : Array Bool := #[isCurrentSlot && tis < bpsDeadlineMs Const.attestationDueBpsGloas,
-                                     isCurrentSlot && tis < bpsDeadlineMs Const.payloadAttestationDueBps]
-    { store with blockTimeliness := FcMap.insert store.blockTimeliness root timeliness }
+forkdef recordBlockTimeliness (store : Store map) (root : Root) : StoreTransition (Store map) := do
+  let block ← FcMap.getOrThrow store.blocks root
+  let tis := timeIntoSlotMs store
+  let isCurrentSlot := getCurrentSlot store == block.slot
+  let timeliness : Array Bool := #[isCurrentSlot && tis < bpsDeadlineMs Const.attestationDueBpsGloas,
+                                   isCurrentSlot && tis < bpsDeadlineMs Const.payloadAttestationDueBps]
+  pure { store with blockTimeliness := FcMap.insert store.blockTimeliness root timeliness }
 
 /-- `update_proposer_boost_root(store, head, root)`: boost a timely first block on the
 same proposer-shuffling lineage as the pre-insertion head. -/
-forkdef updateProposerBoostRoot (store : Store map) (head root : Root) : Store map :=
+forkdef updateProposerBoostRoot (store : Store map) (head root : Root) :
+    StoreTransition (Store map) := do
   let isFirstBlock := store.proposerBoostRoot == fcZeroRoot
-  let isTimely := (FcMap.lookupD store.blockTimeliness root)[Const.attestationTimelinessIndex]?.getD false
-  let isSameDependentRoot := getDependentRoot store root == getDependentRoot store head
-  if isTimely && isFirstBlock && isSameDependentRoot then { store with proposerBoostRoot := root } else store
+  -- `store.block_timeliness[root][ATTESTATION_TIMELINESS_INDEX]` (`gloas/fork-choice.md:960`):
+  -- the outer `[root]` is a plain `Dict` (raises `KeyError`, `getOrThrow`), the inner index a
+  -- raising `list` index (`IndexError`, `arrGetIdx`). Both faithful throws.
+  let timeliness ← FcMap.getOrThrow store.blockTimeliness root
+  let isTimely ← arrGetIdx timeliness Const.attestationTimelinessIndex
+  -- The spec's `get_dependent_root(store, root) == get_dependent_root(store, head)`
+  -- evaluates left-to-right, so the *root* walk runs (and, when both would miss, throws)
+  -- first; bind in that order so the surfaced `missingKey` names the same read.
+  let depRoot ← getDependentRoot store root
+  let depHead ← getDependentRoot store head
+  let isSameDependentRoot := depHead == depRoot
+  if isTimely && isFirstBlock && isSameDependentRoot then
+    pure { store with proposerBoostRoot := root }
+  else pure store
 
 /-! ## PTC vote recording -/
 
@@ -586,7 +662,7 @@ forkdef notifyPtcMessages (store : Store map) (state : State) (payloadAttestatio
 
 /-! ## on_block -/
 
-/-- `on_block`. Rejects (via `assert` / `missingKey`) an unknown parent, a
+/-- `on_block`. Rejects (via `assert`) an unknown parent, a
 full-but-unverified parent, a future block, or a finality conflict, and propagates a
 failed `state_transition` through `runStateTransition`. The ePBS additions over the
 prior fork: the parent-full assert, the two per-block vote-map inits, and
@@ -594,20 +670,23 @@ prior fork: the parent-full assert, the two per-block vote-map inits, and
 forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   let store ← get
   let block := signedBlock.message
-  let parentState ← FcMap.getOrThrow store.blockStates block.parentRoot
+  let parentState ← FcMap.getOrAssert store.blockStates block.parentRoot
+    "block.parent_root in store.block_states"
 
   -- Reject a full-but-unverified parent, a future block, or a finality conflict.
-  assert (!(isParentNodeFull store block) || isPayloadVerified store block.parentRoot)
+  let parentFull ← isParentNodeFull store block
+  assert (!parentFull || isPayloadVerified store block.parentRoot)
   assert (getCurrentSlot store ≥ block.slot)
   let finalizedSlot := computeStartSlotAtEpoch store.finalizedCheckpoint.epoch
   assert (block.slot > finalizedSlot)
-  assert (store.finalizedCheckpoint.root == getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch)
+  let finalizedBlock ← getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch
+  assert (store.finalizedCheckpoint.root == finalizedBlock)
 
   -- Run the state transition, then snapshot the head before the block is added.
   let postState ← runStateTransition parentState (stateTransition signedBlock)
   let blockRoot := htr block
   -- The head is taken BEFORE the new block is added (`update_proposer_boost_root`).
-  let head := getHead store
+  let head ← getHead store
 
   -- Insert the block, its post-state, and the two empty per-block PTC vote maps.
   let emptyVotes : Array (Option Bool) := Array.replicate Const.ptcSize none
@@ -619,10 +698,10 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
 
   -- Replay the block's PTC votes, record timeliness, boost, and pull up the tip.
   let store := notifyPtcMessages store postState block.body.payloadAttestations.toArray
-  let store := recordBlockTimeliness store blockRoot
-  let store := updateProposerBoostRoot store head.root blockRoot
+  let store ← recordBlockTimeliness store blockRoot
+  let store ← updateProposerBoostRoot store head.root blockRoot
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
-  set (computePulledUpTip store blockRoot)
+  set (← computePulledUpTip store blockRoot)
 
 /-! ## on_execution_payload_envelope -/
 
@@ -631,17 +710,26 @@ forkdef computeTimeAtSlot (state : State) (slot : Slot) : UInt64 :=
   (sszGet state genesisTime) + (slot - Const.genesisSlot) * Const.slotDurationMs / 1000
 
 /-- `verify_execution_payload_envelope_signature`: the envelope is signed by the
-builder's key (the proposer's, for a self-build) under `DOMAIN_BEACON_BUILDER`. -/
-forkdef verifyExecutionPayloadEnvelopeSignature (state : State) (signedEnv : SignedExecutionPayloadEnvelope) : Bool :=
+builder's key (the proposer's, for a self-build) under `DOMAIN_BEACON_BUILDER`.
+
+`state.validators[proposer_index]` / `state.builders[builder_index]` are bare indexed reads
+with no guarding assert, and `builder_index` comes straight from the untrusted envelope, so an
+out-of-range index is the spec's `IndexError`. `sszGetIdx` surfaces it as the wrapped
+`.transition (.outOfBounds …)` reject where the former `[i]!` panicked, hence the
+`Except StoreTransitionError Bool` signature; the caller binds the result before the `assert`. -/
+forkdef verifyExecutionPayloadEnvelopeSignature (state : State) (signedEnv : SignedExecutionPayloadEnvelope) :
+    Except StoreTransitionError Bool := do
   let builderIndex := signedEnv.message.builderIndex
-  let pubkey :=
-    if builderIndex == Const.builderIndexSelfBuild then
+  let pubkey ←
+    if builderIndex == Const.builderIndexSelfBuild then do
       let validatorIndex := (sszGet state latestBlockHeader).proposerIndex
-      (sszGet state validators[validatorIndex.toNat]!).pubkey
-    else
-      (sszGet state builders[builderIndex.toNat]!).pubkey
+      let v ← sszGetIdx (sszGet state validators) validatorIndex.toNat
+      pure v.pubkey
+    else do
+      let b ← sszGetIdx (sszGet state builders) builderIndex.toNat
+      pure b.pubkey
   let signingRoot := computeSigningRoot signedEnv.message (getDomain state Const.domainBeaconBuilder (currentEpochOf state))
-  blsVerify pubkey signingRoot signedEnv.signature
+  pure (blsVerify pubkey signingRoot signedEnv.signature)
 
 /-- `verify_execution_payload_envelope`: the consensus-side envelope checks. The EL
 `verify_and_notify_new_payload` and `is_data_available` are modeled as always `true`
@@ -655,7 +743,7 @@ forkdef verifyExecutionPayloadEnvelope (state : State) (signedEnv : SignedExecut
   let payload := envelope.payload
 
   -- Builder signature over the envelope.
-  assert (verifyExecutionPayloadEnvelopeSignature state signedEnv)
+  assert (← verifyExecutionPayloadEnvelopeSignature state signedEnv)
 
   -- Block-root binding: the envelope commits to this state's block header (warmed
   -- with its computed state root) and its parent.
@@ -683,7 +771,8 @@ and enables `is_payload_verified`. -/
 forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) : StoreTransition Unit := do
   let store ← get
   let envelope := signedEnv.message
-  let state ← FcMap.getOrThrow store.blockStates envelope.beaconBlockRoot
+  let state ← FcMap.getOrAssert store.blockStates envelope.beaconBlockRoot
+    "envelope.beacon_block_root in store.block_states"
 
   match verifyExecutionPayloadEnvelope state signedEnv with
   | .error e => throw e
@@ -720,17 +809,19 @@ forkdef onPayloadAttestationMessage (msg : PayloadAttestationMessage) (isFromBlo
 
 /-- `store_target_checkpoint_state`: cache the target's state, advancing to the
 target epoch start if needed (best-effort, so `EStateM.run`). -/
-forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) : Store map :=
-  if FcMap.contains store.checkpointStates target then store
-  else match FcMap.lookup store.blockStates target.root with
-    | none => store
-    | some base =>
-      let targetSlot := computeStartSlotAtEpoch target.epoch
-      let advanced :=
-        if (sszGet base slot) < targetSlot then
-          runBestEffort (processSlots targetSlot) base
-        else base
-      { store with checkpointStates := FcMap.insert store.checkpointStates target advanced }
+forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
+    StoreTransition (Store map) := do
+  if FcMap.contains store.checkpointStates target then pure store
+  else
+    -- `target not in store.checkpoint_states` is a membership guard (faithful), but the
+    -- following `store.block_states[target.root]` is a plain `Dict` read that raises.
+    let base ← FcMap.getOrThrow store.blockStates target.root
+    let targetSlot := computeStartSlotAtEpoch target.epoch
+    let advanced :=
+      if (sszGet base slot) < targetSlot then
+        runBestEffort (processSlots targetSlot) base
+      else base
+    pure { store with checkpointStates := FcMap.insert store.checkpointStates target advanced }
 
 /-- `validate_on_attestation` (Gloas): adds `index ∈ {0, 1}`, same-slot ⇒ index 0,
 and full vote (index 1) ⇒ the head block's payload is verified. -/
@@ -752,7 +843,8 @@ forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlo
   assert (att.data.index == 0 || att.data.index == 1)
   assert (!(b.slot == att.data.slot) || att.data.index == 0)
   assert (!(att.data.index == 1) || isPayloadVerified store att.data.beaconBlockRoot)
-  assert (target.root == getCheckpointBlock store att.data.beaconBlockRoot target.epoch)
+  let checkpointBlock ← getCheckpointBlock store att.data.beaconBlockRoot target.epoch
+  assert (target.root == checkpointBlock)
   assert (getCurrentSlot store ≥ att.data.slot + 1)
 
 /-- `update_latest_messages` (Gloas): slot-ordered, carrying `payload_present`
@@ -776,7 +868,7 @@ block-implied one. -/
 forkdef onAttestation (att : Attestation) (isFromBlock : Bool) : StoreTransition Unit := do
   validateOnAttestation (← get) att isFromBlock
 
-  let store := storeTargetCheckpointState (← get) att.data.target
+  let store ← storeTargetCheckpointState (← get) att.data.target
   let targetState ← FcMap.getOrThrowKey store.checkpointStates att.data.target att.data.target.root
   let attesting := (← liftErr (getAttestingIndices targetState att)).qsort (· < ·)
   let indexedAttestation : IndexedAttestation := { attestingIndices := sszOfArray attesting, data := att.data, signature := att.signature }

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -820,7 +820,11 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
 /-! ## on_attestation -/
 
 /-- `store_target_checkpoint_state`: cache the target's state, advancing to the
-target epoch start if needed (best-effort, so `EStateM.run`). -/
+target epoch start if needed. The pinned `process_slots` call is unguarded, so a
+rejected advance propagates (wrapped `.transition`) and nothing is cached, aborting
+the surrounding `on_attestation` with the store unchanged. Reachable only from
+degenerate near-zero-stake states; the pre-conversion `runBestEffort` cached the
+UNADVANCED base state instead, a wrong-slot entry later reads would consume. -/
 forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
     StoreTransition (Store map) := do
   if FcMap.contains store.checkpointStates target then pure store
@@ -829,10 +833,10 @@ forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
     -- following `store.block_states[target.root]` is a plain `Dict` read that raises.
     let base ← FcMap.getOrThrow store.blockStates target.root
     let targetSlot := computeStartSlotAtEpoch target.epoch
-    let advanced :=
+    let advanced ←
       if (sszGet base slot) < targetSlot then
-        runBestEffort (processSlots targetSlot) base
-      else base
+        runStateTransition base (processSlots targetSlot)
+      else pure base
     pure { store with checkpointStates := FcMap.insert store.checkpointStates target advanced }
 
 /-- `validate_on_attestation` (Gloas): adds `index ∈ {0, 1}`, same-slot ⇒ index 0,
@@ -1013,5 +1017,35 @@ private def pinReplayThrows : Bool :=
   | .error (.assert _) _ => true
   | _ => false
 example : pinReplayThrows = true := by native_decide
+
+/-- The target-checkpoint advance propagates a `process_slots` reject. The fixture
+state is `default` (zero validators, slot 0) carrying one queued
+`PendingConsolidation`: advancing to epoch 1's start slot reaches
+`process_pending_consolidations`, whose `state.validators[source_index]` read is a
+pinned plain-list read (pyspec `IndexError`), so the epoch step rejects with
+`outOfBounds` and the unguarded pinned `process_slots` means
+`store_target_checkpoint_state` re-throws it (`.transition`) with nothing cached,
+where the pre-conversion `runBestEffort` cached the unadvanced state. This pins the
+propagation semantics; the throw site inside epoch processing is incidental. The
+consolidation carrier is deliberate: a bare zero-validator advance does NOT reject,
+it grinds through `cbwsAux`'s 10M-iteration fuel in the proposer lookahead, so the
+reject must land earlier in the epoch pipeline. `State` is FFI-backed (`FastBox`),
+so `native_decide`. -/
+private def pinTargetAdvanceRejects : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  -- `process_slots` runs the state machine, whose section wants a `CryptoBackend`.
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let bs : @EthCLSpecs.Gloas.BeaconState minimal :=
+    { (default : @EthCLSpecs.Gloas.BeaconState minimal) with
+      pendingConsolidations := sszOfArray #[{ sourceIndex := 0, targetIndex := 0 }] }
+  let state : State := SSZ.FastBox bs
+  let store := { pinStore with blockStates := FcMap.insert FcMap.empty pinRoot state }
+  let target : Checkpoint := { epoch := 1, root := pinRoot }
+  match (storeTargetCheckpointState (map := treeMap) store target : PinM (Store treeMap)).run store with
+  | .error (.transition _) _ => true
+  | _ => false
+example : pinTargetAdvanceRejects = true := by native_decide
 
 end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -544,23 +544,18 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
 
 /-- `compute_pulled_up_tip`: pull up the block's post-state through
 `process_justification_and_finalization`, record its unrealized justification, and
-(for a prior-epoch block) realize it. Best-effort, so `EStateM.run`, not
-`runStateTransition`. -/
+(for a prior-epoch block) realize it. The `block_states` / `blocks` reads raise on a
+miss, and the pull-up itself propagates: pyspec runs `process_justification_and_finalization`
+unguarded, so a reject aborts the surrounding `on_block`. -/
 forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
-  -- The spec reads `store.block_states[block_root]` and `store.blocks[block_root]`, both
-  -- plain `Dict`s that raise on a miss. (The inner `processJustificationAndFinalization`
-  -- stays best-effort — a separate discrepancy from the missing-key throws this sweep fixes.)
   let state ← FcMap.getOrThrow store.blockStates blockRoot
   let block ← FcMap.getOrThrow store.blocks blockRoot
-  let act : EStateM StateTransitionError State Unit := processJustificationAndFinalization
-  match act.run state with
-  | .ok _ pulled =>
-    let cj := sszGet pulled currentJustifiedCheckpoint
-    let fz := sszGet pulled finalizedCheckpoint
-    let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-    let store := updateUnrealizedCheckpoints store cj fz
-    pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
-  | .error _ _ => pure store
+  let pulled ← runStateTransition state processJustificationAndFinalization
+  let cj := sszGet pulled currentJustifiedCheckpoint
+  let fz := sszGet pulled finalizedCheckpoint
+  let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+  let store := updateUnrealizedCheckpoints store cj fz
+  pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
 
 /-! ## on_tick -/
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -894,29 +894,38 @@ forkdef onAttesterSlashing (asl : AttesterSlashing) : StoreTransition Unit := do
 
 /-! ## get_forkchoice_store -/
 
-/-- `get_forkchoice_store(anchor_state, anchor_block)` (Gloas): `block_timeliness`
-seeds `[True, True]` for the anchor, the three ePBS maps start empty, and the time
-uses the ms-based `SLOT_DURATION_MS * slot // 1000` form. -/
-forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
+/-- `get_forkchoice_store(anchor_state, anchor_block)` (Gloas,
+`consensus-specs/specs/gloas/fork-choice.md:183-184`): `block_timeliness` seeds `[True, True]`
+for the anchor, the three ePBS maps start empty, and the time uses the ms-based
+`SLOT_DURATION_MS * slot // 1000` form. The pyspec opens with
+`assert anchor_block.state_root == hash_tree_root(anchor_state)`, so the seed is a throwing
+`Except StoreTransitionError` action rather than a total store literal (reject branch
+vectorless; Heze's `pinAnchorRejects` locks the identical assert). -/
+forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
+    Except StoreTransitionError (Store map) := do
+  -- `anchor_block.state_root == hash_tree_root(anchor_state)`: the boxed state hashes
+  -- through `stateRoot` (the cached-tree path), not `htr` (which wants a bare `SSZRepr`).
+  assert (anchorBlock.stateRoot == bytesToRoot (stateRoot anchorState).1)
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
 
-  { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
-    genesisTime := sszGet anchorState genesisTime
-    justifiedCheckpoint := cp, finalizedCheckpoint := cp
-    unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
-    proposerBoostRoot := fcZeroRoot
-    equivocatingIndices := #[]
-    blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
-    blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
-    blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
-    checkpointStates := FcMap.insert FcMap.empty cp anchorState
-    latestMessages := FcMap.empty
-    unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
-    payloads := FcMap.empty
-    payloadTimelinessVote := FcMap.empty
-    payloadDataAvailabilityVote := FcMap.empty }
+  pure
+    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+      genesisTime := sszGet anchorState genesisTime
+      justifiedCheckpoint := cp, finalizedCheckpoint := cp
+      unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
+      proposerBoostRoot := fcZeroRoot
+      equivocatingIndices := #[]
+      blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
+      blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
+      blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
+      checkpointStates := FcMap.insert FcMap.empty cp anchorState
+      latestMessages := FcMap.empty
+      unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
+      payloads := FcMap.empty
+      payloadTimelinessVote := FcMap.empty
+      payloadDataAvailabilityVote := FcMap.empty }
 
 end
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -16,8 +16,9 @@ map backing (`EthCLLib.Spec.FcMap`) and the Gloas boxed `State`, the section ope
 `fork_choice_section map`, and the wire handlers are monadic `StoreTransition` actions over
 the typed `StoreTransitionError`. The ePBS surface adds `on_execution_payload_envelope`,
 `on_payload_attestation_message`, the two per-block PTC vote maps, the parent-payload
-assert, and `notify_ptc_messages` (the block's payload attestations replayed per
-validator, a pure store transform). `on_block` runs the Gloas `state_transition` through
+assert, and `notify_ptc_messages` (the block's payload attestations replayed per validator
+through `on_payload_attestation_message`, so the handler's rejects apply on the
+block path too). `on_block` runs the Gloas `state_transition` through
 `runStateTransition`.
 
 The `Ord (Vector UInt8 32)` instance and the `Checkpoint` `Ord` / `BEq` / `Hashable`
@@ -627,38 +628,68 @@ forkdef updateProposerBoostRoot (store : Store map) (head root : Root) :
 /-! ## PTC vote recording -/
 
 /-- Write `payload_present` / `blob_data_available` at the given PTC positions for the
-attested block (the shared core of `on_payload_attestation_message`'s vote write). -/
+attested block (the shared core of `on_payload_attestation_message`'s vote write). The
+two vote-map reads are plain `Dict` reads in the pinned spec
+(`store.payload_timeliness_vote[data.beacon_block_root]`, fork-choice.md:1110-1111),
+so a miss rejects with `missingKey` rather than defaulting. -/
 forkdef recordPtcVotes (store : Store map) (data : PayloadAttestationData) (ptcIndices : Array Nat) :
-    Store map :=
-  let timelinessVote := FcMap.lookupD store.payloadTimelinessVote data.beaconBlockRoot
-  let availabilityVote := FcMap.lookupD store.payloadDataAvailabilityVote data.beaconBlockRoot
+    StoreTransition (Store map) := do
+  let timelinessVote ← FcMap.getOrThrow store.payloadTimelinessVote data.beaconBlockRoot
+  let availabilityVote ← FcMap.getOrThrow store.payloadDataAvailabilityVote data.beaconBlockRoot
   let (timelinessVote, availabilityVote) := ptcIndices.foldl (init := (timelinessVote, availabilityVote))
     fun (tv, av) i => (tv.set! i (some data.payloadPresent), av.set! i (some data.blobDataAvailable))
-  { store with
+  pure { store with
     payloadTimelinessVote := FcMap.insert store.payloadTimelinessVote data.beaconBlockRoot timelinessVote
     payloadDataAvailabilityVote := FcMap.insert store.payloadDataAvailabilityVote data.beaconBlockRoot availabilityVote }
 
+/-! ## on_payload_attestation_message -/
+
+/-- `on_payload_attestation_message(store, ptc_message, is_from_block)` (the wire
+handler, `is_from_block = false`): the attested block's state slot must match, the
+validator must sit in its PTC, the message must be for the current slot, and its
+signature must verify; then the votes are recorded. -/
+forkdef onPayloadAttestationMessage (msg : PayloadAttestationMessage) (isFromBlock : Bool) :
+    StoreTransition Unit := do
+  let store ← get
+  let data := msg.data
+  let state ← FcMap.getOrAssert store.blockStates data.beaconBlockRoot
+    "data.beacon_block_root in store.block_states"
+
+  if !(data.slot == sszGet state slot) then pure ()
+  else
+    let ptc := getPtc state data.slot
+    let ptcIndices := (Array.range Const.ptcSize).filter fun i => vget ptc i == msg.validatorIndex
+    assert (ptcIndices.size > 0)
+    if isFromBlock then set (← recordPtcVotes store data ptcIndices)
+    else
+      assert (data.slot == getCurrentSlot store)
+      let indexed : IndexedPayloadAttestation :=
+        { attestingIndices := sszOfArray #[msg.validatorIndex], data := data, signature := msg.signature }
+      assert (isValidIndexedPayloadAttestation state indexed)
+      set (← recordPtcVotes store data ptcIndices)
+
 /-- `notify_ptc_messages(store, state, payload_attestations)`: replay the block's
 payload attestations as per-validator `on_payload_attestation_message`s
-(`is_from_block = true`). The block-replay never asserts, so the per-message effect is
-inlined as a pure store transform: apply the vote when the attested block's state slot
-matches and the validator sits in its PTC, otherwise skip. -/
-forkdef notifyPtcMessages (store : Store map) (state : State) (payloadAttestations : Array PayloadAttestation) :
-    Store map := Id.run do
-  if sszGet state slot == 0 then return store
-
-  let mut store := store
+(`is_from_block = true`), exactly the pinned loop (fork-choice.md:217-237): each
+attesting index becomes a `PayloadAttestationMessage` with an empty signature (never
+verified on the block path) and runs through the wire handler. The handler's ungated
+rejects apply on this path too, as in pyspec. An unknown `beacon_block_root` rejects with
+the spec's `assert data.beacon_block_root in store.block_states` (a `getOrAssert` `.assert`),
+and an attester outside the attested block's PTC rejects with
+the `ptc_indices` assert. Either reject aborts the whole surrounding `on_block`.
+`state` is the block's post-state, used only to resolve the attesting indices
+(`get_indexed_payload_attestation`); the handler re-reads the attested block's own
+state from the store, as the spec does. -/
+forkdef notifyPtcMessages (state : State) (payloadAttestations : Array PayloadAttestation) :
+    StoreTransition Unit := do
+  if sszGet state slot == 0 then return
   for pa in payloadAttestations do
     let indexed := getIndexedPayloadAttestation state pa
     for idx in indexed.attestingIndices do
-      match FcMap.lookup store.blockStates pa.data.beaconBlockRoot with
-      | none => pure ()
-      | some attState =>
-        if pa.data.slot == sszGet attState slot then
-          let ptc := getPtc attState pa.data.slot
-          let ptcIndices := (Array.range Const.ptcSize).filter fun i => vget ptc i == idx
-          if ptcIndices.size > 0 then store := recordPtcVotes store pa.data ptcIndices
-  return store
+      -- `(map := map)`: the handler takes no store argument, so the section's map backing
+      -- is undetermined at this call site (the ambient `get`/`set` constraint alone leaves
+      -- it a stuck metavariable); name it explicitly.
+      onPayloadAttestationMessage (map := map) { validatorIndex := idx, data := pa.data, signature := default } true
 
 /-! ## on_block -/
 
@@ -689,15 +720,21 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   let head ← getHead store
 
   -- Insert the block, its post-state, and the two empty per-block PTC vote maps.
+  -- `set` before the replay: the routed `notify_ptc_messages` reads the ambient store,
+  -- and pyspec's mutation order has these four writes precede it, so a replay reject
+  -- leaves them in place.
   let emptyVotes : Array (Option Bool) := Array.replicate Const.ptcSize none
-  let store := { store with
+  set { store with
     blocks := FcMap.insert store.blocks blockRoot block
     blockStates := FcMap.insert store.blockStates blockRoot postState
     payloadTimelinessVote := FcMap.insert store.payloadTimelinessVote blockRoot emptyVotes
     payloadDataAvailabilityVote := FcMap.insert store.payloadDataAvailabilityVote blockRoot emptyVotes }
 
-  -- Replay the block's PTC votes, record timeliness, boost, and pull up the tip.
-  let store := notifyPtcMessages store postState block.body.payloadAttestations.toArray
+  -- Replay the block's PTC votes through the wire handler (`is_from_block = true`),
+  -- then record timeliness, boost, and pull up the tip. `(map := map)` as in the replay
+  -- itself: no store argument determines the backing.
+  notifyPtcMessages (map := map) postState block.body.payloadAttestations.toArray
+  let store ← get
   let store ← recordBlockTimeliness store blockRoot
   let store ← updateProposerBoostRoot store head.root blockRoot
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
@@ -779,31 +816,6 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
   | .ok warm => set { store with
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
-
-/-! ## on_payload_attestation_message -/
-
-/-- `on_payload_attestation_message(store, ptc_message, is_from_block)` (the wire
-handler, `is_from_block = false`): the attested block's state slot must match, the
-validator must sit in its PTC, the message must be for the current slot, and its
-signature must verify; then the votes are recorded. -/
-forkdef onPayloadAttestationMessage (msg : PayloadAttestationMessage) (isFromBlock : Bool) :
-    StoreTransition Unit := do
-  let store ← get
-  let data := msg.data
-  let state ← FcMap.getOrThrow store.blockStates data.beaconBlockRoot
-
-  if !(data.slot == sszGet state slot) then pure ()
-  else
-    let ptc := getPtc state data.slot
-    let ptcIndices := (Array.range Const.ptcSize).filter fun i => vget ptc i == msg.validatorIndex
-    assert (ptcIndices.size > 0)
-    if isFromBlock then set (recordPtcVotes store data ptcIndices)
-    else
-      assert (data.slot == getCurrentSlot store)
-      let indexed : IndexedPayloadAttestation :=
-        { attestingIndices := sszOfArray #[msg.validatorIndex], data := data, signature := msg.signature }
-      assert (isValidIndexedPayloadAttestation state indexed)
-      set (recordPtcVotes store data ptcIndices)
 
 /-! ## on_attestation -/
 
@@ -928,5 +940,78 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
       payloadDataAvailabilityVote := FcMap.empty }
 
 end
+
+/-! ### Build-enforced pins (vectorless): the PTC replay rejects
+
+The replay conversions' reject branches are unreachable by conformance vectors (the
+generators cannot ship the pyspec `KeyError` case), so they are locked here, the
+same pattern as Heze's inclusion-list pins. `pinStore` mirrors Heze's
+`pinPilsStore` without the two FOCIL fields. -/
+
+/-- The pins' concrete fork-choice monad: the minimal preset over the deterministic
+`treeMap` and the FFI hasher. -/
+private abbrev PinM := EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag)
+
+private def pinRoot : Root := Vector.replicate 32 9
+
+/-- A minimal empty Gloas `Store`: every field empty/zero, mirroring the
+`getForkchoiceStore` literal. The `letI`s fix the preset / hasher so the anonymous
+`Store` constructor synthesizes them. -/
+private def pinStore : @Store minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { time := 0, genesisTime := 0
+    justifiedCheckpoint := default, finalizedCheckpoint := default
+    unrealizedJustifiedCheckpoint := default, unrealizedFinalizedCheckpoint := default
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.empty
+    blockStates := FcMap.empty
+    blockTimeliness := FcMap.empty
+    checkpointStates := FcMap.empty
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.empty
+    payloads := FcMap.empty
+    payloadTimelinessVote := FcMap.empty
+    payloadDataAvailabilityVote := FcMap.empty }
+
+/-- `recordPtcVotes` rejects (`missingKey`) when the per-block vote maps carry no
+entry for the attested root, the pinned plain-`Dict` read; the pre-conversion
+`lookupD` silently defaulted to `#[]` and the writes no-opped. `FcMap` only
+(hash-free), so kernel `#guard`. -/
+private def pinRecordPtcVotesThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let data : PayloadAttestationData := { (default : PayloadAttestationData) with beaconBlockRoot := pinRoot }
+  match (recordPtcVotes (map := treeMap) pinStore data #[0] : PinM (Store treeMap)).run pinStore with
+  | .error (.missingKey _) _ => true
+  | _ => false
+#guard pinRecordPtcVotesThrows = true
+
+/-- The routed replay throw, end-to-end: `notifyPtcMessages` over a state at
+`slot := 1` (zeroed `ptc_window`, so the PTC is all validator 0; alpha.11 `get_ptc`
+is a plain window read) and a one-bit payload attestation whose `beacon_block_root`
+the store does not know rejects with the wire handler's `.assert` (the pinned
+`assert data.beacon_block_root in store.block_states` membership assert, a
+`getOrAssert` miss), where the pre-conversion replay silently skipped the
+message. This locks the routing itself: the replay path IS
+`on_payload_attestation_message (is_from_block = true)`. `State` is FFI-backed
+(`FastBox`), so `native_decide`. -/
+private def pinReplayThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  -- The handler wants a `CryptoBackend` for its wire-path signature check; the
+  -- block-replay path (`is_from_block = true`) never reaches it, but elaboration does.
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Gloas.BeaconState minimal) with slot := 1 })
+  let pa : PayloadAttestation := { (default : PayloadAttestation) with
+    aggregationBits := bitSet default 0 true
+    data := { (default : PayloadAttestationData) with beaconBlockRoot := pinRoot, slot := 1 } }
+  match (notifyPtcMessages (map := treeMap) state #[pa] : PinM Unit).run pinStore with
+  | .error (.assert _) _ => true
+  | _ => false
+example : pinReplayThrows = true := by native_decide
 
 end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -576,7 +576,7 @@ of `on_tick`, ms-based). Fuel-bounded by the number of slots to advance. -/
 forkdef advanceStoreTime (store : Store map) (time : UInt64) : Store map :=
   -- The slot `time` lands in. It is loop-invariant (only `time` and the fixed
   -- `genesisTime` feed it, and `onTickPerSlot` touches neither), so it doubles as
-  -- the fuel bound and is read unchanged inside the sweep.
+  -- the fuel bound and is read unchanged inside the loop.
   let targetSlot := ((time - store.genesisTime) * 1000) / Const.slotDurationMs
   let fuel := (targetSlot - getCurrentSlot store).toNat + 1
   fuelIterate fuel store fun store =>
@@ -1070,5 +1070,25 @@ private def pinBlockRootRecencyRejects : Bool :=
   | .error (.assert _) _ => true
   | _ => false
 example : pinBlockRootRecencyRejects = true := by native_decide
+
+/-- `verifyExecutionPayloadEnvelopeSignature` rejects (`.transition (.outOfBounds …)`) an
+out-of-range `builder_index`: a `default` state has an empty `builders` registry, so an
+envelope with `builder_index = 1` (not the self-build sentinel `UINT64_MAX`) reads
+`state.builders[1]`, which the spec's `IndexError` surfaces through `sszGetIdx` where the
+former `[i]!` would have panicked. The read throws before `bls.Verify`, so no backend runs.
+`State` is FFI-backed, so `native_decide`. -/
+private def pinEnvelopeSigBuilderOob : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Gloas.BeaconState minimal)
+  let signedEnv : SignedExecutionPayloadEnvelope :=
+    { (default : SignedExecutionPayloadEnvelope) with
+      message := { (default : ExecutionPayloadEnvelope) with builderIndex := 1 } }
+  match verifyExecutionPayloadEnvelopeSignature state signedEnv with
+  | .error (.transition (.outOfBounds _ _)) => true
+  | _ => false
+example : pinEnvelopeSigBuilderOob = true := by native_decide
 
 end EthCLSpecs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -541,7 +541,13 @@ where
   3-tuple *eagerly for every child*, so `get_payload_status_tiebreaker` (whose
   `payload_timeliness` membership assert throws) runs even when weight alone decides;
   both tiebreakers are therefore bound before any comparison, keeping a losing child's
-  throw observable exactly where pyspec raises it. -/
+  throw observable exactly where pyspec raises it.
+
+  The `foldlM` re-evaluates the accumulator's key on every step, where `max` evaluates each
+  child's key once. That leaves which reject surfaces unchanged. An accumulator reached its
+  position by surviving an earlier step, so its key already succeeded and cannot throw on the
+  re-run, and the first throw stays at the first child whose key raises, in index order, as
+  under `max`. What the repetition does cost is a second `getWeight` walk per comparison. -/
   betterOf (store : Store map) (a b : ForkChoiceNode) : StoreTransition ForkChoiceNode := do
     let weightA ← getWeight store a
     let weightB ← getWeight store b

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -136,7 +136,9 @@ forkdef timeIntoSlotMs (store : Store map) : StoreTransition UInt64 := do
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full
-`bps * SLOT_DURATION_MS` product. -/
+`bps * SLOT_DURATION_MS` product. The product stays bare rather than `checkedMul`: both
+factors are constants, so it peaks near `1.2e8` and cannot reach the `uint64` bound
+(`Fulu.bpsDeadlineMs`). -/
 forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
   bps * Const.slotDurationMs / Const.basisPoints
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -258,7 +258,8 @@ forkdef isPreviousSlotPayloadDecision (store : Store map) (node : ForkChoiceNode
   -- The spec reads `store.blocks[node.root].slot` (plain `Dict`), raising on a missing root.
   let block ← FcMap.getOrThrow store.blocks node.root
   let currentSlot ← getCurrentSlot store
-  let isPreviousSlot := block.slot + 1 == currentSlot
+  let nextSlot ← checkedAdd block.slot 1 "is_previous_slot_payload_decision: blocks[root].slot + 1"
+  let isPreviousSlot := nextSlot == currentSlot
   let isPayloadDecision :=
     node.payloadStatus == Const.payloadStatusEmpty || node.payloadStatus == Const.payloadStatusFull
   pure (isPreviousSlot && isPayloadDecision)
@@ -391,7 +392,8 @@ forkdef shouldApplyProposerBoost (store : Store map) : StoreTransition Bool := d
     let parentRoot := block.parentRoot
     let parent ← FcMap.getOrThrow store.blocks parentRoot
     let slot := block.slot
-    if parent.slot + 1 < slot then pure true
+    let parentNextSlot ← checkedAdd parent.slot 1 "is_proposer_equivocation: parent.slot + 1"
+    if parentNextSlot < slot then pure true
     else if !(← isHeadWeak store parentRoot) then pure true
     else
       -- The spec's equivocation comprehension iterates `store.blocks.items()`
@@ -405,8 +407,9 @@ forkdef shouldApplyProposerBoost (store : Store map) : StoreTransition Bool := d
       let equivExists ← entries.foldlM (init := false) fun found (root, b) => do
         let tl ← FcMap.getOrThrow store.blockTimeliness root
         let timely ← arrGetIdx tl Const.ptcTimelinessIndex
+        let bNextSlot ← checkedAdd b.slot 1 "is_proposer_equivocation: block.slot + 1"
         pure (found || (timely && b.proposerIndex == parent.proposerIndex
-          && b.slot + 1 == slot && root != parentRoot))
+          && bNextSlot == slot && root != parentRoot))
       pure (!equivExists)
 
 /-- `get_weight(store, node)`: zero for an undecided previous-slot payload; otherwise
@@ -461,10 +464,14 @@ where
       -- checkpoint (genesis, the same epoch, or within two epochs of the current one).
       let currentEpoch ← getCurrentStoreEpoch store
       let votingSource ← getVotingSource store blockRoot
-      let correctJustified :=
+      -- Python's `or` short-circuits, so the `+ 2` runs only once the two cheap disjuncts
+      -- fail; the guard keeps that order, since the add is a checked `uint64` op.
+      let justifiedWithoutHorizon :=
         store.justifiedCheckpoint.epoch == Const.genesisEpoch
           || votingSource.epoch == store.justifiedCheckpoint.epoch
-          || votingSource.epoch + 2 ≥ currentEpoch
+      let correctJustified ← if justifiedWithoutHorizon then pure true else do
+        let horizon ← checkedAdd votingSource.epoch 2 "filter_block_tree: voting_source.epoch + 2"
+        pure (decide (horizon ≥ currentEpoch))
 
       -- The finalized checkpoint must also lie on this branch.
       let finalizedBlock ← getCheckpointBlock store blockRoot store.finalizedCheckpoint.epoch

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -113,21 +113,26 @@ forkdef fcZeroRoot : Root := Vector.replicate 32 0
 /-! ## Time / slot accessors -/
 
 /-- `get_slots_since_genesis` (Gloas, ms-based): `(time - genesis_time) * 1000 //
-SLOT_DURATION_MS`. -/
-forkdef getSlotsSinceGenesis (store : Store map) : UInt64 :=
-  ((store.time - store.genesisTime) * 1000) / Const.slotDurationMs
+SLOT_DURATION_MS`. Throwing: `time - genesis_time` (underflow) and `* 1000` (overflow) are
+`uint64` ops that raise `ValueError`, uncaught by the runner, so `checkedSub` / `checkedMul`. -/
+forkdef getSlotsSinceGenesis (store : Store map) : StoreTransition UInt64 := do
+  let elapsed ← checkedSub store.time store.genesisTime "get_slots_since_genesis: time - genesis_time"
+  let ms ← checkedMul elapsed 1000 "get_slots_since_genesis: (time - genesis_time) * 1000"
+  pure (ms / Const.slotDurationMs)
 
-/-- `get_current_slot`. -/
-forkdef getCurrentSlot (store : Store map) : Slot := Const.genesisSlot + getSlotsSinceGenesis store
+/-- `get_current_slot`. `GENESIS_SLOT = 0`, so the `+` cannot overflow. -/
+forkdef getCurrentSlot (store : Store map) : StoreTransition Slot := do
+  pure (Const.genesisSlot + (← getSlotsSinceGenesis store))
 
 /-- `get_current_store_epoch`. -/
-forkdef getCurrentStoreEpoch (store : Store map) : Epoch := computeEpochAtSlot (getCurrentSlot store)
+forkdef getCurrentStoreEpoch (store : Store map) : StoreTransition Epoch := do
+  pure (computeEpochAtSlot (← getCurrentSlot store))
 
 /-- `time_into_slot`, in milliseconds: wall-clock elapsed since the slot start, modulo the slot
-length, via the overflow-guarded `seconds_to_milliseconds` (shared with Fulu). The prior form
-was a raw `* 1000`, missing the pinned clamp; value-identical at realistic slots. Heze inherits. -/
-forkdef timeIntoSlotMs (store : Store map) : UInt64 :=
-  Fulu.secondsToMilliseconds (store.time - store.genesisTime) % Const.slotDurationMs
+length, via the overflow-guarded `seconds_to_milliseconds` (shared with Fulu). Heze inherits. -/
+forkdef timeIntoSlotMs (store : Store map) : StoreTransition UInt64 := do
+  let seconds ← checkedSub store.time store.genesisTime "time_into_slot: time - genesis_time"
+  pure (Fulu.secondsToMilliseconds seconds % Const.slotDurationMs)
 
 /-- A basis-points deadline within a slot, in milliseconds: `bps * SLOT_DURATION_MS //
 BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor lands on the full
@@ -135,7 +140,13 @@ BASIS_POINTS`. Multiply before the `UInt64` truncating divide, so the floor land
 forkdef bpsDeadlineMs (bps : UInt64) : UInt64 :=
   bps * Const.slotDurationMs / Const.basisPoints
 
-/-! ## Parent payload status + node walks -/
+/-! ## Parent payload status + node walks
+
+The walks here are `fuelLoop`-bounded rather than closed by `termination_by`, the choice
+`SPECS_ARCHITECTURE.md` §7.2 asks each loop to justify: the reads raise, so the walk is
+monadic, and a measure would have to be carried through a step that can reject. The bounds
+are honest counts over a finite acyclic DAG, so fuel-out is unreachable.
+-/
 
 /-- `get_parent_payload_status(store, block)`: the parent edge is FULL when the
 block's committed parent block hash matches the parent's own bid block hash, else
@@ -200,7 +211,7 @@ forkdef getSupportedNode (store : Store map) (message : LatestMessage) :
 /-- `get_dependent_root` (Gloas, node-based): the block root that determined the
 current epoch's proposer shuffling. -/
 forkdef getDependentRoot (store : Store map) (root : Root) : StoreTransition Root := do
-  let epoch := getCurrentStoreEpoch store
+  let epoch ← getCurrentStoreEpoch store
   if epoch ≤ Const.minSeedLookahead then pure fcZeroRoot
   else
     let node : ForkChoiceNode := .pending root
@@ -246,7 +257,8 @@ forkdef isPreviousSlotPayloadDecision (store : Store map) (node : ForkChoiceNode
     StoreTransition Bool := do
   -- The spec reads `store.blocks[node.root].slot` (plain `Dict`), raising on a missing root.
   let block ← FcMap.getOrThrow store.blocks node.root
-  let isPreviousSlot := block.slot + 1 == getCurrentSlot store
+  let currentSlot ← getCurrentSlot store
+  let isPreviousSlot := block.slot + 1 == currentSlot
   let isPayloadDecision :=
     node.payloadStatus == Const.payloadStatusEmpty || node.payloadStatus == Const.payloadStatusFull
   pure (isPreviousSlot && isPayloadDecision)
@@ -257,7 +269,9 @@ forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition 
   -- The spec opens with `assert store.blocks[root].slot + 1 == get_current_slot(store)`:
   -- read the block (raising on a missing root), then assert the slot equation.
   let rootBlock ← FcMap.getOrThrow store.blocks root
-  assert (rootBlock.slot + 1 == getCurrentSlot store)
+  let currentSlot ← getCurrentSlot store
+  let nextSlot ← checkedAdd rootBlock.slot 1 "should_extend_payload: blocks[root].slot + 1"
+  assert (nextSlot == currentSlot)
   if !isPayloadVerified store root then pure false
   else
     let proposerRoot := store.proposerBoostRoot
@@ -270,7 +284,7 @@ forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition 
     else
       let pb ← FcMap.getOrThrow store.blocks proposerRoot
       -- The final `or` short-circuits too: `is_parent_node_full` (whose
-      -- `store.blocks[pb.parent_root]` read now throws) never runs when
+      -- `store.blocks[pb.parent_root]` read throws) never runs when
       -- `pb.parent_root != root` already decides the disjunction.
       if pb.parentRoot != root then pure true
       else isParentNodeFull store pb
@@ -307,8 +321,8 @@ forkdef getProposerScore (store : Store map) : StoreTransition Gwei := do
 
 /-- `get_attestation_score(store, node, state)`: the effective balance of the
 unslashed active validators whose supported node is an ancestor of `node`. The validator
-reads are at active-validator indices (in range by construction); this becomes monadic only
-to bind the now-throwing `getSupportedNode` / `isAncestor`. -/
+reads are at active-validator indices (in range by construction); the fold is monadic only
+to bind `getSupportedNode` / `isAncestor`, which can reject. -/
 forkdef getAttestationScore (store : Store map) (node : ForkChoiceNode) (state : State) :
     StoreTransition Gwei := do
   let active := getActiveValidatorIndices state (currentEpochOf state)
@@ -340,8 +354,9 @@ forkdef isHeadWeak (store : Store map) (headRoot : Root) : StoreTransition Bool 
   -- The equivocator read is `justified_state.validators[i]` with `i` drawn from the *head*
   -- state's committees, so a cross-branch registry skew can push it past the justified
   -- registry's end; the spec raises `IndexError` there, hence `sszGetIdx` (the wrapped
-  -- `outOfBounds` reject) in place of the silent-default `[i.toNat]!`. The folds turn
-  -- monadic (`foldlM`) only to bind that throwing read.
+  -- `outOfBounds` reject) for this fold's validator reads, and `foldlM` to bind it. The
+  -- sibling `getAttestationScore` fold keeps `validators[idx]!`: its indices come from
+  -- `getActiveValidatorIndices` on the same state it reads, so they are in range.
   let headWeight ← (List.range (getCommitteeCountPerSlot headState epoch)).foldlM (init := baseWeight) fun acc index => do
     let committee := getBeaconCommittee headState headBlock.slot index
     committee.foldlM (init := acc) fun a i =>
@@ -418,7 +433,7 @@ forkdef getVotingSource (store : Store map) (blockRoot : Root) : StoreTransition
   -- `store.unrealized_justifications[block_root]` or `store.block_states[block_root]`, all
   -- plain `Dict`s that raise on a missing key.
   let block ← FcMap.getOrThrow store.blocks blockRoot
-  let currentEpoch := getCurrentStoreEpoch store
+  let currentEpoch ← getCurrentStoreEpoch store
   if currentEpoch > computeEpochAtSlot block.slot then
     FcMap.getOrThrow store.unrealizedJustifications blockRoot
   else
@@ -444,7 +459,7 @@ where
     if children.isEmpty then
       -- A leaf branch is viable when its voting source stays close to the justified
       -- checkpoint (genesis, the same epoch, or within two epochs of the current one).
-      let currentEpoch := getCurrentStoreEpoch store
+      let currentEpoch ← getCurrentStoreEpoch store
       let votingSource ← getVotingSource store blockRoot
       let correctJustified :=
         store.justifiedCheckpoint.epoch == Const.genesisEpoch
@@ -488,7 +503,7 @@ forkdef getNodeChildren (store : Store map) (blocks : Array Root) (node : ForkCh
       let b ← FcMap.getOrThrow store.blocks root
       -- `get_parent_payload_status(store, blocks[root])` runs only after
       -- `blocks[root].parent_root == node.root` (Python `and` short-circuits), so guard the
-      -- now-throwing helper the same way. It never fires for an unrelated block.
+      -- throwing helper the same way. It never fires for an unrelated block.
       if b.parentRoot == node.root then
         let parentStatus ← getParentPayloadStatus store b
         if node.payloadStatus == parentStatus then
@@ -502,8 +517,8 @@ descends to a new root or flips a pending node to a decided child. -/
 forkdef getHead (store : Store map) : StoreTransition ForkChoiceNode := do
   let blocks ← getFilteredBlockTree store
   let head : ForkChoiceNode := .pending store.justifiedCheckpoint.root
-  -- Monadic `fuelLoop` (the `exhausted` sentinel `head` is unreachable, matching the old
-  -- `fuelIterate` fuel-out); the `max` fold becomes a `foldlM` over `betterOf`.
+  -- Monadic `fuelLoop`; the `exhausted` sentinel `head` is unreachable, and the `max` fold is
+  -- a `foldlM` over the throwing `betterOf`.
   fuelLoop (2 * (FcMap.keys store.blocks).length + 2) head head fun head => do
     let children ← getNodeChildren store blocks head
     if children.isEmpty then pure (.done head)
@@ -547,47 +562,61 @@ forkdef updateUnrealizedCheckpoints (store : Store map) (uj uf : Checkpoint) : S
 (for a prior-epoch block) realize it. The `block_states` / `blocks` reads raise on a
 miss, and the pull-up itself propagates: pyspec runs `process_justification_and_finalization`
 unguarded, so a reject aborts the surrounding `on_block`. -/
-forkdef computePulledUpTip (store : Store map) (blockRoot : Root) : StoreTransition (Store map) := do
+forkdef computePulledUpTip (blockRoot : Root) : StoreTransition Unit := do
+  let store ← get
   let state ← FcMap.getOrThrow store.blockStates blockRoot
-  let block ← FcMap.getOrThrow store.blocks blockRoot
   let pulled ← runStateTransition state processJustificationAndFinalization
   let cj := sszGet pulled currentJustifiedCheckpoint
   let fz := sszGet pulled finalizedCheckpoint
-  let store := { store with unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
-  let store := updateUnrealizedCheckpoints store cj fz
-  pure (if computeEpochAtSlot block.slot < getCurrentStoreEpoch store then updateCheckpoints store cj fz else store)
+  set { store with
+    unrealizedJustifications := FcMap.insert store.unrealizedJustifications blockRoot cj }
+  set (updateUnrealizedCheckpoints (← get) cj fz)
+  -- Only now does pyspec read the block and the store clock.
+  let block ← FcMap.getOrThrow (← get).blocks blockRoot
+  let currentEpoch ← getCurrentStoreEpoch (← get)
+  if computeEpochAtSlot block.slot < currentEpoch then
+    set (updateCheckpoints (← get) cj fz)
 
 /-! ## on_tick -/
 
-/-- `on_tick_per_slot`. -/
-forkdef onTickPerSlot (store : Store map) (time : UInt64) : Store map :=
-  let previousSlot := getCurrentSlot store
+/-- `on_tick_per_slot`. Throwing: `get_current_slot` (before and after the `time` bump) can raise. -/
+forkdef onTickPerSlot (store : Store map) (time : UInt64) : StoreTransition (Store map) := do
+  let previousSlot ← getCurrentSlot store
   let store := { store with time := time }
-  let currentSlot := getCurrentSlot store
+  let currentSlot ← getCurrentSlot store
   let store := if currentSlot > previousSlot then { store with proposerBoostRoot := fcZeroRoot } else store
-  if currentSlot > previousSlot && computeSlotsSinceEpochStart currentSlot == 0 then
+  pure <| if currentSlot > previousSlot && computeSlotsSinceEpochStart currentSlot == 0 then
     updateCheckpoints store store.unrealizedJustifiedCheckpoint store.unrealizedFinalizedCheckpoint
   else store
 where
+  -- The epoch-start slot is always `≤ slot`, so this `uint64` subtraction cannot underflow.
   computeSlotsSinceEpochStart (slot : Slot) : UInt64 := slot - computeStartSlotAtEpoch (computeEpochAtSlot slot)
 
-/-- `advance_store_time`: catch up slot-by-slot, then set the exact time (the pure core
-of `on_tick`, ms-based). Fuel-bounded by the number of slots to advance. -/
-forkdef advanceStoreTime (store : Store map) (time : UInt64) : Store map :=
-  -- The slot `time` lands in. It is loop-invariant (only `time` and the fixed
-  -- `genesisTime` feed it, and `onTickPerSlot` touches neither), so it doubles as
-  -- the fuel bound and is read unchanged inside the loop.
-  let targetSlot := ((time - store.genesisTime) * 1000) / Const.slotDurationMs
-  let fuel := (targetSlot - getCurrentSlot store).toNat + 1
-  fuelIterate fuel store fun store =>
-    if getCurrentSlot store < targetSlot then
-      let nextSlotTime := store.genesisTime + (getCurrentSlot store + 1) * Const.slotDurationMs / 1000
-      .next (onTickPerSlot store nextSlotTime)
-    else .done (onTickPerSlot store time)
-
-/-- `on_tick`: advance the store clock to `time`. -/
+/-- `on_tick`: advance the store clock to `time`. Each `on_tick_per_slot` commits before the
+next iteration, because pyspec calls it against the live store and a raise partway through the
+catch-up leaves the earlier per-slot boost resets and checkpoint updates applied. Threading a
+local and committing once discarded them. Same rule as `aed053b`'s, at the site it did not
+reach; the loop body can now throw, so the divergence is live in principle. -/
 forkdef onTick (time : UInt64) : StoreTransition Unit := do
-  modify fun store => advanceStoreTime store time
+  let store ← get
+  let elapsed ← checkedSub time store.genesisTime "on_tick: time - genesis_time"
+  let tickMs ← checkedMul elapsed 1000 "on_tick: (time - genesis_time) * 1000"
+  let tickSlot := tickMs / Const.slotDurationMs
+  let cur ← getCurrentSlot store
+  -- The fuel bound is a Lean artifact, not a spec op: a raw `-` here can only underflow to a huge
+  -- ceiling when `tickSlot < cur`, and then the step `.done`s on its first iteration anyway.
+  fuelIterateM! ((tickSlot - cur).toNat + 1) () "on_tick: per-slot catch-up" fun _ => do
+    let cs ← getCurrentSlot (← get)
+    if cs < tickSlot then
+      let bumped ← checkedAdd cs 1 "on_tick: get_current_slot + 1"
+      let scaled ← checkedMul bumped Const.slotDurationMs
+        "on_tick: (get_current_slot + 1) * SLOT_DURATION_MS"
+      let nextSlotTime ← checkedAdd store.genesisTime (scaled / 1000) "on_tick: genesis_time + …"
+      set (← onTickPerSlot (← get) nextSlotTime)
+      pure (.next ())
+    else
+      set (← onTickPerSlot (← get) time)
+      pure (.done ())
 
 /-! ## record_block_timeliness / update_proposer_boost_root -/
 
@@ -595,8 +624,9 @@ forkdef onTick (time : UInt64) : StoreTransition Unit := do
 PTC-due), each `is_current_slot ∧ time_into_slot_ms < threshold`. -/
 forkdef recordBlockTimeliness (store : Store map) (root : Root) : StoreTransition (Store map) := do
   let block ← FcMap.getOrThrow store.blocks root
-  let tis := timeIntoSlotMs store
-  let isCurrentSlot := getCurrentSlot store == block.slot
+  let tis ← timeIntoSlotMs store
+  let currentSlot ← getCurrentSlot store
+  let isCurrentSlot := currentSlot == block.slot
   let timeliness : Array Bool := #[isCurrentSlot && tis < bpsDeadlineMs Const.attestationDueBpsGloas,
                                    isCurrentSlot && tis < bpsDeadlineMs Const.payloadAttestationDueBps]
   pure { store with blockTimeliness := FcMap.insert store.blockTimeliness root timeliness }
@@ -653,12 +683,16 @@ forkdef onPayloadAttestationMessage (msg : PayloadAttestationMessage) (isFromBlo
 
   if !(data.slot == sszGet state slot) then pure ()
   else
-    let ptc := getPtc state data.slot
+    -- `get_ptc` asserts, and it is a state-file `forkdef`, so its `StateTransitionError`
+    -- crosses `evalStateTransition` to reach this store handler. The bind sits after the
+    -- `data.slot == state.slot` guard that bounds the index.
+    let ptc ← evalStateTransition state (getPtc state data.slot)
     let ptcIndices := (Array.range Const.ptcSize).filter fun i => vget ptc i == msg.validatorIndex
     assert (ptcIndices.size > 0)
     if isFromBlock then set (← recordPtcVotes store data ptcIndices)
     else
-      assert (data.slot == getCurrentSlot store)
+      let currentSlot ← getCurrentSlot store
+      assert (data.slot == currentSlot)
       let indexed : IndexedPayloadAttestation :=
         { attestingIndices := sszOfArray #[msg.validatorIndex], data := data, signature := msg.signature }
       assert (isValidIndexedPayloadAttestation state indexed)
@@ -680,7 +714,9 @@ forkdef notifyPtcMessages (state : State) (payloadAttestations : Array PayloadAt
     StoreTransition Unit := do
   if sszGet state slot == 0 then return
   for pa in payloadAttestations do
-    let indexed := getIndexedPayloadAttestation state pa
+    -- Second bridge crossing: `get_indexed_payload_attestation` inherited `get_ptc`'s asserts,
+    -- and this replay loop runs in the store machine.
+    let indexed ← evalStateTransition state (getIndexedPayloadAttestation state pa)
     for idx in indexed.attestingIndices do
       -- `(map := map)`: the handler takes no store argument, so the section's map backing
       -- is undetermined at this call site (the ambient `get`/`set` constraint alone leaves
@@ -703,7 +739,8 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   -- Reject a full-but-unverified parent, a future block, or a finality conflict.
   let parentFull ← isParentNodeFull store block
   assert (!parentFull || isPayloadVerified store block.parentRoot)
-  assert (getCurrentSlot store ≥ block.slot)
+  let currentSlot ← getCurrentSlot store
+  assert (currentSlot ≥ block.slot)
   let finalizedSlot := computeStartSlotAtEpoch store.finalizedCheckpoint.epoch
   assert (block.slot > finalizedSlot)
   let finalizedBlock ← getCheckpointBlock store block.parentRoot store.finalizedCheckpoint.epoch
@@ -740,13 +777,23 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   set store
   let store := updateCheckpoints store (sszGet postState currentJustifiedCheckpoint) (sszGet postState finalizedCheckpoint)
   set store
-  set (← computePulledUpTip store blockRoot)
+  -- `(map := map)`: no store argument, so the section's map backing is undetermined here
+  -- (the ambient `get`/`set` constraint alone leaves it a stuck metavariable); name it.
+  computePulledUpTip (map := map) blockRoot
 
 /-! ## on_execution_payload_envelope -/
 
-/-- `compute_time_at_slot(state, slot)`. -/
-forkdef computeTimeAtSlot (state : State) (slot : Slot) : UInt64 :=
-  (sszGet state genesisTime) + (slot - Const.genesisSlot) * Const.slotDurationMs / 1000
+/-- `compute_time_at_slot(state, slot)`. The pinned spec text flags this function itself as
+"unsafe with respect to overflows and underflows" (`phase0/beacon-chain.md:897`), and it gates
+the envelope timestamp assert in `verify_execution_payload_envelope`, which Heze inherits, so it
+sits on a reachable fork-choice path. All three ops are checked. -/
+forkdef computeTimeAtSlot (state : State) (slot : Slot) : StoreTransition UInt64 := do
+  let slotsSinceGenesis ← checkedSub slot Const.genesisSlot
+    "compute_time_at_slot: slot - GENESIS_SLOT"
+  let elapsedMs ← checkedMul slotsSinceGenesis Const.slotDurationMs
+    "compute_time_at_slot: (slot - GENESIS_SLOT) * SLOT_DURATION_MS"
+  checkedAdd (sszGet state genesisTime) (elapsedMs / 1000)
+    "compute_time_at_slot: genesis_time + (slot - GENESIS_SLOT) * SLOT_DURATION_MS // 1000"
 
 /-- `verify_execution_payload_envelope_signature`: the envelope is signed by the
 builder's key (the proposer's, for a self-build) under `DOMAIN_BEACON_BUILDER`.
@@ -800,7 +847,8 @@ forkdef verifyExecutionPayloadEnvelope (state : State) (signedEnv : SignedExecut
   assert (htr envelope.executionRequests == bid.executionRequestsRoot)
   assert (payload.slotNumber == sszGet state slot)
   assert (payload.parentHash == sszGet state latestBlockHash)
-  assert (payload.timestamp == computeTimeAtSlot state (sszGet state slot))
+  let expectedTime ← computeTimeAtSlot state (sszGet state slot)
+  assert (payload.timestamp == expectedTime)
   assert (htr payload.withdrawals == htr (sszGet state payloadExpectedWithdrawals))
   return warm
 
@@ -825,8 +873,8 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
 target epoch start if needed. The pinned `process_slots` call is unguarded, so a
 rejected advance propagates (wrapped `.transition`) and nothing is cached, aborting
 the surrounding `on_attestation` with the store unchanged. Reachable only from
-degenerate near-zero-stake states; the pre-conversion `runBestEffort` cached the
-UNADVANCED base state instead, a wrong-slot entry later reads would consume. -/
+degenerate near-zero-stake states. Caching the unadvanced base state instead would leave
+a wrong-slot entry for later reads to consume. -/
 forkdef storeTargetCheckpointState (store : Store map) (target : Checkpoint) :
     StoreTransition (Store map) := do
   if FcMap.contains store.checkpointStates target then pure store
@@ -846,7 +894,7 @@ and full vote (index 1) ⇒ the head block's payload is verified. -/
 forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlock : Bool) :
     StoreTransition Unit := do
   let target := att.data.target
-  let currentEpoch := getCurrentStoreEpoch store
+  let currentEpoch ← getCurrentStoreEpoch store
   let previousEpoch := if currentEpoch > Const.genesisEpoch then currentEpoch - 1 else Const.genesisEpoch
 
   -- Target epoch in range and consistent with the attestation slot; both roots known.
@@ -863,7 +911,17 @@ forkdef validateOnAttestation (store : Store map) (att : Attestation) (isFromBlo
   assert (!(att.data.index == 1) || isPayloadVerified store att.data.beaconBlockRoot)
   let checkpointBlock ← getCheckpointBlock store att.data.beaconBlockRoot target.epoch
   assert (target.root == checkpointBlock)
-  assert (getCurrentSlot store ≥ att.data.slot + 1)
+  let currentSlot ← getCurrentSlot store
+  -- `att.data.slot` is wire-controlled and the epoch-scope guard above is skipped when
+  -- `is_from_block`, so a block-implied attestation reaches here with an arbitrary slot. The
+  -- bare `+` wraps `0xFFFF…FFFF + 1` to `0`, `currentSlot ≥ 0` holds for every store, and the
+  -- attestation is ACCEPTED into `latest_messages`, corrupting the head walk. pyspec
+  -- (`phase0/fork-choice.md:813`) forms a checked `uint64` sum that raises `ValueError`, which
+  -- `expect_assertion_error` does not catch. Sequenced after every preceding assert, matching
+  -- Python's evaluation order.
+  let attestationDeadline ← checkedAdd att.data.slot 1
+    "on_attestation: attestation.data.slot + 1"
+  assert (currentSlot ≥ attestationDeadline)
 
 /-- `update_latest_messages` (Gloas): slot-ordered, carrying `payload_present`
 (`data.index == 1`), skipping equivocators. -/
@@ -932,8 +990,16 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
 
+  -- `uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000)`
+  -- (`phase0/fork-choice.md:223`): both the product and the sum are checked. `anchor_state`
+  -- comes straight off the wire, so a slot at or above `2^64 / SLOT_DURATION_MS` wraps and
+  -- seeds the store with a wrong clock where pyspec errors.
+  let elapsedMs ← checkedMul Const.slotDurationMs (sszGet anchorState slot)
+    "get_forkchoice_store: SLOT_DURATION_MS * anchor_state.slot"
+  let storeTime ← checkedAdd (sszGet anchorState genesisTime) (elapsedMs / 1000)
+    "get_forkchoice_store: genesis_time + SLOT_DURATION_MS * slot // 1000"
   pure
-    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+    { time := storeTime
       genesisTime := sszGet anchorState genesisTime
       justifiedCheckpoint := cp, finalizedCheckpoint := cp
       unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
@@ -1030,9 +1096,8 @@ state is `default` (zero validators, slot 0) carrying one queued
 `process_pending_consolidations`, whose `state.validators[source_index]` read is a
 pinned plain-list read (pyspec `IndexError`), so the epoch step rejects with
 `outOfBounds` and the unguarded pinned `process_slots` means
-`store_target_checkpoint_state` re-throws it (`.transition`) with nothing cached,
-where the pre-conversion `runBestEffort` cached the unadvanced state. This pins the
-propagation semantics; the throw site inside epoch processing is incidental. The
+`store_target_checkpoint_state` re-throws it (`.transition`) with nothing cached. This
+pins the propagation semantics; the throw site inside epoch processing is incidental. The
 consolidation carrier is deliberate: a bare zero-validator advance does NOT reject,
 it grinds through `cbwsAux`'s 10M-iteration fuel in the proposer lookahead, so the
 reject must land earlier in the epoch pipeline. `State` is FFI-backed (`FastBox`),
@@ -1050,7 +1115,10 @@ private def pinTargetAdvanceRejects : Bool :=
   let store := { pinStore with blockStates := FcMap.insert FcMap.empty pinRoot state }
   let target : Checkpoint := { epoch := 1, root := pinRoot }
   match (storeTargetCheckpointState (map := treeMap) store target : PinM (Store treeMap)).run store with
-  | .error (.transition _) _ => true
+  -- Match the constructor, not the wrapper: `.transition` also spans `.arithmetic`, an uncaught
+  -- fault that would fail the very step this fixture pins as an expected rejection. The pin has
+  -- to break when the reject class changes, which is what Leo's note 3 asked for.
+  | .error (.transition (.outOfBounds _ _)) _ => true
   | _ => false
 example : pinTargetAdvanceRejects = true := by native_decide
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -280,41 +280,51 @@ the head node's payload status and the per-block PTC vote arrays. -/
 private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
     (P : Preset) (store0 : Store hashMap) (steps : Array FcStep) : Except StoreTransitionError Unit := do
   -- Same uniform shape as Fulu's `fcInterpret`: each step runs to an `Except` outcome,
-  -- which `checkStepValidity` resolves against the step's `valid` flag over the pre-step
-  -- snapshot (the framework owns the valid/invalid policy; this loop only threads the
-  -- store). The `block` step folds `on_block` and the block's own attestations /
-  -- attester-slashings into one action; `execution_payload` / `payload_attestation_message`
-  -- are the two ePBS-new valid-flagged steps.
+  -- which `checkStepValidity` resolves against the step's `valid` flag, continuing an
+  -- expected rejection from the error-time store (the framework owns the valid/invalid
+  -- policy; this loop only threads the store). The `block` step folds `on_block` and the
+  -- block's own attestations / attester-slashings into one action; `execution_payload` /
+  -- `payload_attestation_message` are the two ePBS-new valid-flagged steps.
   let mut store : Store hashMap := store0
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity store true
+      store := (← checkStepValidity true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes _columns valid =>
-      let outcome := decodeStepOr (α := @Gloas.SignedBeaconBlock P) bytes "block" fun sb =>
-        let action : EStateM StoreTransitionError (Store hashMap) Unit := do
-          onBlock (map := hashMap) sb
-          for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
-          for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-        runOn store action
-      store := (← checkStepValidity store valid outcome)
+      -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
+      -- invalid block returns right after `on_block` rejects (`:393`), so its own attestations /
+      -- attester-slashings replay only on the valid path (`:400-406`), each `valid = True`. So
+      -- check `on_block` against `valid`, then replay the sub-steps only when the block was
+      -- accepted. (Combining them would let a sub-attestation reject stand in for `on_block`'s on
+      -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
+      match SizzLean.SSZ.deserialize (T := @Gloas.SignedBeaconBlock P) bytes with
+      | .error _ =>
+        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+      | .ok sb =>
+        store := (← checkStepValidity valid
+          (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))
+        if valid then
+          let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
+            for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+            for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+          store := (← checkStepValidity true (runOn store subAction))
     | .attestation bytes valid =>
-      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" fun a =>
+      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .attesterSlashing bytes valid =>
-      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" fun a =>
+      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .executionPayload bytes valid =>
-      let outcome := decodeStepOr (α := @Gloas.SignedExecutionPayloadEnvelope P) bytes "envelope" fun env =>
+      let outcome := decodeStepOr (α := @Gloas.SignedExecutionPayloadEnvelope P) bytes "envelope" store fun env =>
         runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .payloadAttestationMessage bytes valid =>
-      let outcome := decodeStepOr (α := @Gloas.PayloadAttestationMessage P) bytes "ptc message" fun msg =>
+      let outcome := decodeStepOr (α := @Gloas.PayloadAttestationMessage P) bytes "ptc message" store fun msg =>
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .checkHead root slot =>
       let head ← queryHead store
       assert (head.root == root)

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -360,7 +360,9 @@ private def runForkChoiceImpl (P : Preset) (C : Config) (anchorStateBytes anchor
   | .error _, _ => .error (.decode "fork_choice anchor state")
   | _, .error _ => .error (.decode "fork_choice anchor block")
   | .ok anchorState, .ok anchorBlock =>
-    RunError.ofSpec (fcInterpretGloas P (getForkchoiceStore anchorState anchorBlock) steps)
+    RunError.ofSpec (do
+      let store ← getForkchoiceStore anchorState anchorBlock
+      fcInterpretGloas P store steps)
 
 /-- The `ssz_static` per-type kernel: decode `bytes` as the container `T`, return
 its hash-tree-root paired with the round-trip check (`reserialize == bytes`). A

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -329,9 +329,11 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
     | .checkTime t => assert (store.time.toNat == t)
     | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
     | .unsupported reason => throw (StoreTransitionError.todo reason)
-    -- Fulu-only checks (e.g. get_proposer_head) never appear in Gloas vectors; ignore
-    -- them so the shared `FcStep` match stays exhaustive.
-    | _ => pure ()
+    -- `get_proposer_head` is Gloas-Modified but not ported, and no alpha.11 vector exercises it;
+    -- surface it as unmodeled (a `todo` xfail) rather than passing it vacuously. This arm makes
+    -- the match exhaustive over `FcStep`, so a newly added constructor becomes a build error rather
+    -- than a silent pass through a catch-all.
+    | .checkProposerHead _ => throw (StoreTransitionError.todo "get_proposer_head check: not modeled")
   pure ()
 
 /-- `runForkChoice` (Gloas): decode the anchor state / block, build the ePBS store,

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -300,7 +300,7 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @Gloas.SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
         store := (← checkStepValidity valid
           (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -263,6 +263,14 @@ private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
           assert (sb.message.stateRoot == bytesToRoot root)
       RunError.ofSpec (runToRoot gloasBox0 gloasAction)
 
+/-- Run `getHead` over the snapshot store as a pure query (`runQuery` discards the final
+store; `getHead` only reads it). Shared by the `checkHead` / `checkHeadPayloadStatus` arms,
+which each need the head node against the current fold state. -/
+private def queryHead [Preset] [Config] [HasherTag] (store : Store hashMap) :
+    Except StoreTransitionError ForkChoiceNode :=
+  runQuery store (getHead (map := hashMap) store :
+    EStateM StoreTransitionError (Store hashMap) ForkChoiceNode)
+
 /-- Fold the decoded fork-choice `steps` over the Gloas store. A `block` step runs
 `on_block` (which internally records PTC votes from the block's payload attestations
 via `notify_ptc_messages`), then replays the block's own attestations /
@@ -308,12 +316,15 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
       store := (← checkStepValidity store valid outcome)
     | .checkHead root slot =>
-      let head := getHead store
+      let head ← queryHead store
       assert (head.root == root)
-      let headSlot := match FcMap.lookup store.blocks head.root with | some b => b.slot.toNat | none => 0
-      assert (headSlot == slot)
+      -- `getOrThrow` is monad-polymorphic, and the fold's own monad is already
+      -- `Except StoreTransitionError`, so the read binds directly (no `runQuery` detour).
+      let headBlock ← FcMap.getOrThrow store.blocks head.root
+      assert (headBlock.slot.toNat == slot)
     | .checkHeadPayloadStatus status =>
-      assert ((getHead store).payloadStatus.toNat == status)
+      let head ← queryHead store
+      assert (head.payloadStatus.toNat == status)
     | .checkPayloadTimelinessVote blockRoot votes =>
       assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
     | .checkPayloadDataAvailabilityVote blockRoot votes =>

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Interface.lean
@@ -289,7 +289,7 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity true
+      store := (← checkStepValidity .tick true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes _columns valid =>
       -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
@@ -300,31 +300,31 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @Gloas.SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity .block valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
-        store := (← checkStepValidity valid
+        store := (← checkStepValidity .block valid
           (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))
         if valid then
           let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
             for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
             for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-          store := (← checkStepValidity true (runOn store subAction))
+          store := (← checkStepValidity .attestation true (runOn store subAction))
     | .attestation bytes valid =>
       let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attestation valid outcome)
     | .attesterSlashing bytes valid =>
       let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attesterSlashing valid outcome)
     | .executionPayload bytes valid =>
       let outcome := decodeStepOr (α := @Gloas.SignedExecutionPayloadEnvelope P) bytes "envelope" store fun env =>
         runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .executionPayload valid outcome)
     | .payloadAttestationMessage bytes valid =>
       let outcome := decodeStepOr (α := @Gloas.PayloadAttestationMessage P) bytes "ptc message" store fun msg =>
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .payloadAttestationMessage valid outcome)
     | .checkHead root slot =>
       let head ← queryHead store
       assert (head.root == root)
@@ -336,9 +336,15 @@ private def fcInterpretGloas [Preset] [Config] [HasherTag] [CryptoBackend]
       let head ← queryHead store
       assert (head.payloadStatus.toNat == status)
     | .checkPayloadTimelinessVote blockRoot votes =>
-      assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
+      -- `add_payload_vote_checks` subscripts a plain `Dict` (`fork_choice.py:517-519`),
+      -- so a missing key raises; the spec-side reads of this same map already throw.
+      let recorded ← FcMap.getOrThrow store.payloadTimelinessVote (bytesToRoot blockRoot)
+      assert (recorded == votes)
     | .checkPayloadDataAvailabilityVote blockRoot votes =>
-      assert (FcMap.lookupD store.payloadDataAvailabilityVote (bytesToRoot blockRoot) == votes)
+      -- `add_payload_vote_checks` subscripts a plain `Dict` (`fork_choice.py:517-519`),
+      -- so a missing key raises; the spec-side reads of this same map already throw.
+      let recorded ← FcMap.getOrThrow store.payloadDataAvailabilityVote (bytesToRoot blockRoot)
+      assert (recorded == votes)
     | .checkJustified epoch root =>
       assert (store.justifiedCheckpoint.epoch.toNat == epoch)
       assert (store.justifiedCheckpoint.root == root)

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
@@ -247,11 +247,13 @@ forkdef processProposerSlashing (ps : ProposerSlashing) : StateTransition Unit :
 /-- `is_attestation_same_slot`: the attestation votes for the block proposed at its
 own slot (head matches this slot's block root but differs from the previous slot's).
 The `slot == 0` guard avoids the `slot - 1` `UInt64` underflow. -/
-forkdef isAttestationSameSlot (state : State) (data : AttestationData) : Bool :=
-  if data.slot == 0 then true
+forkdef isAttestationSameSlot (state : State) (data : AttestationData) : StateTransition Bool := do
+  if data.slot == 0 then pure true
   else
     let blockroot := data.beaconBlockRoot
-    blockroot == getBlockRootAtSlot state data.slot && blockroot != getBlockRootAtSlot state (data.slot - 1)
+    let slotRoot ← getBlockRootAtSlot state data.slot
+    let prevRoot ← getBlockRootAtSlot state (data.slot - 1)
+    pure (blockroot == slotRoot && blockroot != prevRoot)
 
 /-- `get_attestation_participation_flag_indices` (Gloas, EIP-7732): adds the
 payload-matching constraint to `is_matching_head`. A same-slot attestation must have
@@ -259,21 +261,23 @@ payload-matching constraint to `is_matching_head`. A same-slot attestation must 
 compares `data.index` to this slot's `execution_payload_availability` bit. `none`
 also covers the `is_matching_source` reject (as in Fulu). -/
 forkdef getAttestationParticipationFlagIndices (state : State) (data : AttestationData)
-    (inclusionDelay : UInt64) : Option (Array Nat) := Id.run do
+    (inclusionDelay : UInt64) : StateTransition (Option (Array Nat)) := do
   let justified := if data.target.epoch == currentEpochOf state then sszGet state currentJustifiedCheckpoint
                    else sszGet state previousJustifiedCheckpoint
   let isMatchingSource := data.source.epoch == justified.epoch && data.source.root == justified.root
   if !isMatchingSource then return none
 
-  let isMatchingTarget := data.target.root == getBlockRoot state data.target.epoch
-  let sameSlot := isAttestationSameSlot state data
+  let targetRoot ← getBlockRoot state data.target.epoch
+  let isMatchingTarget := data.target.root == targetRoot
+  let sameSlot ← isAttestationSameSlot state data
   if sameSlot && data.index != 0 then return none
   let payloadMatches : Bool :=
     if sameSlot then true
     else
       let bit := bitGet (sszGet state executionPayloadAvailability) (data.slot.toNat % Const.slotsPerHistoricalRoot)
       data.index == (if bit then (1 : UInt64) else 0)
-  let isMatchingHead := isMatchingTarget && data.beaconBlockRoot == getBlockRootAtSlot state data.slot && payloadMatches
+  let headRoot ← getBlockRootAtSlot state data.slot
+  let isMatchingHead := isMatchingTarget && data.beaconBlockRoot == headRoot && payloadMatches
 
   let mut flags : Array Nat := #[]
   if inclusionDelay ≤ UInt64.ofNat (isqrt Const.slotsPerEpoch) then flags := flags.push Const.timelySourceFlagIndex
@@ -303,7 +307,7 @@ forkdef processAttestation (att : Attestation) : StateTransition Unit := do
   assert (att.aggregationBits.size == offset)
 
   -- Resolve the participation flags, then validate the aggregate signature.
-  let flagIndices ← match getAttestationParticipationFlagIndices state data ((sszGet state slot) - data.slot) with
+  let flagIndices ← match ← getAttestationParticipationFlagIndices state data ((sszGet state slot) - data.slot) with
     | some f => pure f
     | none   => throw (StateTransitionError.assert "attestation participation flags")
   let indexedAttestation : IndexedAttestation :=
@@ -313,7 +317,7 @@ forkdef processAttestation (att : Attestation) : StateTransition Unit := do
 
   -- Apply participation flags and accumulate the builder-payment weight.
   let currentTarget := data.target.epoch == currentEpochOf state
-  let sameSlot := isAttestationSameSlot state data
+  let sameSlot ← isAttestationSameSlot state data
   let paymentIdx := builderPaymentIndex data.slot currentTarget
   let payment0 := vget (sszGet state builderPendingPayments) paymentIdx
   let mut stateAcc := state
@@ -469,7 +473,8 @@ forkdef processExecutionPayloadBid (signedBid : SignedExecutionPayloadBid) : Sta
   assert (bid.slot == sszGet state slot)
   assert ((sszGet state slot) > Const.genesisSlot)
   assert (bid.parentBlockHash == sszGet state latestBlockHash)
-  assert (bid.parentBlockRoot == getBlockRootAtSlot state ((sszGet state slot) - 1))
+  let parentBlockRoot ← getBlockRootAtSlot state ((sszGet state slot) - 1)
+  assert (bid.parentBlockRoot == parentBlockRoot)
   let randaoMix ← getRandaoMix (currentEpochOf state)
   assert (bid.prevRandao == randaoMix)
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Operations.lean
@@ -297,7 +297,14 @@ forkdef processAttestation (att : Attestation) : StateTransition Unit := do
   -- Reject on shape: target epoch, slot timing, and the payload-presence bit.
   assert (data.target.epoch == previousEpochOf state || data.target.epoch == currentEpochOf state)
   assert (data.target.epoch == computeEpochAtSlot data.slot)
-  assert (data.slot + Const.minAttestationInclusionDelay ≤ sszGet state slot)
+  -- `data.slot` is wire-controlled and `MIN_ATTESTATION_INCLUSION_DELAY` is 1, so the bare `+`
+  -- wraps `0xFFFF…FFFF + 1` to `0` and `0 ≤ state.slot` bypasses the guard for every state: a
+  -- false ACCEPT, the state-transition twin of `on_attestation`'s. pyspec's checked `uint64` add
+  -- raises `ValueError`, which `process_attestation` does not catch, so the driver scores it
+  -- `uncaughtFault`. Sequenced after the two epoch asserts above, matching Python's order.
+  let inclusionSlot ← checkedAdd data.slot Const.minAttestationInclusionDelay
+    "process_attestation: data.slot + MIN_ATTESTATION_INCLUSION_DELAY"
+  assert (inclusionSlot ≤ sszGet state slot)
   assert (data.index < 2)
 
   -- Every committee index is valid and non-empty; the bitfield covers them all.
@@ -364,28 +371,52 @@ where
       (true, 0)
 
 /-- `get_ptc` (v1.7.0-alpha.11): read the cached PTC for `slot` from `ptc_window`.
-For a slot in the previous epoch the window's first `SLOTS_PER_EPOCH` entries hold
-it; otherwise an `(epoch - state_epoch + 1) * SLOTS_PER_EPOCH` offset applies. The
-spec asserts the slot is within `[state_epoch-1, state_epoch + MIN_SEED_LOOKAHEAD]`;
-callers (`process_payload_attestation`) guarantee this via `data.slot + 1 ==
-state.slot`, so the index is always in range. -/
-forkdef getPtc (state : State) (slot : Slot) : Vector ValidatorIndex Const.ptcSize :=
+For a slot in the previous epoch the window's first `SLOTS_PER_EPOCH` entries hold it;
+otherwise an `(epoch - state_epoch + 1) * SLOTS_PER_EPOCH` offset applies.
+
+The pinned spec (`gloas/beacon-chain.md:853-864`) guards each branch with its own assert,
+`epoch + 1 == state_epoch` on the past-epoch side and
+`epoch <= state_epoch + MIN_SEED_LOOKAHEAD` on the other, and both are modeled here. They
+are also what bounds the index: `MIN_SEED_LOOKAHEAD` is 1, so the else branch's
+`epoch - state_epoch` is 0 or 1, the scaled offset is one or two epochs, and the read lands
+inside the `3 * SLOTS_PER_EPOCH` window by construction. That is why the total `vget` is
+sound once the asserts are in place, and why the spec's own `IndexError` on this subscript is
+unreachable rather than unmodeled.
+
+Both callers already bound the index structurally (`process_payload_attestation` asserts
+`data.slot + 1 == state.slot`, `on_payload_attestation_message` guards
+`data.slot == state.slot`), so no corpus input reaches either reject. This closes a
+faithfulness gap, not a live divergence. Throwing, so `get_indexed_payload_attestation` and
+the fork-choice handler bind it. -/
+forkdef getPtc (state : State) (slot : Slot) :
+    StateTransition (Vector ValidatorIndex Const.ptcSize) := do
   let epoch := computeEpochAtSlot slot
   let stateEpoch := currentEpochOf state
   let spe := UInt64.ofNat Const.slotsPerEpoch
-  if epoch < stateEpoch then vmodGet (sszGet state ptcWindow) slot Const.slotsPerEpoch
-  -- The else index `(epoch - stateEpoch + 1) * spe + slot % spe` is in range only under the
-  -- caller's slot-range guarantee (`process_payload_attestation`'s `data.slot + 1 ==
-  -- state.slot`), which is not in scope here, so it stays a total read.
-  else vget (sszGet state ptcWindow) (((epoch - stateEpoch + 1) * spe + slot % spe).toNat)
+  if epoch < stateEpoch then
+    let nextEpoch ← checkedAdd epoch 1 "get_ptc: epoch + 1"
+    assert (nextEpoch == stateEpoch)
+    pure (vmodGet (sszGet state ptcWindow) slot Const.slotsPerEpoch)
+  else
+    let lookaheadBound ← checkedAdd stateEpoch Const.minSeedLookahead
+      "get_ptc: state_epoch + MIN_SEED_LOOKAHEAD"
+    assert (epoch ≤ lookaheadBound)
+    let offset ← checkedSub epoch stateEpoch "get_ptc: epoch - state_epoch"
+    let windowed ← checkedAdd offset 1 "get_ptc: (epoch - state_epoch) + 1"
+    let scaled ← checkedMul windowed spe "get_ptc: (epoch - state_epoch + 1) * SLOTS_PER_EPOCH"
+    let idx ← checkedAdd scaled (slot % spe) "get_ptc: … + slot % SLOTS_PER_EPOCH"
+    pure (vget (sszGet state ptcWindow) idx.toNat)
 
 /-- `get_indexed_payload_attestation`: resolve the PTC bits to the (sorted) attesting
-validator set. The `aggregation_bits` index into the `PTC_SIZE`-length PTC. -/
-forkdef getIndexedPayloadAttestation (state : State) (pa : PayloadAttestation) : IndexedPayloadAttestation :=
-  let ptc := getPtc state pa.data.slot
+validator set. The `aggregation_bits` index into the `PTC_SIZE`-length PTC. Throwing,
+because `get_ptc` is. -/
+forkdef getIndexedPayloadAttestation (state : State) (pa : PayloadAttestation) :
+    StateTransition IndexedPayloadAttestation := do
+  let ptc ← getPtc state pa.data.slot
   let attesting := (Array.range Const.ptcSize).foldl
     (fun acc i => if bitGet pa.aggregationBits i then acc.push (vget ptc i) else acc) (#[] : Array ValidatorIndex)
-  { attestingIndices := sszOfArray (attesting.qsort (· < ·)), data := pa.data, signature := pa.signature }
+  pure { attestingIndices := sszOfArray (attesting.qsort (· < ·)), data := pa.data,
+         signature := pa.signature }
 
 /-- `is_valid_indexed_payload_attestation`: non-empty, *non-strictly* sorted indices
 (the PTC can repeat a validator), in range, with a valid `DOMAIN_PTC_ATTESTER`
@@ -410,8 +441,16 @@ forkdef processPayloadAttestation (pa : PayloadAttestation) : StateTransition Un
   let state ← get
   let data := pa.data
   assert (data.beaconBlockRoot == (sszGet state latestBlockHeader).parentRoot)
-  assert (data.slot + 1 == sszGet state slot)
-  assert (isValidIndexedPayloadAttestation state (getIndexedPayloadAttestation state pa))
+  -- Only satisfiable by wrap when `state.slot == 0`, which block processing cannot reach — but
+  -- it is the sole path by which `get_ptc`'s asserts could ever be reached, so it is
+  -- checked rather than argued about. pyspec's `data.slot + 1` is a checked `uint64` add.
+  let attestedSlot ← checkedAdd data.slot 1 "process_payload_attestation: data.slot + 1"
+  assert (attestedSlot == sszGet state slot)
+  -- The bind stays after the slot assert: that assert is what bounds `get_ptc`'s index, and the
+  -- spec's order is `beacon_block_root`, then `data.slot + 1 == state.slot`, then the indexed
+  -- signature check.
+  let indexed ← getIndexedPayloadAttestation state pa
+  assert (isValidIndexedPayloadAttestation state indexed)
 
 /-! ## Execution payload bid + parent-payload application (EIP-7732) -/
 

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
@@ -37,11 +37,23 @@ def addressOf (v : Validator) : ExecutionAddress :=
 
 /-- `get_balance_after_withdrawals` over `Gloas.State`: the balance net of any
 already-queued withdrawals for `vi`. Fulu's version is a plain `def` bound to
-`Fulu.State`, so it is restated here for the Gloas state. -/
-def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) : Gwei :=
+`Fulu.State`, so it is restated here for the Gloas state.
+
+Throwing (`StateTransition`), because the spec's `return state.balances[validator_index] -
+withdrawn` (`capella/beacon-chain.md:378`) raises two ways, neither an explicit `assert`:
+`state.balances[validator_index]` is a bare list index (`IndexError` out of range), so it goes
+through `sszGetIdx` (→ `outOfBounds`); `- withdrawn` is a bare `uint64` subtraction whose
+underflow raises `ValueError`, which the reference runner does NOT catch (`context.py:429-433`),
+so it throws the uncaught `.arithmetic` reject rather than a caught `.assert`. Both are
+unreachable on a well-formed state (`len(balances) == len(validators)`, and a validator's queued
+withdrawals never exceed its balance), but the reads are modeled faithfully rather than clamped. -/
+def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
+    StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
-  let bal := sszGet state balances[vi.toNat]!
-  if withdrawn > bal then 0 else bal - withdrawn
+  let bal ← sszGetIdx (sszGet state balances) vi.toNat
+  if withdrawn > bal then
+    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
+  return bal - withdrawn
 
 /-- `get_builder_withdrawals` (NEW, EIP-7732): drain `builder_pending_withdrawals`
 into validator-flagged withdrawals, capped at `MAX_WITHDRAWALS_PER_PAYLOAD - 1`. -/
@@ -71,7 +83,6 @@ forkdef getPendingPartialWithdrawals (withdrawalIndex : WithdrawalIndex)
   let state ← get
   let epoch := currentEpochOf state
   let limit := Nat.min (prior.size + Const.maxPendingPartialsPerWithdrawalsSweep) (Const.maxWithdrawalsPerPayload - 1)
-  let validators := (sszGet state validators).toArray
   let mut wi := withdrawalIndex
   let mut count := 0
   let mut ws : Array Withdrawal := #[]
@@ -80,9 +91,8 @@ forkdef getPendingPartialWithdrawals (withdrawalIndex : WithdrawalIndex)
     let allW := prior ++ ws
     if !(w.withdrawableEpoch ≤ epoch) || allW.size ≥ limit then break
     let vi := w.validatorIndex
-    let hb ← assertH (vi.toNat < validators.size)
-    let validator := validators[vi.toNat]'hb.down
-    let bal := balanceAfterWithdrawals state vi allW
+    let validator ← sszGetIdx (sszGet state validators) vi.toNat
+    let bal ← balanceAfterWithdrawals state vi allW
     if isEligibleForPartialWithdrawals validator bal then
       ws := ws.push
         { index := wi, validatorIndex := vi, address := addressOf validator,
@@ -109,8 +119,7 @@ forkdef getBuildersSweepWithdrawals (withdrawalIndex : WithdrawalIndex)
 
   for _ in [0:buildersLimit] do
     if prior.size + ws.size ≥ limit then break
-    let hb ← assertH (builderIndex < bs.size)
-    let builder := bs[builderIndex]'hb.down
+    let builder ← sszGetIdx (sszGet state builders) builderIndex
     if builder.withdrawableEpoch ≤ epoch && builder.balance > 0 then
       ws := ws.push
         { index := wi, validatorIndex := convertBuilderIndexToValidatorIndex (UInt64.ofNat builderIndex),
@@ -139,9 +148,8 @@ forkdef getValidatorsSweepWithdrawals (withdrawalIndex : WithdrawalIndex)
   for _ in [0:validatorsLimit] do
     let allW := prior ++ ws
     if allW.size ≥ limit then break
-    assert (vi < nvals)
-    let validator := validators[vi]?.getD default
-    let bal := balanceAfterWithdrawals state (UInt64.ofNat vi) allW
+    let validator ← sszGetIdx (sszGet state validators) vi
+    let bal ← balanceAfterWithdrawals state (UInt64.ofNat vi) allW
     if isFullyWithdrawable validator bal epoch then
       ws := ws.push { index := wi, validatorIndex := UInt64.ofNat vi, address := addressOf validator, amount := bal }
       wi := wi + 1
@@ -175,8 +183,7 @@ forkdef applyWithdrawals (withdrawals : Array Withdrawal) : StateTransition Unit
   for w in withdrawals do
     if isBuilderIndex w.validatorIndex then
       let builderIndex := toBuilderIndex w.validatorIndex
-      let hb ← assertH (builderIndex.toNat < (sszGet stateAcc builders).size)
-      let b := (sszGet stateAcc builders)[builderIndex.toNat]'hb.down
+      let b ← sszGetIdx (sszGet stateAcc builders) builderIndex.toNat
       stateAcc := sszUpdate stateAcc with builders[builderIndex.toNat]! := { b with balance := b.balance - umin w.amount b.balance }
     else
       stateAcc := decreaseBalance stateAcc w.validatorIndex w.amount

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
@@ -48,13 +48,15 @@ so it throws the uncaught `.arithmetic` reject rather than a caught `.assert`. B
 unreachable on a well-formed state (`len(balances) == len(validators)`, and a validator's queued
 withdrawals never exceed its balance), and the reads are modeled rather than clamped.
 
-The `withdrawn` accumulator is the Fulu divergence restated here, deferred with it: pyspec's
-`sum(...)` adds unbounded ints, this fold wraps on `UInt64`, so a true sum ≥ 2^64 wraps past the
-`withdrawn > bal` guard and returns a wrong balance where pyspec raises. `checkedAdd`
-(`Spec/Errors.lean`) is the fix when it is taken up. -/
+The `withdrawn` accumulator folds through `checkedAdd`, as in Fulu: pyspec's `sum(...)`
+accumulates in `Gwei` rather than widening to a Python `int`, so it raises during the
+accumulation at the same point. See `Fulu.balanceAfterWithdrawals`. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
-  let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
+  let withdrawn ← ws.foldlM (init := (0 : Gwei)) fun acc w =>
+    if w.validatorIndex == vi then
+      checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
+    else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
   if withdrawn > bal then
     throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
@@ -58,9 +58,7 @@ def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Wi
       checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
     else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
-  if withdrawn > bal then
-    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
-  return bal - withdrawn
+  checkedSub bal withdrawn "get_balance_after_withdrawals: balances[i] - withdrawn"
 
 /-- `get_builder_withdrawals` (NEW, EIP-7732): drain `builder_pending_withdrawals`
 into validator-flagged withdrawals, capped at `MAX_WITHDRAWALS_PER_PAYLOAD - 1`. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/Withdrawals.lean
@@ -43,10 +43,15 @@ Throwing (`StateTransition`), because the spec's `return state.balances[validato
 withdrawn` (`capella/beacon-chain.md:378`) raises two ways, neither an explicit `assert`:
 `state.balances[validator_index]` is a bare list index (`IndexError` out of range), so it goes
 through `sszGetIdx` (→ `outOfBounds`); `- withdrawn` is a bare `uint64` subtraction whose
-underflow raises `ValueError`, which the reference runner does NOT catch (`context.py:429-433`),
+underflow raises `ValueError`, which the reference runner does NOT catch (`context.py:424-435`),
 so it throws the uncaught `.arithmetic` reject rather than a caught `.assert`. Both are
 unreachable on a well-formed state (`len(balances) == len(validators)`, and a validator's queued
-withdrawals never exceed its balance), but the reads are modeled faithfully rather than clamped. -/
+withdrawals never exceed its balance), and the reads are modeled rather than clamped.
+
+The `withdrawn` accumulator is the Fulu divergence restated here, deferred with it: pyspec's
+`sum(...)` adds unbounded ints, this fold wraps on `UInt64`, so a true sum ≥ 2^64 wraps past the
+`withdrawn > bal` guard and returns a wrong balance where pyspec raises. `checkedAdd`
+(`Spec/Errors.lean`) is the fix when it is taken up. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0

--- a/packages/EthCLSpecs/EthCLSpecs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze.lean
@@ -9,10 +9,13 @@ import EthCLSpecs.Heze.Signing
 /-!
 # `EthCLSpecs.Heze`: the Heze fork (EIP-7805 FOCIL), a thin diff over Gloas
 
-At alpha.11 Heze adds the `InclusionList` family (PR #5371 reverted the bid change) and the
-`upgradeToHeze` near-passthrough. EIP-7805 changes no state transition, so the spine is the
-Gloas spine re-instantiated over Heze types (`EpochProcessing` / `Operations` / `Withdrawals` /
-`Transition`, pulled in via `Interface`); the fork-interface drives every tested runner.
+At alpha.11 Heze adds the `InclusionList`
+family (PR #5371 reverted the bid change) and the `upgradeToHeze` near-passthrough. EIP-7805
+changes no state transition, so the spine (the `process_slots` / `process_block` /
+`process_epoch` pipeline) is the Gloas one re-instantiated over Heze types.
+`EpochProcessing` / `Operations` / `Withdrawals` / `Transition` carry that
+re-instantiation, pulled in via `Interface`, and the fork-interface drives every tested
+runner. The as-built divergence catalogue is `IMPLEMENTATION_NOTES.md`, "Heze diff".
 
 The FOCIL functions land in concern files, following the ePBS shape rather than a per-feature
 file. `get_inclusion_list_committee` sits with the committee accessors (`Committees`);
@@ -24,6 +27,7 @@ The fork choice (`ForkChoice`) is Gloas's with the EIP-7805 inclusion-list layer
 `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
 `get_inclusion_list_due_ms` helpers, the `should_extend_payload` and
 `on_execution_payload_envelope` overrides, and the new `on_inclusion_list` handler. FOCIL has no
-conformance vector, so that layer is pinned to the spec by the `InclusionListStore` `#guard`s in
-`ForkChoice` rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
+behavioral conformance vector (the two new containers do pass their `ssz_static` suites), so that
+layer is pinned to the spec by the build-enforced pins in `ForkChoice`, kernel `#guard`s plus
+`native_decide` examples, rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze.lean
@@ -18,9 +18,11 @@ re-instantiation, pulled in via `Interface`, and the fork-interface drives every
 runner. The as-built divergence catalogue is `IMPLEMENTATION_NOTES.md`, "Heze diff".
 
 The FOCIL functions land in concern files, following the ePBS shape rather than a per-feature
-file. `get_inclusion_list_committee` sits with the committee accessors (`Committees`);
-`is_valid_inclusion_list_signature` with the signing surface (`Signing`); the `InclusionListStore`
-and its three helpers with fork choice (`ForkChoice`), folded into the fork-choice `Store`.
+file. `get_inclusion_list_committee` sits in the store-throwing fork-choice block
+(`ForkChoice`, beside its sole caller; `Committees` keeps its unit-checkable `cyclicSample`
+core); `is_valid_inclusion_list_signature` with the signing surface (`Signing`); the
+`InclusionListStore` and its three helpers with fork choice (`ForkChoice`), folded into the
+fork-choice `Store`.
 
 The fork choice (`ForkChoice`) is Gloas's with the EIP-7805 inclusion-list layer added: the
 `InclusionListStore` and its three helpers, folded into the fork-choice `Store`, the

--- a/packages/EthCLSpecs/EthCLSpecs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze.lean
@@ -1,0 +1,29 @@
+import EthCLSpecs.Heze.Containers
+import EthCLSpecs.Heze.Upgrade
+import EthCLSpecs.Heze.Interface
+import EthCLSpecs.Heze.Committees
+-- Load-bearing: `isValidInclusionListSignature` has no in-model caller, so this import is the
+-- only path that pulls `Signing` into the build. Do not drop it as a "redundant" sibling.
+import EthCLSpecs.Heze.Signing
+
+/-!
+# `EthCLSpecs.Heze`: the Heze fork (EIP-7805 FOCIL), a thin diff over Gloas
+
+At alpha.11 Heze adds the `InclusionList` family (PR #5371 reverted the bid change) and the
+`upgradeToHeze` near-passthrough. EIP-7805 changes no state transition, so the spine is the
+Gloas spine re-instantiated over Heze types (`EpochProcessing` / `Operations` / `Withdrawals` /
+`Transition`, pulled in via `Interface`); the fork-interface drives every tested runner.
+
+The FOCIL functions land in concern files, following the ePBS shape rather than a per-feature
+file. `get_inclusion_list_committee` sits with the committee accessors (`Committees`);
+`is_valid_inclusion_list_signature` with the signing surface (`Signing`); the `InclusionListStore`
+and its three helpers with fork choice (`ForkChoice`), folded into the fork-choice `Store`.
+
+The fork choice (`ForkChoice`) is Gloas's with the EIP-7805 inclusion-list layer added: the
+`InclusionListStore` and its three helpers, folded into the fork-choice `Store`, the
+`is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
+`get_inclusion_list_due_ms` helpers, the `should_extend_payload` and
+`on_execution_payload_envelope` overrides, and the new `on_inclusion_list` handler. FOCIL has no
+conformance vector, so that layer is pinned to the spec by the `InclusionListStore` `#guard`s in
+`ForkChoice` rather than exercised by a runner. Pinned to v1.7.0-alpha.11.
+-/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
@@ -5,9 +5,9 @@ import EthCLSpecs.Heze.Containers.InclusionList
 
 `BeaconBlockBody` / `BeaconBlock` / `SignedBeaconBlock` are Gloas's, unchanged (EIP-7805
 touches none of them), so all three are `inherit`ed verbatim, including the signed wrapper.
-The `Containers.InclusionList` import is the load-order entry (it pulls `Heze.Inherited` +
-the `fork Heze from Gloas` lineage that `inherit` resolves against); it is load-bearing,
-do not drop it.
+The `Containers.InclusionList` import looks unused but is required: it transitively loads
+`Heze.Inherited` and the `fork Heze from Gloas` declaration that `inherit` resolves
+against. Do not remove it.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Block.lean
@@ -1,0 +1,24 @@
+import EthCLSpecs.Heze.Containers.InclusionList
+
+/-!
+# `EthCLSpecs.Heze.Block`: the Heze block containers (inherited from Gloas)
+
+`BeaconBlockBody` / `BeaconBlock` / `SignedBeaconBlock` are Gloas's, unchanged (EIP-7805
+touches none of them), so all three are `inherit`ed verbatim, including the signed wrapper.
+The `Containers.InclusionList` import is the load-order entry (it pulls `Heze.Inherited` +
+the `fork Heze from Gloas` lineage that `inherit` resolves against); it is load-bearing,
+do not drop it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit BeaconBlockBody
+inherit BeaconBlock
+inherit SignedBeaconBlock
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -1,0 +1,70 @@
+import EthCLSpecs.Heze.EpochProcessing
+
+/-!
+# `EthCLSpecs.Heze.Committees`: the EIP-7805 (FOCIL) inclusion-list committee accessor
+
+Heze inherits `Committees` from Fulu verbatim; this file adds the one new committee accessor
+EIP-7805 introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
+`consensus-specs/specs/heze/beacon-chain.md:95-110`) samples a fixed-size committee from the
+slot's beacon committees. It leans on accessors inherited over `Heze.State` in `EpochProcessing`
+(`getBeaconCommittee`, `getCommitteeCountPerSlot`, `computeEpochAtSlot`). FOCIL adds no state
+transition, so this is a pure accessor rather than a transition step.
+
+`get_inclusion_list_committee` is reached from the `on_execution_payload_envelope` vectors (via
+`get_inclusion_list_transactions`) but against an empty store, so the Python is the oracle. The
+accessor mirrors it branch-for-branch, and the build-enforced `#guard`s below pin the load-bearing
+cyclic resampling to values worked out by hand from the spec's list comprehension.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-- The cyclic resampling `get_inclusion_list_committee` uses to fill its fixed-length
+result: element `i` is `xs[i % xs.size]`, wrapping back to the front once `i` passes the end
+of the concatenated committees (the spec's `indices[i % len(indices)]`,
+`consensus-specs/specs/heze/beacon-chain.md:108-110`). Factored out of the accessor so the
+wrap-around index arithmetic is unit-checkable below without building a whole `BeaconState`.
+`xs.getD … default` is total via `[Inhabited α]`; on the spec path `xs` is the non-empty committee
+concatenation, so `i % xs.size < xs.size` and `getD` always returns a real element. The `default`
+fallback covers only the unreachable empty-`xs` case (a state a real beacon chain never reaches),
+which `getD` returns silently rather than panicking to stderr as `xs[…]!` would. -/
+private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : Vector α n :=
+  Vector.ofFn (fun i : Fin n => xs.getD (i.val % xs.size) default)
+
+-- Pins for the cyclic resampling, expected values computed by hand from the Python
+-- comprehension `[indices[i % len(indices)] for i in range(n)]`. First: a size-3 source over
+-- n = 8 wraps as i % 3 = 0,1,2,0,1,2,0,1. Second: a size-2 source over the real
+-- `INCLUSION_LIST_COMMITTEE_SIZE` (= 16) alternates 0,1,…; the 16-element result also pins
+-- the constant, since a different size would change the list length and fail the `=`.
+#guard (cyclicSample (#[10, 20, 30] : Array UInt64) 8).toList
+  = [10, 20, 30, 10, 20, 30, 10, 20]
+#guard (cyclicSample (#[7, 8] : Array UInt64) Const.inclusionListCommitteeSize).toList
+  = [7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8]
+
+state_section
+
+/-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
+`consensus-specs/specs/heze/beacon-chain.md:95-110`): concatenate every beacon committee for
+`slot` in committee-index order, then take the first `INCLUSION_LIST_COMMITTEE_SIZE` members
+cyclically. Mirrors the Python branch-for-branch: `epoch = compute_epoch_at_slot(slot)`, the
+`range(committees_per_slot)` accumulation that `extend`s each `get_beacon_committee`, and the
+`indices[i % len(indices)]` `Vector` fill (here `cyclicSample`). `get_beacon_committee` takes
+a `Nat` committee index in this framework, so the loop counter `i` is passed directly; the
+Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee case the
+Python would hit with a `ZeroDivisionError` (`len(indices) == 0`) is instead a total read here
+(`i % 0 = i`, default element), a state a real beacon chain never reaches. -/
+forkdef getInclusionListCommittee (state : State) (slot : Slot) :
+    Vector ValidatorIndex Const.inclusionListCommitteeSize :=
+  let epoch := computeEpochAtSlot slot
+  let committeesPerSlot := getCommitteeCountPerSlot state epoch
+  let indices := (Array.range committeesPerSlot).foldl
+    (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
+  cyclicSample indices Const.inclusionListCommitteeSize
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -4,7 +4,7 @@ import EthCLSpecs.Heze.EpochProcessing
 # `EthCLSpecs.Heze.Committees`: the EIP-7805 (FOCIL) inclusion-list committee accessor
 
 Heze inherits `Committees` from Fulu verbatim; this file adds the one new committee accessor
-EIP-7805 introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
+EIP-7805 (FOCIL) introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
 `consensus-specs/specs/heze/beacon-chain.md:95-110`) samples a fixed-size committee from the
 slot's beacon committees. It leans on accessors inherited over `Heze.State` in `EpochProcessing`
 (`getBeaconCommittee`, `getCommitteeCountPerSlot`, `computeEpochAtSlot`). FOCIL adds no state
@@ -45,6 +45,10 @@ private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : 
 #guard (cyclicSample (#[7, 8] : Array UInt64) Const.inclusionListCommitteeSize).toList
   = [7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8]
 
+-- `state_section` is the framework's header macro (`SPEC_AUTHORING_MODEL.md` §4): it opens
+-- the section and emits the `variable` line, `[Preset]` / `[Config]` / `[HasherTag]` /
+-- `[CryptoBackend]` plus the `StateTransition` monad variable and its constraints, which the
+-- `forkdef`s below take implicitly (`EthCLLib.Spec.Header`).
 state_section
 
 /-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
@@ -54,9 +58,8 @@ cyclically. Mirrors the Python branch-for-branch: `epoch = compute_epoch_at_slot
 `range(committees_per_slot)` accumulation that `extend`s each `get_beacon_committee`, and the
 `indices[i % len(indices)]` `Vector` fill (here `cyclicSample`). `get_beacon_committee` takes
 a `Nat` committee index in this framework, so the loop counter `i` is passed directly; the
-Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee case the
-Python would hit with a `ZeroDivisionError` (`len(indices) == 0`) is instead a total read here
-(`i % 0 = i`, default element), a state a real beacon chain never reaches. -/
+Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee read is
+total here where the Python would raise; `cyclicSample` above carries the mechanics. -/
 forkdef getInclusionListCommittee (state : State) (slot : Slot) :
     Vector ValidatorIndex Const.inclusionListCommitteeSize :=
   let epoch := computeEpochAtSlot slot

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -1,24 +1,20 @@
-import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Fulu.Constants
 
 /-!
-# `EthCLSpecs.Heze.Committees`: the EIP-7805 (FOCIL) inclusion-list committee accessor
+# `EthCLSpecs.Heze.Committees`: the FOCIL inclusion-list committee resampling helper
 
-Heze inherits `Committees` from Fulu verbatim; this file adds the one new committee accessor
-EIP-7805 (FOCIL) introduces. `get_inclusion_list_committee` (the "Beacon state accessors" section,
-`consensus-specs/specs/heze/beacon-chain.md:95-110`) samples a fixed-size committee from the
-slot's beacon committees. It leans on accessors inherited over `Heze.State` in `EpochProcessing`
-(`getBeaconCommittee`, `getCommitteeCountPerSlot`, `computeEpochAtSlot`). FOCIL adds no state
-transition, so this is a pure accessor rather than a transition step.
-
-`get_inclusion_list_committee` is reached from the `on_execution_payload_envelope` vectors (via
-`get_inclusion_list_transactions`) but against an empty store, so the Python is the oracle. The
-accessor mirrors it branch-for-branch, and the build-enforced `#guard`s below pin the load-bearing
-cyclic resampling to values worked out by hand from the spec's list comprehension.
+EIP-7805 (FOCIL) adds one beacon-state accessor, `get_inclusion_list_committee`
+(`consensus-specs/specs/heze/beacon-chain.md:95-110`), which samples a fixed-size committee from the
+slot's beacon committees. That accessor lives in `Heze/ForkChoice.lean`, next to its sole caller
+`get_inclusion_list_transactions`: it throws the fork-choice reject on the spec's degenerate
+empty-committee read (`indices[i % 0]` raises `ZeroDivisionError`), so it belongs in the
+store-throwing monad rather than among the pure state accessors. This file holds the one piece
+factored out of it: `cyclicSample`, the wrap-around index fill, kept here so its arithmetic is
+unit-checkable by the `#guard`s below without building a whole `BeaconState`.
 -/
 
 set_option autoImplicit false
 
-open EthCLLib.Spec
 open EthCLSpecs.Fulu
 
 namespace EthCLSpecs.Heze
@@ -28,11 +24,10 @@ result: element `i` is `xs[i % xs.size]`, wrapping back to the front once `i` pa
 of the concatenated committees (the spec's `indices[i % len(indices)]`,
 `consensus-specs/specs/heze/beacon-chain.md:108-110`). Factored out of the accessor so the
 wrap-around index arithmetic is unit-checkable below without building a whole `BeaconState`.
-`xs.getD … default` is total via `[Inhabited α]`; on the spec path `xs` is the non-empty committee
-concatenation, so `i % xs.size < xs.size` and `getD` always returns a real element. The `default`
-fallback covers only the unreachable empty-`xs` case (a state a real beacon chain never reaches),
-which `getD` returns silently rather than panicking to stderr as `xs[…]!` would. -/
-private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : Vector α n :=
+`xs.getD … default` is total via `[Inhabited α]`; the sole caller (`getInclusionListCommittee`
+in `Heze/ForkChoice.lean`) asserts `indices.size != 0` before reaching here, so on every path
+`xs` is non-empty, `i % xs.size < xs.size`, and `getD` always returns a real element. -/
+def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : Vector α n :=
   Vector.ofFn (fun i : Fin n => xs.getD (i.val % xs.size) default)
 
 -- Pins for the cyclic resampling, expected values computed by hand from the Python
@@ -44,30 +39,5 @@ private def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : 
   = [10, 20, 30, 10, 20, 30, 10, 20]
 #guard (cyclicSample (#[7, 8] : Array UInt64) Const.inclusionListCommitteeSize).toList
   = [7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8]
-
--- `state_section` is the framework's header macro (`SPEC_AUTHORING_MODEL.md` §4): it opens
--- the section and emits the `variable` line, `[Preset]` / `[Config]` / `[HasherTag]` /
--- `[CryptoBackend]` plus the `StateTransition` monad variable and its constraints, which the
--- `forkdef`s below take implicitly (`EthCLLib.Spec.Header`).
-state_section
-
-/-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
-`consensus-specs/specs/heze/beacon-chain.md:95-110`): concatenate every beacon committee for
-`slot` in committee-index order, then take the first `INCLUSION_LIST_COMMITTEE_SIZE` members
-cyclically. Mirrors the Python branch-for-branch: `epoch = compute_epoch_at_slot(slot)`, the
-`range(committees_per_slot)` accumulation that `extend`s each `get_beacon_committee`, and the
-`indices[i % len(indices)]` `Vector` fill (here `cyclicSample`). `get_beacon_committee` takes
-a `Nat` committee index in this framework, so the loop counter `i` is passed directly; the
-Python `CommitteeIndex(i)` wrapper is the same value. The degenerate empty-committee read is
-total here where the Python would raise; `cyclicSample` above carries the mechanics. -/
-forkdef getInclusionListCommittee (state : State) (slot : Slot) :
-    Vector ValidatorIndex Const.inclusionListCommitteeSize :=
-  let epoch := computeEpochAtSlot slot
-  let committeesPerSlot := getCommitteeCountPerSlot state epoch
-  let indices := (Array.range committeesPerSlot).foldl
-    (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
-  cyclicSample indices Const.inclusionListCommitteeSize
-
-end
 
 end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Committees.lean
@@ -25,8 +25,11 @@ of the concatenated committees (the spec's `indices[i % len(indices)]`,
 `consensus-specs/specs/heze/beacon-chain.md:108-110`). Factored out of the accessor so the
 wrap-around index arithmetic is unit-checkable below without building a whole `BeaconState`.
 `xs.getD … default` is total via `[Inhabited α]`; the sole caller (`getInclusionListCommittee`
-in `Heze/ForkChoice.lean`) asserts `indices.size != 0` before reaching here, so on every path
-`xs` is non-empty, `i % xs.size < xs.size`, and `getD` always returns a real element. -/
+in `Heze/ForkChoice.lean`) rejects an empty committee before reaching here, so on every path
+`xs` is non-empty, `i % xs.size < xs.size`, and `getD` always returns a real element. That
+guard is an `.arithmetic` throw, not an `assert`: the spec's `i % len(indices)` raises
+`ZeroDivisionError` on an empty committee, an uncaught fault the reference runner propagates
+rather than catching, so it can never be a vector's expected rejection. -/
 def cyclicSample {α : Type} [Inhabited α] (xs : Array α) (n : Nat) : Vector α n :=
   Vector.ofFn (fun i : Fin n => xs.getD (i.val % xs.size) default)
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Constants.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Constants.lean
@@ -1,0 +1,29 @@
+import EthCLSpecs.Gloas.Constants
+
+/-!
+# `EthCLSpecs.Heze.Constants`: the Heze fork declaration + version values
+
+Heze is a diff over Gloas, adding EIP-7805 (FOCIL). At alpha.11 it modifies no Gloas
+container (PR #5371 reverted the bid change), so the only Heze-specific constants here
+are the two `HEZE_FORK_VERSION` values. `fork Heze from Gloas` records the lineage so
+`inherit` replays Gloas (and through Gloas, Fulu) declarations in the Heze namespace.
+The FOCIL `DOMAIN_INCLUSION_LIST_COMMITTEE` tag lives with every other BLS domain in
+`Fulu.Const` (`Const.domainInclusionListCommittee`); the FOCIL
+`is_valid_inclusion_list_signature` predicate (`Heze/Signing.lean`) verifies signatures under it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+fork Heze from Gloas
+
+/-- `HEZE_FORK_VERSION` at the `minimal` config (`0x08000001`). -/
+def hezeForkVersionMinimal : Version := ⟨#[0x08, 0x00, 0x00, 0x01], by decide⟩
+/-- `HEZE_FORK_VERSION` at the `mainnet` config (`0x08000000`). -/
+def hezeForkVersionMainnet : Version := ⟨#[0x08, 0x00, 0x00, 0x00], by decide⟩
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers.lean
@@ -1,0 +1,11 @@
+import EthCLSpecs.Heze.State
+import EthCLSpecs.Heze.Block
+
+/-!
+# `EthCLSpecs.Heze.Containers`: the Heze container re-export root
+
+A single `import EthCLSpecs.Heze.Containers` brings the whole Heze container layer into
+scope; it holds no declarations of its own. The only Heze-new containers are the
+`InclusionList` family (`Containers.InclusionList`); the rest are inherited from Gloas /
+Fulu (`Inherited`, `State`, `Block`).
+-/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
@@ -7,6 +7,13 @@ The two containers EIP-7805 adds at alpha.11: an `InclusionList` (a committee me
 committed transactions for a slot) and its signed wrapper. `Transaction` and
 `MAX_TRANSACTIONS_PER_PAYLOAD` are the existing Fulu/Gloas types. These are the *only*
 new Heze containers; the bid is unchanged at alpha.11.
+
+The two DSL forms: `forkcontainer` declares an SSZ container in the fork namespace and
+captures it for a later fork's `inherit`. Field order is declaration order, and that order
+fixes both the SSZ serialization and the hash-tree-root. `signedwrapper SignedX wraps X`
+expands to the two-field `forkcontainer { message : X, signature : BLSSignature }`, in that
+order (`EthCLLib.Spec.Forms` documents `forkcontainer`; `EthCLSpecs.Forms` documents
+`signedwrapper`).
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Containers/InclusionList.lean
@@ -1,0 +1,30 @@
+import EthCLSpecs.Heze.Inherited
+
+/-!
+# `EthCLSpecs.Heze.Containers.InclusionList`: the FOCIL inclusion list (EIP-7805, new)
+
+The two containers EIP-7805 adds at alpha.11: an `InclusionList` (a committee member's
+committed transactions for a slot) and its signed wrapper. `Transaction` and
+`MAX_TRANSACTIONS_PER_PAYLOAD` are the existing Fulu/Gloas types. These are the *only*
+new Heze containers; the bid is unchanged at alpha.11.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-- An inclusion list (EIP-7805): the transactions an inclusion-list-committee member
+commits to for a slot. -/
+forkcontainer InclusionList where
+  slot                       : Slot
+  validatorIndex             : ValidatorIndex
+  inclusionListCommitteeRoot : Root
+  transactions               : SSZList Transaction Const.maxTransactionsPerPayload
+
+/-- A signed inclusion list. -/
+signedwrapper SignedInclusionList wraps InclusionList
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
@@ -5,7 +5,8 @@ import EthCLSpecs.Gloas.EpochProcessing
 # `EthCLSpecs.Heze.EpochProcessing`: the inherited epoch substeps (Gloas over Heze state)
 
 EIP-7805 (FOCIL) changes no epoch processing. Every Gloas epoch substep and accessor is
-`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` re-elaborates in the Heze
+`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` (the DSL stores every
+`forkdef`'s source for inheritance; `SPEC_AUTHORING_MODEL.md` §8) re-elaborates in the Heze
 namespace against `Heze.State` (`= SSZ.Box _ Heze.BeaconState`), its sibling calls
 rebinding to the Heze copies. No substep body is restated. The order matches Gloas's so
 each callee is declared before its caller.

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/EpochProcessing.lean
@@ -1,0 +1,115 @@
+import EthCLSpecs.Heze.Containers
+import EthCLSpecs.Gloas.EpochProcessing
+
+/-!
+# `EthCLSpecs.Heze.EpochProcessing`: the inherited epoch substeps (Gloas over Heze state)
+
+EIP-7805 (FOCIL) changes no epoch processing. Every Gloas epoch substep and accessor is
+`inherit`ed here verbatim: each captured Gloas/Fulu `forkdef` re-elaborates in the Heze
+namespace against `Heze.State` (`= SSZ.Box _ Heze.BeaconState`), its sibling calls
+rebinding to the Heze copies. No substep body is restated. The order matches Gloas's so
+each callee is declared before its caller.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit computeEpochAtSlot
+inherit computeStartSlotAtEpoch
+inherit getCurrentEpoch
+inherit getPreviousEpoch
+inherit getRandaoMix
+inherit modBalance
+inherit increaseBalance
+inherit decreaseBalance
+inherit modValidator
+inherit computeActivationExitEpoch
+inherit currentEpochOf
+inherit previousEpochOf
+inherit getBeaconProposerIndex
+inherit getBlockRootAtSlot
+inherit getBlockRoot
+inherit isActiveValidator
+inherit isSlashableValidator
+inherit isEligibleForActivationQueue
+inherit isEligibleForActivation
+inherit credPrefix
+inherit hasEth1WithdrawalCredential
+inherit hasCompoundingWithdrawalCredential
+inherit hasExecutionWithdrawalCredential
+inherit getMaxEffectiveBalance
+inherit hasNotInitiatedExit
+inherit passedShardCommitteePeriod
+inherit getActiveValidatorIndices
+inherit getTotalBalance
+inherit getTotalActiveBalance
+inherit getBaseRewardPerIncrement
+inherit getBaseReward
+inherit getUnslashedParticipatingIndices
+inherit getEligibleValidatorIndices
+inherit validatorIndexByPubkey?
+inherit getFinalityDelay
+inherit isInInactivityLeak
+inherit getBalanceChurnLimit
+inherit getActivationExitChurnLimit
+inherit getExitChurnLimit
+inherit getActivationChurnLimit
+inherit computeExitEpochAndUpdateChurn
+inherit initiateValidatorExit
+inherit slashValidator
+inherit getDomain
+inherit getPendingBalanceToWithdraw
+inherit getConsolidationChurnLimit
+inherit computeConsolidationEpochAndUpdateChurn
+inherit queueExcessActiveBalance
+inherit switchToCompoundingValidator
+inherit getValidatorFromDeposit
+inherit addValidatorToRegistry
+inherit isValidDepositSignature
+inherit applyPendingDeposit
+inherit computeShuffledPermutation
+inherit getSeed
+inherit getCommitteeCountPerSlot
+inherit computeCommittee
+inherit getBeaconCommittee
+inherit getCommitteeIndices
+inherit cbwsAux
+inherit computeBalanceWeightedSelection
+inherit computeProposerIndices
+inherit getNextSyncCommittee
+inherit getBeaconProposerIndices
+inherit weighJustificationAndFinalization
+inherit processJustificationAndFinalization
+inherit processInactivityUpdates
+inherit getFlagIndexDeltas
+inherit getInactivityPenaltyDeltas
+inherit applyDeltas
+inherit processRewardsAndPenalties
+inherit processRegistryUpdates
+inherit processSlashings
+inherit DepositScan
+inherit ppdLoop
+inherit processPendingDeposits
+inherit pcLoop
+inherit processPendingConsolidations
+inherit processEffectiveBalanceUpdates
+inherit processSlashingsReset
+inherit processRandaoMixesReset
+inherit processEth1DataReset
+inherit processHistoricalSummariesUpdate
+inherit processParticipationFlagUpdates
+inherit processSyncCommitteeUpdates
+inherit processProposerLookahead
+inherit processBuilderPendingPayments
+inherit computePtc
+inherit processPtcWindow
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -7,14 +7,19 @@ import EthCLLib.Spec.Engine
 /-!
 # `EthCLSpecs.Heze.ForkChoice`: the ePBS node-based fork choice with EIP-7805 (FOCIL)
 
-Heze inherits Gloas's whole ePBS node fork choice and adds the EIP-7805 inclusion-list layer
-on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` / `LatestMessage` are
-`inherit`ed unchanged; the `Store` is re-declared (a `forkstruct` rather than an `inherit`) to
-carry the two `[New in Heze:EIP7805]` fields, `payloadInclusionListSatisfaction` and the folded-in
-`inclusionListStore`. The spec keeps a separate process-lifetime `InclusionListStore`, but this
-framework's pure `EStateM` fork choice threads one `Store`, so the inclusion-list store rides inside
-it (see the `InclusionListStore` block below for the full rationale). Most handlers are
-inherited verbatim; the FOCIL touch points are re-declared here:
+Heze inherits the whole node-based fork choice of Gloas's ePBS (EIP-7732) and adds the
+EIP-7805 FOCIL layer on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` /
+`LatestMessage` are `inherit`ed unchanged (`inherit` replays an ancestor fork's captured
+declaration in this namespace; the inheritance mechanism is `SPEC_AUTHORING_MODEL.md` §8).
+The three node smart constructors and the `deriving` lines are plain declarations in Gloas,
+which the capture does not cover, so they are restated here. The `Store` is re-declared as a
+fresh `forkstruct` (the framework's fork-aware `structure` form, capturable for a later
+fork's `inherit`) instead of an `inherit`, to carry the two `[New in Heze:EIP7805]` fields:
+`payloadInclusionListSatisfaction` and the folded-in `inclusionListStore`. The spec keeps a
+separate process-lifetime `InclusionListStore`; this framework's fork choice threads one
+`Store` value through the generic `StoreTransition` monad, so the inclusion-list store rides
+inside it (the `InclusionListStore` declaration below carries the full rationale). Most
+handlers are inherited verbatim; the FOCIL touch points are re-declared here:
 
 * `get_forkchoice_store` seeds the two new store fields empty;
 * `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
@@ -23,19 +28,24 @@ inherited verbatim; the FOCIL touch points are re-declared here:
 * `on_execution_payload_envelope` records satisfaction before storing the payload;
 * `on_inclusion_list` is the new wire handler.
 
-EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it through
-`notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both are the production-side Engine-API
-surface a proposer drives to build its own payload, so they sit outside the modeled
-state-transition and fork-choice scope and stay unmodeled here, the same boundary every fork keeps.
-Only the consumption-side `is_inclusion_list_satisfied` is modeled, through the `[ExecutionEngine]`
-seam that `record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
+EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it
+through `notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both belong to the
+production-side Engine-API surface, the calls a proposer drives to build its own payload.
+That surface sits outside the modeled state-transition and fork-choice scope, the boundary
+every fork keeps, so both stay unmodeled here. Only the consumption side is modeled:
+`is_inclusion_list_satisfied`, through the `[ExecutionEngine]` seam (one of the injection
+seams, `FRAMEWORK_ARCHITECTURE.md` §1; defined in `EthCLLib.Spec.Engine`) that
+`record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
 
-The `on_execution_payload_envelope` fork_choice vectors do drive the two overrides, but only the
-empty-inclusion-list, always-satisfied path they share with Gloas; the FOCIL-specific behavior (the
-discriminating satisfaction gate and `on_inclusion_list`) has no vector, so the pinned alpha.11 spec
-is its oracle. Each override mirrors its Python branch-for-branch, and the `InclusionListStore`
-`#guard`s below pin the inclusion-list store logic. The three node smart constructors and the `deriving` lines are
-plain declarations in Gloas (not captured), so they are restated here.
+Vector coverage is partial, and the split matters. The `on_execution_payload_envelope`
+fork_choice vectors do drive `onExecutionPayloadEnvelope` and `shouldExtendPayload`, but only
+on the empty-inclusion-list, always-satisfied path they share with Gloas. The FOCIL-specific
+behavior (the discriminating satisfaction gate and `on_inclusion_list`) has no vector; the
+pinned spec text (`consensus-specs` at tag `v1.7.0-alpha.11`) is its oracle
+(`IMPLEMENTATION_NOTES.md`, "Heze diff", is the catalogue). Each override mirrors its Python
+branch-for-branch, and the build-enforced pin sections below fix the inclusion-list logic's
+expected outcomes at build time: kernel `#guard`s where the outcome is hash-free,
+`native_decide` examples where a hash-tree-root must be computed.
 -/
 
 set_option autoImplicit false
@@ -56,19 +66,24 @@ inherit LatestMessage
 deriving instance Inhabited for LatestMessage
 
 /-- `InclusionListStore` (`consensus-specs/specs/heze/inclusion-list.md:28-38`): the
-fork-choice node's view of the inclusion lists it has seen. `inclusionLists` files each
-stored `InclusionList` under its committee root then its own hash-tree root
-(`DefaultDict[Root, Dict[Root, InclusionList]]`); `inclusionListTimeliness` records, per
-stored-list root, whether it arrived before `INCLUSION_LIST_DUE_BPS`; `equivocators` is the
-per-committee set of validator indices caught publishing two different lists. A `forkstruct`
-rather than a bare `structure`, so a later fork can `inherit` it, and so it carries the auto
-`[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+fork-choice node's view of the inclusion lists it has seen. The three fields:
 
-Declared here, above the fork-choice `Store` that carries it as a field, rather than in a
-separate feature file: the spec keeps `InclusionListStore` as a process-lifetime singleton reached
-through `get_inclusion_list_store()`, but this framework's fork choice is a pure `EStateM` over one
-`Store`, so the store is modeled as a field of that `Store`. It is fork-choice state, so it lives
-with fork choice, next to the handlers that drive it. -/
+* `inclusionLists`: every stored `InclusionList`, keyed first by its committee root, then by
+  the list's own hash-tree root (the spec's `DefaultDict[Root, Dict[Root, InclusionList]]`);
+* `inclusionListTimeliness`: per stored-list root, whether the list arrived before the
+  `INCLUSION_LIST_DUE_BPS` deadline;
+* `equivocators`: per committee root, the validators caught publishing two different lists.
+
+A `forkstruct` rather than a bare `structure`, so a later fork can `inherit` it, and so it
+carries the auto `[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+
+This declaration is the canonical home of the fold-in rationale. The spec keeps
+`InclusionListStore` as a process-lifetime singleton reached through
+`get_inclusion_list_store()`. This framework's fork choice threads one `Store` value through
+the generic `StoreTransition` monad (`SPEC_AUTHORING_MODEL.md` §4), with no ambient mutable
+singleton to hang the spec's store off, so the store is modeled as a `Store` field instead
+and moves with the rest of the state. Behavior is identical. It is fork-choice state, so it
+lives here, next to the handlers that drive it. -/
 forkstruct InclusionListStore (map : MapKind) [HasherTag] where
   inclusionLists          : map Root (map Root InclusionList)
   inclusionListTimeliness : map Root Bool
@@ -78,28 +93,32 @@ section
 
 variable [Preset] [HasherTag] [Config] {map : MapKind} [FcMap map]
 
-/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators. The seed
-`get_forkchoice_store` plants (`consensus-specs/specs/heze/fork-choice.md:165`) and the base
-every pin builds from, so the all-empty literal lives in one place. -/
+/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators.
+`getForkchoiceStore` seeds the folded-in `Store` field with it. The spec has no counterpart
+line: there the store is the lazily-created `get_inclusion_list_store()` singleton (see the
+`InclusionListStore` docstring above for the fold-in). Every pin below also builds from it,
+so the all-empty literal lives in one place. -/
 def InclusionListStore.empty : InclusionListStore map :=
   { inclusionLists := FcMap.empty, inclusionListTimeliness := FcMap.empty, equivocators := FcMap.empty }
 
 /-- The inner comprehension of `get_inclusion_list_transactions`
 (`consensus-specs/specs/heze/inclusion-list.md:105-114`): over the inclusion lists stored for
 one committee key, keep those from non-equivocating validators (and, when `onlyTimely`, only
-the timely ones), gather their transactions, and deduplicate. Factored out of the accessor so
-the equivocator / timeliness / dedup logic is unit-checkable without building a `BeaconState`
-for the committee key (the `cyclicSample` pattern). One pass with `FcMap.fold` over the stored
-map, which hands each `(ilRoot, il)` straight to the step (no second `lookup`, no dead `none`
-branch). `timeliness[ilRoot]` is a plain dict read in the spec (every stored list has a
-timeliness entry, written together in `process_inclusion_list`); the structurally-present key
-reads through `.getD false`, the default never reached on the spec path. The dedup is the house
-`arrayUnion #[] …` first-occurrence union: the spec's `list(set(transactions))` keeps each
-transaction once and calls the order irrelevant, so a deterministic first-occurrence
-representative lets the result be pinned by `#guard`. -/
+the timely ones), gather their transactions, and deduplicate.
+
+Factored out of the accessor so the equivocator / timeliness / dedup logic is unit-checkable
+without building a `BeaconState` for the committee key, the same reason `cyclicSample` is
+factored out in `Committees`. The dedup keeps each transaction's first occurrence
+(`arrayUnion`): the spec's `list(set(transactions))` keeps each transaction once and calls
+the order irrelevant, so a deterministic representative lets `#guard` pin the result.
+`timeliness[ilRoot]` is a plain dict read in the spec; the `.getD false` default here is
+unreachable on the spec path, because `process_inclusion_list` writes every stored list and
+its timeliness entry together. -/
 private def collectInclusionListTransactions (inclusionLists : map Root InclusionList)
     (equivocators : Array ValidatorIndex) (timeliness : map Root Bool) (onlyTimely : Bool) :
     Array Transaction :=
+  -- One `FcMap.fold` pass: each stored `(ilRoot, il)` goes straight to the filter, with no
+  -- second `lookup` and no dead `none` branch.
   let collected : Array Transaction :=
     FcMap.fold (fun acc ilRoot il =>
       let timely := FcMap.lookupD timeliness ilRoot
@@ -229,12 +248,13 @@ inherit payloadDataAvailability
 inherit isPreviousSlotPayloadDecision
 
 /-- `is_payload_inclusion_list_satisfied(store, root)`
-(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root` satisfied
-the inclusion-list constraints and is locally available. The spec opens with `assert root in
-store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so a missing
-key reads as `false` through `lookupD`, the same default-on-miss the sibling `payloadTimeliness`
-uses. That default sits off the spec path thanks to the `payloads`/satisfaction co-write; the
-INVARIANT note in `onExecutionPayloadEnvelope` is the canonical statement. -/
+(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root`
+satisfied the inclusion-list constraints and is locally available. The spec opens with
+`assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot
+throw, so a missing key reads as `false` through `lookupD` (the same default-on-miss the
+sibling `payloadTimeliness` uses). The default is unreachable on the spec path, because
+`onExecutionPayloadEnvelope` always writes `payloads` and the satisfaction entry together;
+the INVARIANT note there is the canonical statement of that argument. -/
 forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : Bool :=
   isPayloadVerified store root && FcMap.lookupD store.payloadInclusionListSatisfaction root
 
@@ -336,10 +356,11 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
   | .ok warm =>
     -- [New in Heze:EIP7805] record whether the payload satisfies the inclusion-list constraints
     let store := recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
-    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are co-written here
-    -- (the satisfaction key via `recordPayloadInclusionListSatisfaction` just above). Keep them
-    -- co-written: `isPayloadInclusionListSatisfied`'s default-false-on-miss is sound only because a
-    -- verified `root` (present in `payloads`) always carries a satisfaction entry.
+    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written
+    -- together here (the satisfaction key via `recordPayloadInclusionListSatisfaction` just
+    -- above). Keep it that way: `isPayloadInclusionListSatisfied`'s default-false-on-miss is
+    -- sound only because a verified `root` (present in `payloads`) always carries a
+    -- satisfaction entry.
     set { store with
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
@@ -353,9 +374,10 @@ inherit onAttesterSlashing
 
 /-- `get_forkchoice_store(anchor_state, anchor_block)` (Heze override,
 `consensus-specs/specs/heze/fork-choice.md:140-166`): the Gloas anchor store with the two
-`[New in Heze:EIP7805]` fields seeded empty, `payloadInclusionListSatisfaction` as an empty
-map and `inclusionListStore` as the empty `InclusionListStore` (`fork-choice.md:165`, decision
-A). The rest is Gloas verbatim. -/
+`[New in Heze:EIP7805]` fields seeded empty: `payloadInclusionListSatisfaction` as an empty
+map (`fork-choice.md:165`) and `inclusionListStore` as the empty `InclusionListStore` (no
+spec counterpart; the spec's store is a process-lifetime singleton, folded into `Store` here,
+see the `InclusionListStore` docstring). The rest is Gloas verbatim. -/
 forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
@@ -376,8 +398,8 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : S
     payloads := FcMap.empty
     payloadTimelinessVote := FcMap.empty
     payloadDataAvailabilityVote := FcMap.empty
-    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the co-write
-    -- INVARIANT in `onExecutionPayloadEnvelope`).
+    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the INVARIANT
+    -- note in `onExecutionPayloadEnvelope`: the two maps are always written together).
     payloadInclusionListSatisfaction := FcMap.empty
     inclusionListStore := InclusionListStore.empty }
 
@@ -405,20 +427,18 @@ end
 
 /-! ### Build-enforced pin (vectorless): the inclusion-list satisfaction gate
 
-`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload` reads
-to refuse a payload that failed its inclusion-list constraints. No conformance vector exercises it,
-and the no-regression sweep only runs the optimistic `is_inclusion_list_satisfied = true` mock, so
-the discriminating `false` branch is otherwise dead. This pin drives the predicate on a minimal
-`Store` directly, fixing its outcomes by hand: verified + recorded-`false` ⇒ `false` (the gate's
-whole point), verified + recorded-`true` ⇒ `true`, unverified ⇒ `false` even with the bit recorded
-`true` (the `is_payload_verified` membership gate dominates), and verified-but-absent ⇒ `false`
-through the `lookupD` default (off the spec path; the co-write INVARIANT in
-`onExecutionPayloadEnvelope`). Hash-free (`is_payload_verified` is a `payloads`
-membership test, no `htr`), so kernel `#guard`. The pin reaches the predicate end-to-end, including
-the `isPayloadVerified` composition; it fixes the recorded bit by hand rather than through the EL,
-so the `isInclusionListSatisfied` verdict is out of its reach. That verdict is the
-`[ExecutionEngine]` seam's job: `pinRecordRefuted` below drives its refuting branch through the
-record path into this gate. -/
+`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload`
+reads to refuse a payload that failed its inclusion-list constraints. No conformance vector
+exercises it, and the pyspec conformance runs answer every engine call through the optimistic
+`is_inclusion_list_satisfied = true` default, so the discriminating `false` branch is
+otherwise dead code. This pin drives the predicate on a minimal `Store` directly; the four
+verified/recorded combinations are enumerated one per `#guard` below, each with its expected
+verdict beside it. Everything is hash-free (`is_payload_verified` is a `payloads` membership
+test, no `htr`), so kernel `#guard` per the hash-tactic rule.
+
+The pin fixes the recorded bit by hand rather than through the engine, so the
+`isInclusionListSatisfied` verdict itself is out of its reach; `pinRecordRefuted` below
+drives that refuting branch through the record path into this gate. -/
 
 private def pinPilsRoot : Root := Vector.replicate 32 9
 
@@ -466,7 +486,8 @@ private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Bool :=
 #guard pinPils true (some true) = true
 -- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
 #guard pinPils false (some true) = false
--- verified but no recorded entry ⇒ `false` via the `lookupD` default (off the spec path).
+-- verified but no recorded entry ⇒ `false` via the `lookupD` default (a state the spec's
+-- own invariant rules out; the INVARIANT note in `onExecutionPayloadEnvelope`).
 #guard pinPils true none = false
 
 /-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
@@ -487,15 +508,17 @@ private def pinIlDueMs : UInt64 :=
   getInclusionListDueMs
 #guard pinIlDueMs = 4000
 
-/-- `record_payload_inclusion_list_satisfaction` records the EL verdict at `root`. With the
-optimistic `isInclusionListSatisfied = true` mock (the `ExecutionEngine` default) it writes
-`true`; the slot-0 `state` drives the underflow-guard branch (no previous slot ⇒ empty required
-set, `getInclusionListTransactions` never reached), though the pinned value alone does not
-discriminate the guard: with an empty store and the optimistic oracle the verdict is `true`
-either way. `state` is a `FastBox` of the default minimal `BeaconState`, the boxed `State` the
-forkdef wants (`State = SSZ.Box HasherTag.H BeaconState`); `FastBox` is FFI-backed, so this is a
-`native_decide` `example`
-(`Lean.ofReduceBool`). -/
+/-- `record_payload_inclusion_list_satisfaction` records the engine verdict at `root`: with
+the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. The slot-0
+`state` also sends execution down the underflow-guard branch (no previous slot, so the
+required set is empty and `getInclusionListTransactions` is never reached). Note the pinned
+value alone does not discriminate that guard: with an empty store and the optimistic oracle
+the verdict is `true` either way. What this pin fixes is the record path writing the verdict
+at the right key.
+
+Lean mechanics: the forkdef wants the boxed `State` (`State = SSZ.Box HasherTag.H
+BeaconState`), so `state` is a `FastBox` of the default minimal `BeaconState`. `FastBox` is
+FFI-backed, so this is a `native_decide` `example` (`Lean.ofReduceBool`). -/
 private def pinRecordSatisfied : Option Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
@@ -506,14 +529,14 @@ private def pinRecordSatisfied : Option Bool :=
   FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
 example : pinRecordSatisfied = some true := by native_decide
 
-/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path, now under a
-*refuting* `[ExecutionEngine]`. A local `letI` answering `false` overrides the global optimistic
-instance, the whole reason the seam exists. So the record path writes `false` at a *verified* `root`
-and `isPayloadInclusionListSatisfied` then refuses to extend it. This drives the
-`isInclusionListSatisfied = false` branch the optimistic default and every conformance vector leave
-dead, end-to-end: oracle → recorded verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`
-so the membership check passes and the recorded bit is what decides. `State` is FFI-backed
-(`FastBox`), so `native_decide`. -/
+/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path under a
+*refuting* engine, a local `letI` instance answering `false` in place of the optimistic
+default (`EthCLLib.Spec.Engine` documents the design). The record path writes `false` at a
+*verified* `root`, and `isPayloadInclusionListSatisfied` then refuses to extend it. That
+covers the branch every conformance vector leaves dead, end-to-end: oracle → recorded
+verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`, so the membership check
+passes and the recorded bit is what decides. `State` is FFI-backed (`FastBox`), so
+`native_decide`. -/
 private def pinRecordRefuted : Option Bool × Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
@@ -550,7 +573,8 @@ example : pinOnIlTimely 4 = some false := by native_decide
 
 /-! ### Build-enforced pins for the inclusion-list store (vectorless)
 
-FOCIL has no conformance vector, so these pin `process_inclusion_list`'s three branches and
+FOCIL has no conformance vector (the module docstring carries the coverage story), so these
+pin `process_inclusion_list`'s three branches and
 `get_inclusion_list_transactions`'s comprehension to hand-derived outcomes. They build a small
 `InclusionListStore treeMap` (deterministic key order) under the minimal preset and the FFI
 hasher. The branch-(A)/(B) pins and every `collectInclusionListTransactions` pin are

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -1,0 +1,669 @@
+import EthCLSpecs.Heze.Transition
+import EthCLSpecs.Gloas.ForkChoice
+import EthCLSpecs.Heze.Committees
+import EthCLLib.Spec.FiniteMap
+import EthCLLib.Spec.Engine
+
+/-!
+# `EthCLSpecs.Heze.ForkChoice`: the ePBS node-based fork choice with EIP-7805 (FOCIL)
+
+Heze inherits Gloas's whole ePBS node fork choice and adds the EIP-7805 inclusion-list layer
+on top (`consensus-specs/specs/heze/fork-choice.md`). `ForkChoiceNode` / `LatestMessage` are
+`inherit`ed unchanged; the `Store` is re-declared (a `forkstruct` rather than an `inherit`) to
+carry the two `[New in Heze:EIP7805]` fields, `payloadInclusionListSatisfaction` and the folded-in
+`inclusionListStore`. The spec keeps a separate process-lifetime `InclusionListStore`, but this
+framework's pure `EStateM` fork choice threads one `Store`, so the inclusion-list store rides inside
+it (see the `InclusionListStore` block below for the full rationale). Most handlers are
+inherited verbatim; the FOCIL touch points are re-declared here:
+
+* `get_forkchoice_store` seeds the two new store fields empty;
+* `is_payload_inclusion_list_satisfied` / `record_payload_inclusion_list_satisfaction` /
+  `get_inclusion_list_due_ms` / `is_inclusion_list_satisfied` are the new helpers;
+* `should_extend_payload` gains the inclusion-list gate;
+* `on_execution_payload_envelope` records satisfaction before storing the payload;
+* `on_inclusion_list` is the new wire handler.
+
+EIP-7805 also extends `PayloadAttributes` with `inclusion_list_transactions` and threads it through
+`notify_forkchoice_updated` (`heze/fork-choice.md:65-104`). Both are the production-side Engine-API
+surface a proposer drives to build its own payload, so they sit outside the modeled
+state-transition and fork-choice scope and stay unmodeled here, the same boundary every fork keeps.
+Only the consumption-side `is_inclusion_list_satisfied` is modeled, through the `[ExecutionEngine]`
+seam that `record_payload_inclusion_list_satisfaction` calls to judge a revealed payload.
+
+The `on_execution_payload_envelope` fork_choice vectors do drive the two overrides, but only the
+empty-inclusion-list, always-satisfied path they share with Gloas; the FOCIL-specific behavior (the
+discriminating satisfaction gate and `on_inclusion_list`) has no vector, so the pinned alpha.11 spec
+is its oracle. Each override mirrors its Python branch-for-branch, and the `InclusionListStore`
+`#guard`s below pin the inclusion-list store logic. The three node smart constructors and the `deriving` lines are
+plain declarations in Gloas (not captured), so they are restated here.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLLib.PySpecTests
+open SizzLean
+open SizzLean.Cache
+open SizzLean.Hasher
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit ForkChoiceNode
+deriving instance BEq, Inhabited for ForkChoiceNode
+
+inherit LatestMessage
+deriving instance Inhabited for LatestMessage
+
+/-- `InclusionListStore` (`consensus-specs/specs/heze/inclusion-list.md:28-38`): the
+fork-choice node's view of the inclusion lists it has seen. `inclusionLists` files each
+stored `InclusionList` under its committee root then its own hash-tree root
+(`DefaultDict[Root, Dict[Root, InclusionList]]`); `inclusionListTimeliness` records, per
+stored-list root, whether it arrived before `INCLUSION_LIST_DUE_BPS`; `equivocators` is the
+per-committee set of validator indices caught publishing two different lists. A `forkstruct`
+rather than a bare `structure`, so a later fork can `inherit` it, and so it carries the auto
+`[Preset]` / `[HasherTag]` uniformly with the containers it nests.
+
+Declared here, above the fork-choice `Store` that carries it as a field, rather than in a
+separate feature file: the spec keeps `InclusionListStore` as a process-lifetime singleton reached
+through `get_inclusion_list_store()`, but this framework's fork choice is a pure `EStateM` over one
+`Store`, so the store is modeled as a field of that `Store`. It is fork-choice state, so it lives
+with fork choice, next to the handlers that drive it. -/
+forkstruct InclusionListStore (map : MapKind) [HasherTag] where
+  inclusionLists          : map Root (map Root InclusionList)
+  inclusionListTimeliness : map Root Bool
+  equivocators            : map Root (Array ValidatorIndex)
+
+section
+
+variable [Preset] [HasherTag] [Config] {map : MapKind} [FcMap map]
+
+/-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators. The seed
+`get_forkchoice_store` plants (`consensus-specs/specs/heze/fork-choice.md:165`) and the base
+every pin builds from, so the all-empty literal lives in one place. -/
+def InclusionListStore.empty : InclusionListStore map :=
+  { inclusionLists := FcMap.empty, inclusionListTimeliness := FcMap.empty, equivocators := FcMap.empty }
+
+/-- The inner comprehension of `get_inclusion_list_transactions`
+(`consensus-specs/specs/heze/inclusion-list.md:105-114`): over the inclusion lists stored for
+one committee key, keep those from non-equivocating validators (and, when `onlyTimely`, only
+the timely ones), gather their transactions, and deduplicate. Factored out of the accessor so
+the equivocator / timeliness / dedup logic is unit-checkable without building a `BeaconState`
+for the committee key (the `cyclicSample` pattern). One pass with `FcMap.fold` over the stored
+map, which hands each `(ilRoot, il)` straight to the step (no second `lookup`, no dead `none`
+branch). `timeliness[ilRoot]` is a plain dict read in the spec (every stored list has a
+timeliness entry, written together in `process_inclusion_list`); the structurally-present key
+reads through `.getD false`, the default never reached on the spec path. The dedup is the house
+`arrayUnion #[] …` first-occurrence union: the spec's `list(set(transactions))` keeps each
+transaction once and calls the order irrelevant, so a deterministic first-occurrence
+representative lets the result be pinned by `#guard`. -/
+private def collectInclusionListTransactions (inclusionLists : map Root InclusionList)
+    (equivocators : Array ValidatorIndex) (timeliness : map Root Bool) (onlyTimely : Bool) :
+    Array Transaction :=
+  let collected : Array Transaction :=
+    FcMap.fold (fun acc ilRoot il =>
+      let timely := FcMap.lookupD timeliness ilRoot
+      if !equivocators.contains il.validatorIndex && (!onlyTimely || timely) then
+        acc ++ il.transactions.toArray
+      else acc) #[] inclusionLists
+  arrayUnion #[] collected
+
+/-- `process_inclusion_list(store, inclusion_list, is_timely)`
+(`consensus-specs/specs/heze/inclusion-list.md:57-82`): file a newly-received inclusion list,
+or record an equivocation. Pure here (returns the updated `InclusionListStore`); the spec
+mutates in place. The three branches mirror the Python:
+
+* (A) the list is from a known equivocator for this committee (`validator_index in
+  store.equivocators[key]`) → ignore it, return the store unchanged.
+* (B) we already hold a list from this validator for this committee → if the new list differs
+  from the stored one, add the validator to `equivocators[key]`; either way we have processed
+  it, so return (storing nothing new). At most one stored list per validator exists (a list is
+  filed only on branch (C), reached only when none matches), so the single `find?` match is
+  exactly the Python loop's first-and-only hit. The equivocator `push` is guarded by branch
+  (A) above, so it never duplicates.
+* (C) otherwise → store the list under its `hash_tree_root` and record its timeliness.
+
+`key` is the list's `inclusion_list_committee_root` (a field, no rehash). -/
+forkdef processInclusionList (store : InclusionListStore map) (inclusionList : InclusionList)
+    (isTimely : Bool) : InclusionListStore map :=
+  let key := inclusionList.inclusionListCommitteeRoot
+  let equivs := FcMap.lookupD store.equivocators key
+  -- (A) ignore inclusion lists from known equivocators for this committee
+  if equivs.contains inclusionList.validatorIndex then store
+  else
+    let stored := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
+    match (FcMap.values stored).find? (fun il => il.validatorIndex == inclusionList.validatorIndex) with
+    -- (B) already hold a list from this validator: equivocate iff it differs, then stop
+    | some existing =>
+      if existing == inclusionList then store
+      else
+        { store with
+            equivocators := FcMap.insert store.equivocators key (equivs.push inclusionList.validatorIndex) }
+    -- (C) first list from this validator: store it and its timeliness
+    | none =>
+      let inclusionListRoot := htr inclusionList
+      let stored' := FcMap.insert stored inclusionListRoot inclusionList
+      { store with
+          inclusionLists := FcMap.insert store.inclusionLists key stored',
+          inclusionListTimeliness := FcMap.insert store.inclusionListTimeliness inclusionListRoot isTimely }
+
+/-- `get_inclusion_list_transactions(store, state, slot, only_timely=True)`
+(`consensus-specs/specs/heze/inclusion-list.md:95-114`): the unique transactions from every
+valid, non-equivocating inclusion list whose committee root matches the one `state`/`slot`
+compute, optionally restricted to lists received before `INCLUSION_LIST_DUE_BPS`. Mirrors the
+Python: derive the committee, key it by `hash_tree_root`, read the `defaultdict` entries for
+that key, then run the comprehension (here `collectInclusionListTransactions`). Returns an
+`Array` for the spec's `Sequence[Transaction]`; the dedup leaves order unspecified, as the
+spec notes. -/
+forkdef getInclusionListTransactions (store : InclusionListStore map) (state : State)
+    (slot : Slot) (onlyTimely : Bool := true) : Array Transaction :=
+  let committee := getInclusionListCommittee state slot
+  let key := htr committee
+  let inclusionLists := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
+  let equivocators := FcMap.lookupD store.equivocators key
+  collectInclusionListTransactions inclusionLists equivocators store.inclusionListTimeliness onlyTimely
+
+end
+
+/-- The Heze fork-choice store: the Gloas store plus the EIP-7805 fields. Re-declared as a
+`forkstruct` rather than an `inherit Store`, so the two `[New in Heze:EIP7805]` fields can be added.
+`payloadInclusionListSatisfaction` tracks, per beacon-block root, whether the revealed payload
+satisfied the inclusion-list constraints (`consensus-specs/specs/heze/fork-choice.md:134`);
+`inclusionListStore` folds in the spec's separate `InclusionListStore` (see the module docstring).
+The seventeen Gloas fields are restated verbatim. -/
+forkstruct Store (map : MapKind) [HasherTag] where
+  time                          : UInt64
+  genesisTime                   : UInt64
+  justifiedCheckpoint           : Checkpoint
+  finalizedCheckpoint           : Checkpoint
+  unrealizedJustifiedCheckpoint : Checkpoint
+  unrealizedFinalizedCheckpoint : Checkpoint
+  proposerBoostRoot             : Root
+  equivocatingIndices           : Array ValidatorIndex
+  blocks                        : map Root BeaconBlock
+  blockStates                   : map Root State
+  blockTimeliness               : map Root (Array Bool)
+  checkpointStates              : map Checkpoint State
+  latestMessages                : map ValidatorIndex LatestMessage
+  unrealizedJustifications      : map Root Checkpoint
+  payloads                      : map Root ExecutionPayloadEnvelope
+  payloadTimelinessVote         : map Root (Array (Option Bool))
+  payloadDataAvailabilityVote   : map Root (Array (Option Bool))
+  -- [New in Heze:EIP7805] (consensus-specs/specs/heze/fork-choice.md:134)
+  payloadInclusionListSatisfaction : map Root Bool
+  -- [New in Heze:EIP7805] the spec's standalone `InclusionListStore`, folded in here as a field
+  inclusionListStore            : InclusionListStore map
+
+fork_choice_section map
+
+/-- A PENDING node at `root`: the undecided block, before either payload realisation is
+committed. -/
+def ForkChoiceNode.pending (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusPending }
+
+/-- An EMPTY node at `root`: the realisation in which the block's payload is absent. -/
+def ForkChoiceNode.empty (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusEmpty }
+
+/-- A FULL node at `root`: the realisation in which the block's payload is present. -/
+def ForkChoiceNode.full (root : Root) : ForkChoiceNode :=
+  { root := root, payloadStatus := Const.payloadStatusFull }
+
+inherit fcZeroRoot
+inherit getSlotsSinceGenesis
+inherit getCurrentSlot
+inherit getCurrentStoreEpoch
+inherit timeIntoSlotMs
+inherit bpsDeadlineMs
+inherit getParentPayloadStatus
+inherit isParentNodeFull
+inherit getAncestor
+inherit isAncestor
+inherit getCheckpointBlock
+inherit getSupportedNode
+inherit getDependentRoot
+inherit isPayloadVerified
+inherit voteCount
+inherit payloadTimeliness
+inherit payloadDataAvailability
+inherit isPreviousSlotPayloadDecision
+
+/-- `is_payload_inclusion_list_satisfied(store, root)`
+(`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root` satisfied
+the inclusion-list constraints and is locally available. The spec opens with `assert root in
+store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so a missing
+key reads as `false` through `lookupD`, the same default-on-miss the sibling `payloadTimeliness`
+uses. That default sits off the spec path thanks to the `payloads`/satisfaction co-write; the
+INVARIANT note in `onExecutionPayloadEnvelope` is the canonical statement. -/
+forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : Bool :=
+  isPayloadVerified store root && FcMap.lookupD store.payloadInclusionListSatisfaction root
+
+/-- `should_extend_payload(store, root)` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:221-236`): the Gloas body with the one new
+inclusion-list gate. After the `is_payload_verified` check, a payload that fails the
+inclusion-list constraints is not extended (`fork-choice.md:226`). The rest is Gloas verbatim.
+-/
+forkdef shouldExtendPayload (store : Store map) (root : Root) : Bool :=
+  if !isPayloadVerified store root then false
+  -- [New in Heze:EIP7805] do not extend a payload that fails the inclusion-list constraints
+  else if !isPayloadInclusionListSatisfied store root then false
+  else
+    let proposerRoot := store.proposerBoostRoot
+    let payloadIsTimely := payloadTimeliness store root true
+    let payloadDataIsAvailable := payloadDataAvailability store root true
+    (payloadIsTimely && payloadDataIsAvailable)
+      || proposerRoot == fcZeroRoot
+      || (match FcMap.lookup store.blocks proposerRoot with
+          | some pb => pb.parentRoot != root || isParentNodeFull store pb
+          | none    => true)
+
+inherit getPayloadStatusTiebreaker
+inherit committeeWeight
+inherit calculateCommitteeFraction
+inherit getProposerScore
+inherit getAttestationScore
+inherit isHeadWeak
+inherit isParentStrong
+inherit shouldApplyProposerBoost
+inherit getWeight
+inherit getVotingSource
+inherit filterBlockTree
+inherit getFilteredBlockTree
+inherit getNodeChildren
+inherit getHead
+inherit updateCheckpoints
+inherit updateUnrealizedCheckpoints
+inherit computePulledUpTip
+inherit onTickPerSlot
+inherit advanceStoreTime
+inherit onTick
+inherit recordBlockTimeliness
+inherit updateProposerBoostRoot
+inherit recordPtcVotes
+inherit notifyPtcMessages
+inherit onBlock
+inherit computeTimeAtSlot
+inherit verifyExecutionPayloadEnvelopeSignature
+inherit verifyExecutionPayloadEnvelope
+
+-- The `is_inclusion_list_satisfied` verdict comes from an external EL over the Engine API
+-- (`consensus-specs/specs/heze/fork-choice.md:54-62`), so it enters through the framework's
+-- `[ExecutionEngine]` seam (`EthCLLib.Spec.Engine`, the canonical home of the optimistic-mock
+-- rationale), instantiated at Heze's payload / transaction types.
+variable [ExecutionEngine ExecutionPayload Transaction]
+
+/-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
+(`consensus-specs/specs/heze/fork-choice.md:54-62`): the `ExecutionEngine` predicate deciding
+whether a payload includes the required inclusion-list transactions. Its verdict is
+EL-implementation-defined (the Engine API answers it against an external EL), so it reads the
+`[ExecutionEngine]` seam rather than a fixed value; the default and the trust boundary are
+documented on `EthCLLib.Spec.ExecutionEngine`. -/
+forkdef isInclusionListSatisfied (payload : ExecutionPayload) (ilTxs : Array Transaction) : Bool :=
+  ExecutionEngine.isInclusionListSatisfied payload ilTxs
+
+/-- `record_payload_inclusion_list_satisfaction(store, state, root, payload, execution_engine)`
+(`consensus-specs/specs/heze/fork-choice.md:180-193`): record whether `payload` satisfies the
+inclusion-list constraints for `root`. Pure here (returns the updated store); the spec mutates
+in place. `get_inclusion_list_store()` is `store.inclusionListStore`; the required
+transactions are read for the previous slot (`state.slot - 1`) at the default `only_timely =
+True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
+`[ExecutionEngine]` seam (the spec's `execution_engine` argument, modeled injectably). -/
+forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
+    (payload : ExecutionPayload) : Store map :=
+  -- The spec reads `Slot(state.slot - 1)`, which assumes `state.slot ≥ 1` (a genesis/slot-0 state
+  -- never reaches a payload envelope). Guard the `UInt64` underflow explicitly: at slot 0 there is
+  -- no previous slot, so no inclusion-list transactions are required.
+  let stateSlot := sszGet state slot
+  let ilTxs := if stateSlot == 0 then #[]
+               else getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
+  let satisfied := isInclusionListSatisfied payload ilTxs
+  { store with
+      payloadInclusionListSatisfaction := FcMap.insert store.payloadInclusionListSatisfaction root satisfied }
+
+/-- `on_execution_payload_envelope` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:273-300`): the Gloas body with one added step,
+`record_payload_inclusion_list_satisfaction` is called on the verified envelope *before* the
+payload is stored (`fork-choice.md:295`), so `should_extend_payload` can later read the
+recorded verdict. `state` is the pre-verify `block_states[root]`, as in the spec; the warm
+state from `verify_execution_payload_envelope` is kept only for `blockStates`. -/
+forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) : StoreTransition Unit := do
+  let store ← get
+  let envelope := signedEnv.message
+  let state ← FcMap.getOrThrow store.blockStates envelope.beaconBlockRoot
+
+  match verifyExecutionPayloadEnvelope state signedEnv with
+  | .error e => throw e
+  | .ok warm =>
+    -- [New in Heze:EIP7805] record whether the payload satisfies the inclusion-list constraints
+    let store := recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
+    -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are co-written here
+    -- (the satisfaction key via `recordPayloadInclusionListSatisfaction` just above). Keep them
+    -- co-written: `isPayloadInclusionListSatisfied`'s default-false-on-miss is sound only because a
+    -- verified `root` (present in `payloads`) always carries a satisfaction entry.
+    set { store with
+      blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
+      payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
+
+inherit onPayloadAttestationMessage
+inherit storeTargetCheckpointState
+inherit validateOnAttestation
+inherit updateLatestMessages
+inherit onAttestation
+inherit onAttesterSlashing
+
+/-- `get_forkchoice_store(anchor_state, anchor_block)` (Heze override,
+`consensus-specs/specs/heze/fork-choice.md:140-166`): the Gloas anchor store with the two
+`[New in Heze:EIP7805]` fields seeded empty, `payloadInclusionListSatisfaction` as an empty
+map and `inclusionListStore` as the empty `InclusionListStore` (`fork-choice.md:165`, decision
+A). The rest is Gloas verbatim. -/
+forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
+  let anchorRoot := htr anchorBlock
+  let epoch := currentEpochOf anchorState
+  let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
+
+  { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+    genesisTime := sszGet anchorState genesisTime
+    justifiedCheckpoint := cp, finalizedCheckpoint := cp
+    unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
+    blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
+    blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
+    checkpointStates := FcMap.insert FcMap.empty cp anchorState
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
+    payloads := FcMap.empty
+    payloadTimelinessVote := FcMap.empty
+    payloadDataAvailabilityVote := FcMap.empty
+    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the co-write
+    -- INVARIANT in `onExecutionPayloadEnvelope`).
+    payloadInclusionListSatisfaction := FcMap.empty
+    inclusionListStore := InclusionListStore.empty }
+
+/-- `get_inclusion_list_due_ms()` (`consensus-specs/specs/heze/fork-choice.md:242-243`):
+`get_slot_component_duration_ms(INCLUSION_LIST_DUE_BPS)`. `bpsDeadlineMs` (inherited from Gloas)
+IS `get_slot_component_duration_ms`. A fork-choice deadline helper leaning on that inherited
+fork-choice function, so it lives here with the rest of the fork-choice layer. -/
+forkdef getInclusionListDueMs : UInt64 := bpsDeadlineMs Const.inclusionListDueBps
+
+/-- `on_inclusion_list(store, signed_inclusion_list)` (the new wire handler,
+`consensus-specs/specs/heze/fork-choice.md:256-267`): on receiving an inclusion list, judge its
+timeliness against `INCLUSION_LIST_DUE_BPS` and hand it to `process_inclusion_list`. The spec's
+`seconds_to_milliseconds(store.time - store.genesis_time) % SLOT_DURATION_MS` is exactly the
+inherited `timeIntoSlotMs`. `process_inclusion_list` is total, so the spec's "an invalid call
+MUST NOT modify the store" is automatic here. The inclusion-list store rides inside `Store`, so
+`get_inclusion_list_store()` is `store.inclusionListStore`. -/
+forkdef onInclusionList (signed : SignedInclusionList) : StoreTransition Unit := do
+  let store ← get
+  let inclusionList := signed.message
+  let isTimely := timeIntoSlotMs store < getInclusionListDueMs
+  set { store with
+    inclusionListStore := processInclusionList store.inclusionListStore inclusionList isTimely }
+
+end
+
+/-! ### Build-enforced pin (vectorless): the inclusion-list satisfaction gate
+
+`is_payload_inclusion_list_satisfied` is the FOCIL fork-choice gate `should_extend_payload` reads
+to refuse a payload that failed its inclusion-list constraints. No conformance vector exercises it,
+and the no-regression sweep only runs the optimistic `is_inclusion_list_satisfied = true` mock, so
+the discriminating `false` branch is otherwise dead. This pin drives the predicate on a minimal
+`Store` directly, fixing its outcomes by hand: verified + recorded-`false` ⇒ `false` (the gate's
+whole point), verified + recorded-`true` ⇒ `true`, unverified ⇒ `false` even with the bit recorded
+`true` (the `is_payload_verified` membership gate dominates), and verified-but-absent ⇒ `false`
+through the `lookupD` default (off the spec path; the co-write INVARIANT in
+`onExecutionPayloadEnvelope`). Hash-free (`is_payload_verified` is a `payloads`
+membership test, no `htr`), so kernel `#guard`. The pin reaches the predicate end-to-end, including
+the `isPayloadVerified` composition; it fixes the recorded bit by hand rather than through the EL,
+so the `isInclusionListSatisfied` verdict is out of its reach. That verdict is the
+`[ExecutionEngine]` seam's job: `pinRecordRefuted` below drives its refuting branch through the
+record path into this gate. -/
+
+private def pinPilsRoot : Root := Vector.replicate 32 9
+
+/-- A minimal Heze `Store` exercising `isPayloadInclusionListSatisfied` at `pinPilsRoot`.
+`payloadPresent` controls whether `root ∈ payloads` (the `is_payload_verified` gate); `recorded` is
+the optional `payloadInclusionListSatisfaction[root]` entry. Every other field is empty/zero
+(`FcMap.empty`, default checkpoints, `fcZeroRoot`), mirroring the `getForkchoiceStore` literal. The
+`payloads` value is never read (the predicate tests membership only), so a `default` envelope
+serves. The `letI`s fix the preset / hasher so the anonymous `Store` constructor synthesizes them. -/
+private def pinPilsStore (payloadPresent : Bool) (recorded : Option Bool) :
+    @Store minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { time := 0, genesisTime := 0
+    justifiedCheckpoint := default, finalizedCheckpoint := default
+    unrealizedJustifiedCheckpoint := default, unrealizedFinalizedCheckpoint := default
+    proposerBoostRoot := fcZeroRoot
+    equivocatingIndices := #[]
+    blocks := FcMap.empty
+    blockStates := FcMap.empty
+    blockTimeliness := FcMap.empty
+    checkpointStates := FcMap.empty
+    latestMessages := FcMap.empty
+    unrealizedJustifications := FcMap.empty
+    payloads := if payloadPresent then FcMap.insert FcMap.empty pinPilsRoot default else FcMap.empty
+    payloadTimelinessVote := FcMap.empty
+    payloadDataAvailabilityVote := FcMap.empty
+    payloadInclusionListSatisfaction :=
+      match recorded with
+      | some b => FcMap.insert FcMap.empty pinPilsRoot b
+      | none   => FcMap.empty
+    inclusionListStore := InclusionListStore.empty }
+
+/-- The predicate's verdict on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
+preset / hasher the `forkdef` parameters want (Lean re-synthesizes them rather than reading the
+store's fixed type), the same pattern the `InclusionListStore` pins in this file use. -/
+private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Bool :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  isPayloadInclusionListSatisfied (pinPilsStore payloadPresent recorded) pinPilsRoot
+
+-- verified + recorded `false` ⇒ `false` (do not extend this payload).
+#guard pinPils true (some false) = false
+-- verified + recorded `true` ⇒ `true`.
+#guard pinPils true (some true) = true
+-- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
+#guard pinPils false (some true) = false
+-- verified but no recorded entry ⇒ `false` via the `lookupD` default (off the spec path).
+#guard pinPils true none = false
+
+/-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
+
+`get_inclusion_list_due_ms`, `record_payload_inclusion_list_satisfaction`, and `on_inclusion_list`
+ship no conformance vector either. These drive them end-to-end so a future edit can't regress them
+silently: the deadline constant, the recorded EL verdict, and the timeliness bit `on_inclusion_list`
+threads into `process_inclusion_list`. -/
+
+/-- `get_inclusion_list_due_ms = INCLUSION_LIST_DUE_BPS * SLOT_DURATION_MS // BASIS_POINTS`. Under
+the minimal config that is `6667 * 6000 / 10000 = 4000` (truncating divide), pinning both the
+`INCLUSION_LIST_DUE_BPS = 6667` constant and the inherited `bpsDeadlineMs` composition. Arithmetic
+only (no hash), so kernel `#guard`. -/
+private def pinIlDueMs : UInt64 :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  getInclusionListDueMs
+#guard pinIlDueMs = 4000
+
+/-- `record_payload_inclusion_list_satisfaction` records the EL verdict at `root`. With the
+optimistic `isInclusionListSatisfied = true` mock (the `ExecutionEngine` default) it writes
+`true`; the slot-0 `state` drives the underflow-guard branch (no previous slot ⇒ empty required
+set, `getInclusionListTransactions` never reached), though the pinned value alone does not
+discriminate the guard: with an empty store and the optimistic oracle the verdict is `true`
+either way. `state` is a `FastBox` of the default minimal `BeaconState`, the boxed `State` the
+forkdef wants (`State = SSZ.Box HasherTag.H BeaconState`); `FastBox` is FFI-backed, so this is a
+`native_decide` `example`
+(`Lean.ofReduceBool`). -/
+private def pinRecordSatisfied : Option Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
+  let after := recordPayloadInclusionListSatisfaction (pinPilsStore false none) state pinPilsRoot
+    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
+  FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
+example : pinRecordSatisfied = some true := by native_decide
+
+/-- The discriminating counterpart to `pinRecordSatisfied`: the same record path, now under a
+*refuting* `[ExecutionEngine]`. A local `letI` answering `false` overrides the global optimistic
+instance, the whole reason the seam exists. So the record path writes `false` at a *verified* `root`
+and `isPayloadInclusionListSatisfied` then refuses to extend it. This drives the
+`isInclusionListSatisfied = false` branch the optimistic default and every conformance vector leave
+dead, end-to-end: oracle → recorded verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`
+so the membership check passes and the recorded bit is what decides. `State` is FFI-backed
+(`FastBox`), so `native_decide`. -/
+private def pinRecordRefuted : Option Bool × Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  letI : ExecutionEngine (@EthCLSpecs.Heze.ExecutionPayload minimal) Transaction :=
+    { isInclusionListSatisfied := fun _ _ => false }
+  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
+  let after := recordPayloadInclusionListSatisfaction (pinPilsStore true none) state pinPilsRoot
+    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
+  (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot,
+   isPayloadInclusionListSatisfied after pinPilsRoot)
+-- refuting oracle ⇒ recorded `false`, and the gate rejects the verified payload.
+example : pinRecordRefuted = (some false, false) := by native_decide
+
+/-- `on_inclusion_list` threads the slot-timeliness bit into `process_inclusion_list`: a list
+received before `INCLUSION_LIST_DUE_BPS` is filed timely, one at/after the deadline untimely. Runs
+the handler end-to-end on a minimal store whose `time` puts `timeIntoSlotMs` below vs at the
+`getInclusionListDueMs = 4000` deadline, then reads the stored timeliness bit back at `htr il`.
+`process_inclusion_list` files the default list on branch (C), computing `htr` (FFI `Sha256`), so
+this is a `native_decide` `example` (`Lean.ofReduceBool`). -/
+private def pinOnIlTimely (time : UInt64) : Option Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let signed : @SignedInclusionList minimal := default
+  match runOn { pinPilsStore false none with time := time }
+      (onInclusionList (map := treeMap) signed : EStateM StoreTransitionError (Store treeMap) Unit) with
+  | .ok after => FcMap.lookup after.inclusionListStore.inclusionListTimeliness (htr signed.message)
+  | .error _  => none
+-- time 0: timeIntoSlotMs = 0 < 4000 ⇒ timely.
+example : pinOnIlTimely 0 = some true := by native_decide
+-- time 4: timeIntoSlotMs = 4000, not < 4000 ⇒ untimely.
+example : pinOnIlTimely 4 = some false := by native_decide
+
+/-! ### Build-enforced pins for the inclusion-list store (vectorless)
+
+FOCIL has no conformance vector, so these pin `process_inclusion_list`'s three branches and
+`get_inclusion_list_transactions`'s comprehension to hand-derived outcomes. They build a small
+`InclusionListStore treeMap` (deterministic key order) under the minimal preset and the FFI
+hasher. The branch-(A)/(B) pins and every `collectInclusionListTransactions` pin are
+hash-free, so kernel `#guard`; the branch-(C) pin computes `htr` (FFI `Sha256`), so it is a
+`native_decide` `example` (`Lean.ofReduceBool`), per the project's hash-tactic rule. -/
+
+private def pinKey : Root := Vector.replicate 32 7
+private def pinDummyRoot : Root := Vector.replicate 32 1
+private def pinAltRoot : Root := Vector.replicate 32 2
+
+/-- A transaction holding the single byte `b` (enough to make two transactions compare
+unequal for the dedup pins). -/
+private def pinTx (b : UInt8) : Transaction := sszOfArray #[b]
+
+/-- An inclusion list from validator `v` over committee `pinKey`, carrying `txs`. The `letI`
+fixes the preset so the anonymous constructor can synthesize it (a return-type annotation alone
+does not flow into instance resolution for `{ … }`). -/
+private def pinIL (v : ValidatorIndex) (txs : Array Transaction) : @InclusionList minimal :=
+  letI : Preset := minimal
+  { slot := 0, validatorIndex := v, inclusionListCommitteeRoot := pinKey, transactions := sszOfArray txs }
+
+/-- Number of inclusion lists stored under `pinKey`. The `letI`s supply the store's preset /
+hasher for the field projection (Lean re-synthesizes them rather than reading the argument's
+fixed type). -/
+private def pinNumStored (s : @InclusionListStore minimal treeMap fastHasherTag) : Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  ((FcMap.lookup s.inclusionLists pinKey).getD FcMap.empty |> FcMap.keys).length
+/-- The equivocator set recorded under `pinKey`. -/
+private def pinEquivs (s : @InclusionListStore minimal treeMap fastHasherTag) : Array ValidatorIndex :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  FcMap.lookupD s.equivocators pinKey
+
+/-- A store already holding one inclusion list from validator 5, filed under an arbitrary root
+(branch (B) never rehashes the stored list, so the key is free). Shared by the two branch-(B)
+pins. -/
+private def pinStoreB : @InclusionListStore minimal treeMap fastHasherTag :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  { inclusionLists := FcMap.insert FcMap.empty pinKey (FcMap.insert FcMap.empty pinDummyRoot (pinIL 5 #[pinTx 0xAA])),
+    inclusionListTimeliness := FcMap.insert FcMap.empty pinDummyRoot true,
+    equivocators := FcMap.empty }
+
+-- Branch (A): a list from a validator already in `equivocators[key]` is ignored; nothing is
+-- stored and the equivocator set is untouched. Hash-free, so kernel `#guard`. Returns
+-- (stored count, equivocator count); expected (0, 1).
+private def pinResA : Nat × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let store : InclusionListStore treeMap :=
+    { InclusionListStore.empty with equivocators := FcMap.insert FcMap.empty pinKey #[5] }
+  let after := processInclusionList store (pinIL 5 #[pinTx 0xAA]) true
+  (pinNumStored after, (pinEquivs after).size)
+#guard pinResA = (0, 1)
+
+-- Branch (B), conflict: a second, differing list from validator 5 adds 5 to `equivocators[key]`
+-- and stores nothing new. Returns (equivocators, stored count); expected (#[5], 1).
+private def pinResBConflict : Array ValidatorIndex × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let after := processInclusionList pinStoreB (pinIL 5 #[pinTx 0xBB]) true
+  (pinEquivs after, pinNumStored after)
+#guard pinResBConflict = (#[5], 1)
+
+-- Branch (B), match: re-receiving the *same* list is a no-op. Returns (equivocator count,
+-- stored count); expected (0, 1).
+private def pinResBMatch : Nat × Nat :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let after := processInclusionList pinStoreB (pinIL 5 #[pinTx 0xAA]) true
+  ((pinEquivs after).size, pinNumStored after)
+#guard pinResBMatch = (0, 1)
+
+-- Branch (C): the first list from a validator is stored (one entry under `key`) with its
+-- timeliness recorded under `htr inclusion_list`. Reads the bit back at the actual `htr il` key
+-- (not just its presence), so a flipped `insert … (!isTimely)` fails; the stored-count half pins
+-- that branch (C) filed exactly one list. Computes `htr` (FFI `Sha256`), so `native_decide`
+-- `example`s. Returns (stored count, timeliness at `htr il`); expected (1, some isTimely).
+private def pinResC (isTimely : Bool) : Nat × Option Bool :=
+  letI : Preset := minimal
+  letI : HasherTag := fastHasherTag
+  let store : InclusionListStore treeMap := InclusionListStore.empty
+  let il := pinIL 5 #[pinTx 0xAA]
+  let after := processInclusionList store il isTimely
+  (pinNumStored after, FcMap.lookup after.inclusionListTimeliness (htr il))
+example : pinResC true = (1, some true) := by native_decide
+example : pinResC false = (1, some false) := by native_decide
+
+-- `collectInclusionListTransactions` (the `get_inclusion_list_transactions` comprehension).
+-- Two stored lists: validator 5 → [0xAA], validator 6 → [0xAA, 0xBB], timeliness 5=true /
+-- 6=false. Pins worked out by hand from the comprehension. All hash-free, kernel `#guard`.
+private def pinLists : treeMap Root (@InclusionList minimal) :=
+  FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot (pinIL 5 #[pinTx 0xAA]))
+    pinAltRoot (pinIL 6 #[pinTx 0xAA, pinTx 0xBB])
+private def pinTimeliness : treeMap Root Bool :=
+  FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot true) pinAltRoot false
+
+/-- Run the comprehension over `pinLists` / `pinTimeliness` under the minimal preset, so the
+hash-free `#guard`s below need no ambient instance. -/
+private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) : Array Transaction :=
+  letI : Preset := minimal
+  collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely
+
+-- No equivocators, timeliness ignored: union of {0xAA} and {0xAA, 0xBB}, deduped to two.
+#guard (pinCollect #[] false).size = 2
+#guard (pinCollect #[] false).contains (pinTx 0xAA)
+#guard (pinCollect #[] false).contains (pinTx 0xBB)
+-- only_timely drops validator 6's untimely list, leaving just {0xAA}.
+#guard (pinCollect #[] true).size = 1
+#guard (pinCollect #[] true).contains (pinTx 0xAA)
+-- Equivocator 6 is filtered out regardless of timeliness, leaving just {0xAA}.
+#guard (pinCollect #[6] false).size = 1
+#guard (pinCollect #[6] false).contains (pinTx 0xAA)
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -185,6 +185,24 @@ forkdef processInclusionList (store : InclusionListStore map) (inclusionList : I
           inclusionLists := FcMap.insert store.inclusionLists key stored',
           inclusionListTimeliness := FcMap.insert store.inclusionListTimeliness inclusionListRoot isTimely }
 
+/-- `get_inclusion_list_committee(state, slot)` (EIP-7805,
+`consensus-specs/specs/heze/beacon-chain.md:95-110`): concatenate every beacon committee for
+`slot` in committee-index order, then take the first `INCLUSION_LIST_COMMITTEE_SIZE` members
+cyclically (`cyclicSample`, in `Heze/Committees.lean`). Relocated from the beacon-state accessors
+into this store-throwing block beside its sole caller `getInclusionListTransactions`: the spec's
+`indices[i % len(indices)]` raises `ZeroDivisionError` when the slot has no committee members, so
+`assert (indices.size != 0)` throws the fork-choice reject rather than silently sampling a
+`default`. `state` stays an explicit parameter (the accessor reads `state`, not the store), and
+the block's `[MonadExceptOf StoreTransitionError]` resolves `assert` to the store reject. -/
+forkdef getInclusionListCommittee (state : State) (slot : Slot) :
+    StoreTransition (Vector ValidatorIndex Const.inclusionListCommitteeSize) := do
+  let epoch := computeEpochAtSlot slot
+  let committeesPerSlot := getCommitteeCountPerSlot state epoch
+  let indices := (Array.range committeesPerSlot).foldl
+    (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
+  assert (indices.size != 0)
+  pure (cyclicSample indices Const.inclusionListCommitteeSize)
+
 /-- `get_inclusion_list_transactions(store, state, slot, only_timely=True)`
 (`consensus-specs/specs/heze/inclusion-list.md:95-114`): the unique transactions from every
 valid, non-equivocating inclusion list whose committee root matches the one `state`/`slot`
@@ -194,17 +212,13 @@ that key, then run the comprehension (here `collectInclusionListTransactions`). 
 `Array` for the spec's `Sequence[Transaction]`; the dedup leaves order unspecified, as the
 spec notes. -/
 forkdef getInclusionListTransactions (store : InclusionListStore map) (state : State)
-    (slot : Slot) (onlyTimely : Bool := true) : StoreTransition (Array Transaction) :=
-  let committee := getInclusionListCommittee state slot
+    (slot : Slot) (onlyTimely : Bool := true) : StoreTransition (Array Transaction) := do
+  let committee ← getInclusionListCommittee state slot
   let key := htr committee
   -- `inclusion_lists` and `equivocators` are `DefaultDict`s (inclusion-list.md:31,35): the
   -- spec's `[key]` auto-creates an empty entry on a miss, so the defaults here are faithful.
   let inclusionLists := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
   let equivocators := FcMap.lookupD store.equivocators key
-  -- TODO(#6): `getInclusionListCommittee`'s empty-committee `indices[i % 0]` (a spec
-  -- `ZeroDivisionError`) is still modeled total. Making it throw reworks the record pins to a
-  -- non-empty-committee state, so it lands as a focused follow-up. The `timeliness` plain-`Dict`
-  -- read is now faithful: `collectInclusionListTransactions` below throws on a miss.
   collectInclusionListTransactions inclusionLists equivocators store.inclusionListTimeliness onlyTimely
 
 end
@@ -557,29 +571,60 @@ private def pinIlDueMs : UInt64 :=
   getInclusionListDueMs
 #guard pinIlDueMs = 4000
 
+/-- The faithful empty-committee throw. Over a zero-validator `default BeaconState` (at `slot :=
+1`, so the `state.slot != 0` underflow assert passes), `slot - 1`'s beacon committee is empty, so
+`getInclusionListCommittee` (reached through the record path) hits `assert (indices.size != 0)`
+and rejects. Pyspec raises `ZeroDivisionError` on the same `indices[i % 0]`. This pins the throw
+that the populated `pinRecordSatisfied` / `pinRecordRefuted` below deliberately avoid. `State` is
+FFI-backed (`FastBox`), so `native_decide`. -/
+private def pinCommitteeThrows : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Heze.BeaconState minimal) with slot := 1 })
+  let store := pinPilsStore false none
+  match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
+      (default : @EthCLSpecs.Heze.ExecutionPayload minimal) : PinM (Store treeMap)).run store with
+  | .ok _ _    => false
+  | .error _ _ => true
+example : pinCommitteeThrows = true := by native_decide
+
+/-- A minimal populated `BeaconState`: `SLOTS_PER_EPOCH` active validators at `slot := 1`. Enough
+that slot-0's beacon committee is non-empty (`computeCommittee` takes the shuffled slice
+`[0, N // SLOTS_PER_EPOCH) = [0, 1)`), so the record path's `getInclusionListCommittee` clears its
+`assert (indices.size != 0)` instead of throwing. A `default` validator has `exitEpoch = 0`, hence
+inactive, so only `exitEpoch := farFutureEpoch` is overridden (`is_active_validator` needs
+`activationEpoch ≤ epoch < exitEpoch`, and `activationEpoch` is already `0`). Effective balance is
+irrelevant here: `computeCommittee` is a plain shuffled slice, not balance-weighted. The registry
+is pushed onto the empty `base.validators` so the `SSZList` element type is inferred, never spelled.
+-/
+private def pinPopulatedState : @EthCLSpecs.Heze.BeaconState minimal :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  let base := (default : @EthCLSpecs.Heze.BeaconState minimal)
+  let activeValidator : Validator := { (default : Validator) with exitEpoch := Const.farFutureEpoch }
+  let vals := (Array.replicate Const.slotsPerEpoch activeValidator).foldl (·.push ·) base.validators
+  { base with slot := 1, validators := vals }
+
 /-- `record_payload_inclusion_list_satisfaction` records the engine verdict at `root`: with
-the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. The slot-0
-`state` also sends execution down the underflow-guard branch (no previous slot, so the
-required set is empty and `getInclusionListTransactions` is never reached). Note the pinned
-value alone does not discriminate that guard: with an empty store and the optimistic oracle
-the verdict is `true` either way. What this pin fixes is the record path writing the verdict
-at the right key.
+the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. `slot := 1` clears the
+faithful `state.slot != 0` underflow assert, and the populated validator set (`pinPopulatedState`)
+gives `slot - 1` a non-empty beacon committee, so the record path runs end-to-end through
+`getInclusionListCommittee` without hitting its empty-committee throw. The recorded verdict is
+`true` regardless of the required transactions (the optimistic oracle ignores `ilTxs`), so what
+this pin fixes is the record path writing the verdict at the right key.
 
 Lean mechanics: the forkdef wants the boxed `State` (`State = SSZ.Box HasherTag.H
-BeaconState`), so `state` is a `FastBox` of the default minimal `BeaconState`. `FastBox` is
+BeaconState`), so `state` is a `FastBox` of `pinPopulatedState`. `FastBox` is
 FFI-backed, so this is a `native_decide` `example` (`Lean.ofReduceBool`). -/
 private def pinRecordSatisfied : Option Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
   letI : HasherTag := fastHasherTag
-  -- Slot 1 (not 0): the faithful `assert state.slot != 0` passes, and `state.slot - 1 = 0`
-  -- with an empty inclusion-list store yields an empty required set, so the optimistic oracle
-  -- still records `true` — now exercised through the (throwing) record path.
-  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Heze.BeaconState minimal) with slot := 1 })
+  let state : State := SSZ.FastBox pinPopulatedState
   let store := pinPilsStore false none
   match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
-      (default : @EthCLSpecs.Heze.ExecutionPayload minimal) :
-      EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) (Store treeMap)).run store with
+      (default : @EthCLSpecs.Heze.ExecutionPayload minimal) : PinM (Store treeMap)).run store with
   | .ok after _ => FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
   | .error _ _  => none
 example : pinRecordSatisfied = some true := by native_decide
@@ -598,19 +643,18 @@ private def pinRecordRefuted : Option Bool × Bool :=
   letI : HasherTag := fastHasherTag
   letI : ExecutionEngine (@EthCLSpecs.Heze.ExecutionPayload minimal) Transaction :=
     { isInclusionListSatisfied := fun _ _ => false }
-  -- Slot 1 so the faithful underflow assert passes (see `pinRecordSatisfied`).
-  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Heze.BeaconState minimal) with slot := 1 })
+  -- Slot 1 clears the faithful underflow assert and the populated set clears the empty-committee
+  -- throw (see `pinRecordSatisfied` / `pinPopulatedState`).
+  let state : State := SSZ.FastBox pinPopulatedState
   let store := pinPilsStore true none
-  Id.run do
-    match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
-        (default : @EthCLSpecs.Heze.ExecutionPayload minimal) :
-        EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) (Store treeMap)).run store with
-    | .error _ _  => return (none, false)
-    | .ok after _ =>
-      match (isPayloadInclusionListSatisfied (map := treeMap) after pinPilsRoot :
-          EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) Bool).run after with
-      | .ok gate _  => return (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot, gate)
-      | .error _ _  => return (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot, false)
+  match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
+      (default : @EthCLSpecs.Heze.ExecutionPayload minimal) : PinM (Store treeMap)).run store with
+  | .error _ _  => (none, false)
+  | .ok after _ =>
+    let recorded := FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
+    match (isPayloadInclusionListSatisfied (map := treeMap) after pinPilsRoot : PinM Bool).run after with
+    | .ok gate _  => (recorded, gate)
+    | .error _ _  => (recorded, false)
 -- refuting oracle ⇒ recorded `false`, and the gate rejects the verified payload.
 example : pinRecordRefuted = (some false, false) := by native_decide
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -190,17 +190,21 @@ forkdef processInclusionList (store : InclusionListStore map) (inclusionList : I
 `slot` in committee-index order, then take the first `INCLUSION_LIST_COMMITTEE_SIZE` members
 cyclically (`cyclicSample`, in `Heze/Committees.lean`). Relocated from the beacon-state accessors
 into this store-throwing block beside its sole caller `getInclusionListTransactions`: the spec's
-`indices[i % len(indices)]` raises `ZeroDivisionError` when the slot has no committee members, so
-`assert (indices.size != 0)` throws the fork-choice reject rather than silently sampling a
-`default`. `state` stays an explicit parameter (the accessor reads `state`, not the store), and
-the block's `[MonadExceptOf StoreTransitionError]` resolves `assert` to the store reject. -/
+`indices[i % len(indices)]` raises `ZeroDivisionError` when the slot has no committee members.
+That is an uncaught fault (the reference runner catches only `AssertionError` / `IndexError`), so
+the empty case throws `.transition (.arithmetic …)` (a `uncaughtFault`, NOT an expected rejection)
+rather than a caught `.assert`, matching how `balanceAfterWithdrawals` models the sibling `uint64`
+fault, and rather than silently sampling a `default`. `state` stays an explicit parameter (the
+accessor reads `state`, not the store). -/
 forkdef getInclusionListCommittee (state : State) (slot : Slot) :
     StoreTransition (Vector ValidatorIndex Const.inclusionListCommitteeSize) := do
   let epoch := computeEpochAtSlot slot
   let committeesPerSlot := getCommitteeCountPerSlot state epoch
   let indices := (Array.range committeesPerSlot).foldl
     (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
-  assert (indices.size != 0)
+  if indices.size == 0 then
+    throw (StoreTransitionError.transition
+      (.arithmetic "get_inclusion_list_committee: indices[i % len(indices)] on an empty committee"))
   pure (cyclicSample indices Const.inclusionListCommitteeSize)
 
 /-- `get_inclusion_list_transactions(store, state, slot, only_timely=True)`
@@ -385,11 +389,14 @@ True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
 `[ExecutionEngine]` seam (the spec's `execution_engine` argument, modeled injectably). -/
 forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
     (payload : ExecutionPayload) : StoreTransition (Store map) := do
-  -- The spec reads `Slot(state.slot - 1)`, a `uint64` subtraction that raises on a slot-0
-  -- state (invalidating the whole envelope). Assert `state.slot != 0` rather than silently
-  -- substituting an empty required set.
+  -- The spec reads `Slot(state.slot - 1)`, a `uint64` subtraction that raises `ValueError` on a
+  -- slot-0 state (invalidating the whole envelope). That fault is uncaught by the reference
+  -- runner, so throw `.transition (.arithmetic …)` (a `uncaughtFault`, not an expected rejection),
+  -- matching `balanceAfterWithdrawals`, rather than a caught `.assert` or a silent empty set.
   let stateSlot := sszGet state slot
-  assert (stateSlot != 0)
+  if stateSlot == 0 then
+    throw (StoreTransitionError.transition
+      (.arithmetic "record_payload_inclusion_list_satisfaction: Slot(state.slot - 1) underflow at slot 0"))
   let ilTxs ← getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
   let satisfied := isInclusionListSatisfied payload ilTxs
   pure { store with
@@ -581,10 +588,12 @@ private def pinIlDueMs : UInt64 :=
 #guard pinIlDueMs = 4000
 
 /-- The faithful empty-committee throw. Over a zero-validator `default BeaconState` (at `slot :=
-1`, so the `state.slot != 0` underflow assert passes), `slot - 1`'s beacon committee is empty, so
-`getInclusionListCommittee` (reached through the record path) hits `assert (indices.size != 0)`
-and rejects. Pyspec raises `ZeroDivisionError` on the same `indices[i % 0]`. This pins the throw
-that the populated `pinRecordSatisfied` / `pinRecordRefuted` below deliberately avoid. `State` is
+1`, so the `state.slot != 0` underflow throw does not fire), `slot - 1`'s beacon committee is
+empty, so `getInclusionListCommittee` (reached through the record path) hits the empty-committee
+guard and rejects. Pyspec raises `ZeroDivisionError` on the same `indices[i % 0]`, an uncaught
+fault, so the pin checks the reject is NOT an expected rejection (a `.transition (.arithmetic …)`,
+not a caught `.assert`), the property a regression to `assert` would break. This is the throw the
+populated `pinRecordSatisfied` / `pinRecordRefuted` below deliberately avoid. `State` is
 FFI-backed (`FastBox`), so `native_decide`. -/
 private def pinCommitteeThrows : Bool :=
   letI : Preset := minimal
@@ -595,13 +604,13 @@ private def pinCommitteeThrows : Bool :=
   match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
       (default : @EthCLSpecs.Heze.ExecutionPayload minimal) : PinM (Store treeMap)).run store with
   | .ok _ _    => false
-  | .error _ _ => true
+  | .error e _ => !e.isExpectedRejection
 example : pinCommitteeThrows = true := by native_decide
 
 /-- A minimal populated `BeaconState`: `SLOTS_PER_EPOCH` active validators at `slot := 1`. Enough
 that slot-0's beacon committee is non-empty (`computeCommittee` takes the shuffled slice
 `[0, N // SLOTS_PER_EPOCH) = [0, 1)`), so the record path's `getInclusionListCommittee` clears its
-`assert (indices.size != 0)` instead of throwing. A `default` validator has `exitEpoch = 0`, hence
+empty-committee guard instead of throwing. A `default` validator has `exitEpoch = 0`, hence
 inactive, so only `exitEpoch := farFutureEpoch` is overridden (`is_active_validator` needs
 `activationEpoch ≤ epoch < exitEpoch`, and `activationEpoch` is already `0`). Effective balance is
 irrelevant here: `computeCommittee` is a plain shuffled slice, not balance-weighted. The registry
@@ -617,7 +626,7 @@ private def pinPopulatedState : @EthCLSpecs.Heze.BeaconState minimal :=
 
 /-- `record_payload_inclusion_list_satisfaction` records the engine verdict at `root`: with
 the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. `slot := 1` clears the
-faithful `state.slot != 0` underflow assert, and the populated validator set (`pinPopulatedState`)
+`state.slot != 0` underflow throw, and the populated validator set (`pinPopulatedState`)
 gives `slot - 1` a non-empty beacon committee, so the record path runs end-to-end through
 `getInclusionListCommittee` without hitting its empty-committee throw. The recorded verdict is
 `true` regardless of the required transactions (the optimistic oracle ignores `ilTxs`), so what

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -93,6 +93,15 @@ section
 
 variable [Preset] [HasherTag] [Config] {map : MapKind} [FcMap map]
 
+-- The store-transition monad, minus `MonadStateOf`: the inclusion-list helpers below thread the
+-- (sub-)store explicitly rather than through `get`, so they need only `Monad` plus the store
+-- reject to throw (`FcMap.getOrThrow`'s `missingKey`). Leaving `MonadStateOf` off lets the
+-- vectorless pins run them in plain `Except StoreTransitionError`, with no dummy `Store` to
+-- `.run` over. A concrete fork-choice monad (the one `fork_choice_section` opens below) still
+-- satisfies these two, so the store handlers bind these helpers with `←` unchanged.
+variable {StoreTransition : Type → Type} [Monad StoreTransition]
+variable [MonadExceptOf StoreTransitionError StoreTransition]
+
 /-- The empty `InclusionListStore`: no stored lists, no timeliness, no equivocators.
 `getForkchoiceStore` seeds the folded-in `Store` field with it. The spec has no counterpart
 line: there the store is the lazily-created `get_inclusion_list_store()` singleton (see the
@@ -111,21 +120,31 @@ without building a `BeaconState` for the committee key, the same reason `cyclicS
 factored out in `Committees`. The dedup keeps each transaction's first occurrence
 (`arrayUnion`): the spec's `list(set(transactions))` keeps each transaction once and calls
 the order irrelevant, so a deterministic representative lets `#guard` pin the result.
-`timeliness[ilRoot]` is a plain dict read in the spec; the `.getD false` default here is
-unreachable on the spec path, because `process_inclusion_list` writes every stored list and
-its timeliness entry together. -/
+`inclusion_list_timeliness` is a plain `Dict` in the spec (`inclusion-list.md:34`), so
+`timeliness[ilRoot]` raises `KeyError` on a miss: `FcMap.getOrThrow` (→ `missingKey`), throwing,
+in place of the old `lookupD false` default. The read is *conditional*: the comprehension's
+`and`/`or` short-circuit reaches `timeliness[il_root]` only for a non-equivocator's list and
+only when `only_timely` is set, so the guards below run in that exact order. Unreachable on
+the spec path either way, where `process_inclusion_list` writes every stored list and its
+timeliness entry together, so every stored `ilRoot` has an entry. -/
 private def collectInclusionListTransactions (inclusionLists : map Root InclusionList)
     (equivocators : Array ValidatorIndex) (timeliness : map Root Bool) (onlyTimely : Bool) :
-    Array Transaction :=
-  -- One `FcMap.fold` pass: each stored `(ilRoot, il)` goes straight to the filter, with no
-  -- second `lookup` and no dead `none` branch.
-  let collected : Array Transaction :=
-    FcMap.fold (fun acc ilRoot il =>
-      let timely := FcMap.lookupD timeliness ilRoot
-      if !equivocators.contains il.validatorIndex && (!onlyTimely || timely) then
-        acc ++ il.transactions.toArray
-      else acc) #[] inclusionLists
-  arrayUnion #[] collected
+    StoreTransition (Array Transaction) := do
+  -- Gather the stored `(ilRoot, il)` entries in the map's fold order first (a pure pass);
+  -- the fold order feeds the `arrayUnion` dedup below, so it is preserved. The throwing
+  -- timeliness read then runs per entry, inside the comprehension's own guard order.
+  let entries : Array (Root × InclusionList) :=
+    FcMap.fold (fun acc ilRoot il => acc.push (ilRoot, il)) #[] inclusionLists
+  let collected ← entries.foldlM (init := (#[] : Array Transaction)) fun acc (ilRoot, il) => do
+    -- The condition is `validator_index not in store.equivocators[key] and (not only_timely
+    -- or store.inclusion_list_timeliness[il_root])`: `and`/`or` short-circuit, so the
+    -- (raising) timeliness read runs last, and only when it can decide the outcome.
+    if equivocators.contains il.validatorIndex then pure acc
+    else if !onlyTimely then pure (acc ++ il.transactions.toArray)
+    else
+      let timely ← FcMap.getOrThrow timeliness ilRoot
+      if timely then pure (acc ++ il.transactions.toArray) else pure acc
+  pure (arrayUnion #[] collected)
 
 /-- `process_inclusion_list(store, inclusion_list, is_timely)`
 (`consensus-specs/specs/heze/inclusion-list.md:57-82`): file a newly-received inclusion list,
@@ -175,17 +194,17 @@ that key, then run the comprehension (here `collectInclusionListTransactions`). 
 `Array` for the spec's `Sequence[Transaction]`; the dedup leaves order unspecified, as the
 spec notes. -/
 forkdef getInclusionListTransactions (store : InclusionListStore map) (state : State)
-    (slot : Slot) (onlyTimely : Bool := true) : Array Transaction :=
+    (slot : Slot) (onlyTimely : Bool := true) : StoreTransition (Array Transaction) :=
   let committee := getInclusionListCommittee state slot
   let key := htr committee
   -- `inclusion_lists` and `equivocators` are `DefaultDict`s (inclusion-list.md:31,35): the
   -- spec's `[key]` auto-creates an empty entry on a miss, so the defaults here are faithful.
   let inclusionLists := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
   let equivocators := FcMap.lookupD store.equivocators key
-  -- TODO(#6): still to make spec-faithful — the `timeliness[ilRoot]` plain-`Dict` read inside
-  -- `collectInclusionListTransactions` and `cyclicSample`'s empty-committee `i % 0` in
-  -- `getInclusionListCommittee` must throw (both are unreachable, but faithfulness is required).
-  -- Deferred only because converting them reworks their kernel `#guard` pins; next follow-up.
+  -- TODO(#6): `getInclusionListCommittee`'s empty-committee `indices[i % 0]` (a spec
+  -- `ZeroDivisionError`) is still modeled total. Making it throw reworks the record pins to a
+  -- non-empty-committee state, so it lands as a focused follow-up. The `timeliness` plain-`Dict`
+  -- read is now faithful: `collectInclusionListTransactions` below throws on a miss.
   collectInclusionListTransactions inclusionLists equivocators store.inclusionListTimeliness onlyTimely
 
 end
@@ -356,7 +375,7 @@ forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : Stat
   -- substituting an empty required set.
   let stateSlot := sszGet state slot
   assert (stateSlot != 0)
-  let ilTxs := getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
+  let ilTxs ← getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
   let satisfied := isInclusionListSatisfied payload ilTxs
   pure { store with
       payloadInclusionListSatisfaction := FcMap.insert store.payloadInclusionListSatisfaction root satisfied }
@@ -718,10 +737,15 @@ private def pinTimeliness : treeMap Root Bool :=
   FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot true) pinAltRoot false
 
 /-- Run the comprehension over `pinLists` / `pinTimeliness` under the minimal preset, so the
-hash-free `#guard`s below need no ambient instance. -/
+hash-free `#guard`s below need no ambient instance. `collectInclusionListTransactions` now throws
+(the `timeliness` plain-`Dict` read), so it runs in `Except StoreTransitionError`; `pinTimeliness`
+carries an entry for every `pinLists` key, so the `.error` branch is unreachable here. -/
 private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) : Array Transaction :=
   letI : Preset := minimal
-  collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely
+  match (collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely :
+      Except StoreTransitionError (Array Transaction)) with
+  | .ok txs  => txs
+  | .error _ => #[]
 
 -- No equivocators, timeliness ignored: union of {0xAA} and {0xAA, 0xBB}, deduped to two.
 #guard (pinCollect #[] false).size = 2

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -414,9 +414,10 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
     let store ← recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
     -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written
     -- together here (the satisfaction key via `recordPayloadInclusionListSatisfaction` just
-    -- above). Keep it that way: `isPayloadInclusionListSatisfied`'s default-false-on-miss is
-    -- sound only because a verified `root` (present in `payloads`) always carries a
-    -- satisfaction entry.
+    -- above). Keep it that way: `isPayloadInclusionListSatisfied` opens with the spec's
+    -- `assert root in store.payload_inclusion_list_satisfaction` (a throwing `getOrAssert`),
+    -- and this pairing is what keeps that reject unreachable for any verified `root`
+    -- (present in `payloads`).
     set { store with
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -432,31 +432,39 @@ inherit onAttesterSlashing
 `[New in Heze:EIP7805]` fields seeded empty: `payloadInclusionListSatisfaction` as an empty
 map (`fork-choice.md:165`) and `inclusionListStore` as the empty `InclusionListStore` (no
 spec counterpart; the spec's store is a process-lifetime singleton, folded into `Store` here,
-see the `InclusionListStore` docstring). The rest is Gloas verbatim. -/
-forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) : Store map :=
+see the `InclusionListStore` docstring). The rest is Gloas verbatim, including the opening
+`assert anchor_block.state_root == hash_tree_root(anchor_state)` (`fork-choice.md:141`), so the
+seed is a throwing `Except StoreTransitionError` action rather than a total store literal.
+`pinAnchorRejects` below locks the reject branch. -/
+forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
+    Except StoreTransitionError (Store map) := do
+  -- `anchor_block.state_root == hash_tree_root(anchor_state)`: the boxed state hashes
+  -- through `stateRoot` (the cached-tree path), not `htr` (which wants a bare `SSZRepr`).
+  assert (anchorBlock.stateRoot == bytesToRoot (stateRoot anchorState).1)
   let anchorRoot := htr anchorBlock
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
 
-  { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
-    genesisTime := sszGet anchorState genesisTime
-    justifiedCheckpoint := cp, finalizedCheckpoint := cp
-    unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
-    proposerBoostRoot := fcZeroRoot
-    equivocatingIndices := #[]
-    blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
-    blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
-    blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
-    checkpointStates := FcMap.insert FcMap.empty cp anchorState
-    latestMessages := FcMap.empty
-    unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
-    payloads := FcMap.empty
-    payloadTimelinessVote := FcMap.empty
-    payloadDataAvailabilityVote := FcMap.empty
-    -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the INVARIANT
-    -- note in `onExecutionPayloadEnvelope`: the two maps are always written together).
-    payloadInclusionListSatisfaction := FcMap.empty
-    inclusionListStore := InclusionListStore.empty }
+  pure
+    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+      genesisTime := sszGet anchorState genesisTime
+      justifiedCheckpoint := cp, finalizedCheckpoint := cp
+      unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
+      proposerBoostRoot := fcZeroRoot
+      equivocatingIndices := #[]
+      blocks := FcMap.insert FcMap.empty anchorRoot anchorBlock
+      blockStates := FcMap.insert FcMap.empty anchorRoot anchorState
+      blockTimeliness := FcMap.insert FcMap.empty anchorRoot #[true, true]
+      checkpointStates := FcMap.insert FcMap.empty cp anchorState
+      latestMessages := FcMap.empty
+      unrealizedJustifications := FcMap.insert FcMap.empty anchorRoot cp
+      payloads := FcMap.empty
+      payloadTimelinessVote := FcMap.empty
+      payloadDataAvailabilityVote := FcMap.empty
+      -- [New in Heze:EIP7805] seeded empty in lockstep with `payloads` above (the INVARIANT
+      -- note in `onExecutionPayloadEnvelope`: the two maps are always written together).
+      payloadInclusionListSatisfaction := FcMap.empty
+      inclusionListStore := InclusionListStore.empty }
 
 /-- `get_inclusion_list_due_ms()` (`consensus-specs/specs/heze/fork-choice.md:242-243`):
 `get_slot_component_duration_ms(INCLUSION_LIST_DUE_BPS)`. `bpsDeadlineMs` (inherited from Gloas)
@@ -801,5 +809,21 @@ private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) : Arra
 -- Equivocator 6 is filtered out regardless of timeliness, leaving just {0xAA}.
 #guard (pinCollect #[6] false).size = 1
 #guard (pinCollect #[6] false).contains (pinTx 0xAA)
+
+/-- Vectorless reject pin for `get_forkchoice_store`'s opening assert
+(`assert anchor_block.state_root == hash_tree_root(anchor_state)`, `fork-choice.md:141`). The
+default block's all-zero `stateRoot` cannot equal `hash_tree_root` of the default state (a
+non-zero SHA-256 digest), so the seed takes the reject branch and returns `.error`;
+`toOption.isNone` reads that verdict. No conformance vector reaches the mismatch (the harness
+derives anchor block + state from one vector, so `state_root` always matches), so this pin is
+the only witness of the throw. Computes `hash_tree_root` (FFI `Sha256`) → `native_decide`. The
+Fulu and Gloas constructors carry the textually-identical assert. -/
+private def pinAnchorRejects : Bool :=
+  letI : Preset := minimal
+  letI : Config := minimalConfig
+  letI : HasherTag := fastHasherTag
+  (getForkchoiceStore (SSZ.FastBox (default : @BeaconState minimal))
+      (default : @BeaconBlock minimal) (map := treeMap)).toOption.isNone
+example : pinAnchorRejects = true := by native_decide
 
 end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -354,6 +354,7 @@ inherit onTick
 inherit recordBlockTimeliness
 inherit updateProposerBoostRoot
 inherit recordPtcVotes
+inherit onPayloadAttestationMessage
 inherit notifyPtcMessages
 inherit onBlock
 inherit computeTimeAtSlot
@@ -420,7 +421,6 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
 
-inherit onPayloadAttestationMessage
 inherit storeTargetCheckpointState
 inherit validateOnAttestation
 inherit updateLatestMessages

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -289,11 +289,11 @@ inherit isPreviousSlotPayloadDecision
 /-- `is_payload_inclusion_list_satisfied(store, root)`
 (`consensus-specs/specs/heze/fork-choice.md:199-212`): whether the payload for `root`
 satisfied the inclusion-list constraints and is locally available. The spec opens with
-`assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot
-throw, so a missing key reads as `false` through `lookupD` (the same default-on-miss the
-sibling `payloadTimeliness` uses). The default is unreachable on the spec path, because
-`onExecutionPayloadEnvelope` always writes `payloads` and the satisfaction entry together;
-the INVARIANT note there is the canonical statement of that argument. -/
+`assert root in store.payload_inclusion_list_satisfaction`; the predicate throws that `assert`
+on a missing key (`StoreTransition Bool`), matching the spec's reject. The assert is unreachable
+on the spec path, because `onExecutionPayloadEnvelope` always writes `payloads` and the
+satisfaction entry together; the INVARIANT note there is the canonical statement of that
+argument. -/
 forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : StoreTransition Bool := do
   -- The spec opens with `assert root in store.payload_inclusion_list_satisfaction`; that fires
   -- (rejecting) even when the payload is unverified, so it precedes the verified check. The

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -178,8 +178,14 @@ forkdef getInclusionListTransactions (store : InclusionListStore map) (state : S
     (slot : Slot) (onlyTimely : Bool := true) : Array Transaction :=
   let committee := getInclusionListCommittee state slot
   let key := htr committee
+  -- `inclusion_lists` and `equivocators` are `DefaultDict`s (inclusion-list.md:31,35): the
+  -- spec's `[key]` auto-creates an empty entry on a miss, so the defaults here are faithful.
   let inclusionLists := (FcMap.lookup store.inclusionLists key).getD FcMap.empty
   let equivocators := FcMap.lookupD store.equivocators key
+  -- TODO(#6): still to make spec-faithful — the `timeliness[ilRoot]` plain-`Dict` read inside
+  -- `collectInclusionListTransactions` and `cyclicSample`'s empty-committee `i % 0` in
+  -- `getInclusionListCommittee` must throw (both are unreachable, but faithfulness is required).
+  -- Deferred only because converting them reworks their kernel `#guard` pins; next follow-up.
   collectInclusionListTransactions inclusionLists equivocators store.inclusionListTimeliness onlyTimely
 
 end
@@ -255,27 +261,42 @@ throw, so a missing key reads as `false` through `lookupD` (the same default-on-
 sibling `payloadTimeliness` uses). The default is unreachable on the spec path, because
 `onExecutionPayloadEnvelope` always writes `payloads` and the satisfaction entry together;
 the INVARIANT note there is the canonical statement of that argument. -/
-forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : Bool :=
-  isPayloadVerified store root && FcMap.lookupD store.payloadInclusionListSatisfaction root
+forkdef isPayloadInclusionListSatisfied (store : Store map) (root : Root) : StoreTransition Bool := do
+  -- The spec opens with `assert root in store.payload_inclusion_list_satisfaction`; that fires
+  -- (rejecting) even when the payload is unverified, so it precedes the verified check. The
+  -- later `[root]` read is then over a present key, so assert and read fuse into one
+  -- `getOrAssert` (an `.assert` reject on a miss).
+  let satisfied ← FcMap.getOrAssert store.payloadInclusionListSatisfaction root
+    "root in store.payload_inclusion_list_satisfaction"
+  if !isPayloadVerified store root then pure false
+  else pure satisfied
 
 /-- `should_extend_payload(store, root)` (Heze override,
 `consensus-specs/specs/heze/fork-choice.md:221-236`): the Gloas body with the one new
 inclusion-list gate. After the `is_payload_verified` check, a payload that fails the
 inclusion-list constraints is not extended (`fork-choice.md:226`). The rest is Gloas verbatim.
 -/
-forkdef shouldExtendPayload (store : Store map) (root : Root) : Bool :=
-  if !isPayloadVerified store root then false
+forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition Bool := do
+  -- Mirrors the (now-throwing) Gloas body plus the inclusion-list gate: the spec opens with
+  -- `assert store.blocks[root].slot + 1 == get_current_slot(store)`.
+  let rootBlock ← FcMap.getOrThrow store.blocks root
+  assert (rootBlock.slot + 1 == getCurrentSlot store)
+  if !isPayloadVerified store root then pure false
   -- [New in Heze:EIP7805] do not extend a payload that fails the inclusion-list constraints
-  else if !isPayloadInclusionListSatisfied store root then false
+  else if !(← isPayloadInclusionListSatisfied store root) then pure false
   else
     let proposerRoot := store.proposerBoostRoot
-    let payloadIsTimely := payloadTimeliness store root true
-    let payloadDataIsAvailable := payloadDataAvailability store root true
-    (payloadIsTimely && payloadDataIsAvailable)
-      || proposerRoot == fcZeroRoot
-      || (match FcMap.lookup store.blocks proposerRoot with
-          | some pb => pb.parentRoot != root || isParentNodeFull store pb
-          | none    => true)
+    let payloadIsTimely ← payloadTimeliness store root true
+    let payloadDataIsAvailable ← payloadDataAvailability store root true
+    if (payloadIsTimely && payloadDataIsAvailable) || proposerRoot == fcZeroRoot then
+      pure true
+    else
+      let pb ← FcMap.getOrThrow store.blocks proposerRoot
+      -- Python's final `or` short-circuits: `is_parent_node_full` (whose
+      -- `store.blocks[pb.parent_root]` read now throws) never runs when
+      -- `pb.parent_root != root` already decides the disjunction (Gloas parity).
+      if pb.parentRoot != root then pure true
+      else isParentNodeFull store pb
 
 inherit getPayloadStatusTiebreaker
 inherit committeeWeight
@@ -329,15 +350,15 @@ transactions are read for the previous slot (`state.slot - 1`) at the default `o
 True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
 `[ExecutionEngine]` seam (the spec's `execution_engine` argument, modeled injectably). -/
 forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
-    (payload : ExecutionPayload) : Store map :=
-  -- The spec reads `Slot(state.slot - 1)`, which assumes `state.slot ≥ 1` (a genesis/slot-0 state
-  -- never reaches a payload envelope). Guard the `UInt64` underflow explicitly: at slot 0 there is
-  -- no previous slot, so no inclusion-list transactions are required.
+    (payload : ExecutionPayload) : StoreTransition (Store map) := do
+  -- The spec reads `Slot(state.slot - 1)`, a `uint64` subtraction that raises on a slot-0
+  -- state (invalidating the whole envelope). Assert `state.slot != 0` rather than silently
+  -- substituting an empty required set.
   let stateSlot := sszGet state slot
-  let ilTxs := if stateSlot == 0 then #[]
-               else getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
+  assert (stateSlot != 0)
+  let ilTxs := getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
   let satisfied := isInclusionListSatisfied payload ilTxs
-  { store with
+  pure { store with
       payloadInclusionListSatisfaction := FcMap.insert store.payloadInclusionListSatisfaction root satisfied }
 
 /-- `on_execution_payload_envelope` (Heze override,
@@ -349,13 +370,14 @@ state from `verify_execution_payload_envelope` is kept only for `blockStates`. -
 forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) : StoreTransition Unit := do
   let store ← get
   let envelope := signedEnv.message
-  let state ← FcMap.getOrThrow store.blockStates envelope.beaconBlockRoot
+  let state ← FcMap.getOrAssert store.blockStates envelope.beaconBlockRoot
+    "envelope.beacon_block_root in store.block_states"
 
   match verifyExecutionPayloadEnvelope state signedEnv with
   | .error e => throw e
   | .ok warm =>
     -- [New in Heze:EIP7805] record whether the payload satisfies the inclusion-list constraints
-    let store := recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
+    let store ← recordPayloadInclusionListSatisfaction store state envelope.beaconBlockRoot envelope.payload
     -- INVARIANT: `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written
     -- together here (the satisfaction key via `recordPayloadInclusionListSatisfaction` just
     -- above). Keep it that way: `isPayloadInclusionListSatisfied`'s default-false-on-miss is
@@ -440,6 +462,10 @@ The pin fixes the recorded bit by hand rather than through the engine, so the
 `isInclusionListSatisfied` verdict itself is out of its reach; `pinRecordRefuted` below
 drives that refuting branch through the record path into this gate. -/
 
+/-- The pins' concrete fork-choice monad: the minimal preset over the deterministic
+`treeMap` and the FFI hasher, the annotation every pin's `.run` otherwise repeats. -/
+private abbrev PinM := EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag)
+
 private def pinPilsRoot : Root := Vector.replicate 32 9
 
 /-- A minimal Heze `Store` exercising `isPayloadInclusionListSatisfied` at `pinPilsRoot`.
@@ -475,20 +501,24 @@ private def pinPilsStore (payloadPresent : Bool) (recorded : Option Bool) :
 /-- The predicate's verdict on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
 preset / hasher the `forkdef` parameters want (Lean re-synthesizes them rather than reading the
 store's fixed type), the same pattern the `InclusionListStore` pins in this file use. -/
-private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Bool :=
+private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Option Bool :=
   letI : Preset := minimal
   letI : HasherTag := fastHasherTag
-  isPayloadInclusionListSatisfied (pinPilsStore payloadPresent recorded) pinPilsRoot
+  let store := pinPilsStore payloadPresent recorded
+  -- Run the now-throwing predicate concretely; `none` marks the `assert root ∈ …` reject.
+  match (isPayloadInclusionListSatisfied (map := treeMap) store pinPilsRoot : PinM Bool).run store with
+  | .ok b _    => some b
+  | .error _ _ => none
 
 -- verified + recorded `false` ⇒ `false` (do not extend this payload).
-#guard pinPils true (some false) = false
+#guard pinPils true (some false) = some false
 -- verified + recorded `true` ⇒ `true`.
-#guard pinPils true (some true) = true
+#guard pinPils true (some true) = some true
 -- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
-#guard pinPils false (some true) = false
--- verified but no recorded entry ⇒ `false` via the `lookupD` default (a state the spec's
--- own invariant rules out; the INVARIANT note in `onExecutionPayloadEnvelope`).
-#guard pinPils true none = false
+#guard pinPils false (some true) = some false
+-- verified but no recorded entry ⇒ the spec's `assert root ∈ payload_inclusion_list_satisfaction`
+-- now *rejects* (a state the invariant rules out) rather than reading a `lookupD` default.
+#guard pinPils true none = none
 
 /-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
 
@@ -523,10 +553,16 @@ private def pinRecordSatisfied : Option Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
   letI : HasherTag := fastHasherTag
-  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
-  let after := recordPayloadInclusionListSatisfaction (pinPilsStore false none) state pinPilsRoot
-    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
-  FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
+  -- Slot 1 (not 0): the faithful `assert state.slot != 0` passes, and `state.slot - 1 = 0`
+  -- with an empty inclusion-list store yields an empty required set, so the optimistic oracle
+  -- still records `true` — now exercised through the (throwing) record path.
+  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Heze.BeaconState minimal) with slot := 1 })
+  let store := pinPilsStore false none
+  match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
+      (default : @EthCLSpecs.Heze.ExecutionPayload minimal) :
+      EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) (Store treeMap)).run store with
+  | .ok after _ => FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
+  | .error _ _  => none
 example : pinRecordSatisfied = some true := by native_decide
 
 /-- The discriminating counterpart to `pinRecordSatisfied`: the same record path under a
@@ -543,11 +579,19 @@ private def pinRecordRefuted : Option Bool × Bool :=
   letI : HasherTag := fastHasherTag
   letI : ExecutionEngine (@EthCLSpecs.Heze.ExecutionPayload minimal) Transaction :=
     { isInclusionListSatisfied := fun _ _ => false }
-  let state : State := SSZ.FastBox (default : @EthCLSpecs.Heze.BeaconState minimal)
-  let after := recordPayloadInclusionListSatisfaction (pinPilsStore true none) state pinPilsRoot
-    (default : @EthCLSpecs.Heze.ExecutionPayload minimal)
-  (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot,
-   isPayloadInclusionListSatisfied after pinPilsRoot)
+  -- Slot 1 so the faithful underflow assert passes (see `pinRecordSatisfied`).
+  let state : State := SSZ.FastBox ({ (default : @EthCLSpecs.Heze.BeaconState minimal) with slot := 1 })
+  let store := pinPilsStore true none
+  Id.run do
+    match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
+        (default : @EthCLSpecs.Heze.ExecutionPayload minimal) :
+        EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) (Store treeMap)).run store with
+    | .error _ _  => return (none, false)
+    | .ok after _ =>
+      match (isPayloadInclusionListSatisfied (map := treeMap) after pinPilsRoot :
+          EStateM StoreTransitionError (@Store minimal treeMap fastHasherTag) Bool).run after with
+      | .ok gate _  => return (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot, gate)
+      | .error _ _  => return (FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot, false)
 -- refuting oracle ⇒ recorded `false`, and the gate rejects the verified payload.
 example : pinRecordRefuted = (some false, false) := by native_decide
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -203,8 +203,7 @@ forkdef getInclusionListCommittee (state : State) (slot : Slot) :
   let indices := (Array.range committeesPerSlot).foldl
     (fun acc i => acc ++ getBeaconCommittee state slot i) (#[] : Array ValidatorIndex)
   if indices.size == 0 then
-    throw (StoreTransitionError.transition
-      (.arithmetic "get_inclusion_list_committee: indices[i % len(indices)] on an empty committee"))
+    throwArithmetic "get_inclusion_list_committee: indices[i % len(indices)] on an empty committee"
   pure (cyclicSample indices Const.inclusionListCommitteeSize)
 
 /-- `get_inclusion_list_transactions(store, state, slot, only_timely=True)`
@@ -394,14 +393,13 @@ True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
 forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
     (payload : ExecutionPayload) : StoreTransition (Store map) := do
   -- The spec reads `Slot(state.slot - 1)`, a `uint64` subtraction that raises `ValueError` on a
-  -- slot-0 state (invalidating the whole envelope). That fault is uncaught by the reference
-  -- runner, so throw `.transition (.arithmetic …)` (an `uncaughtFault`, not an expected rejection),
-  -- matching `balanceAfterWithdrawals`, rather than a caught `.assert` or a silent empty set.
+  -- slot-0 state (invalidating the whole envelope). The reference runner leaves that fault
+  -- uncaught, so it is `checkedSub`, the same operator `balanceAfterWithdrawals` reads its
+  -- underflow through. The reject arrives as `.transition (.arithmetic …)`, an `uncaughtFault`
+  -- rather than a caught `.assert` or a silent empty set.
   let stateSlot := sszGet state slot
-  if stateSlot == 0 then
-    throw (StoreTransitionError.transition
-      (.arithmetic "record_payload_inclusion_list_satisfaction: Slot(state.slot - 1) underflow at slot 0"))
-  let ilTxs ← getInclusionListTransactions store.inclusionListStore state (stateSlot - 1)
+  let prevSlot ← checkedSub stateSlot 1 "record_payload_inclusion_list_satisfaction: Slot(state.slot - 1)"
+  let ilTxs ← getInclusionListTransactions store.inclusionListStore state prevSlot
   let satisfied := isInclusionListSatisfied payload ilTxs
   pure { store with
       payloadInclusionListSatisfaction := FcMap.insert store.payloadInclusionListSatisfaction root satisfied }

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -192,7 +192,7 @@ cyclically (`cyclicSample`, in `Heze/Committees.lean`). Relocated from the beaco
 into this store-throwing block beside its sole caller `getInclusionListTransactions`: the spec's
 `indices[i % len(indices)]` raises `ZeroDivisionError` when the slot has no committee members.
 That is an uncaught fault (the reference runner catches only `AssertionError` / `IndexError`), so
-the empty case throws `.transition (.arithmetic …)` (a `uncaughtFault`, NOT an expected rejection)
+the empty case throws `.transition (.arithmetic …)` (an `uncaughtFault`, not an expected rejection)
 rather than a caught `.assert`, matching how `balanceAfterWithdrawals` models the sibling `uint64`
 fault, and rather than silently sampling a `default`. `state` stays an explicit parameter (the
 accessor reads `state`, not the store). -/
@@ -314,10 +314,12 @@ inclusion-list gate. After the `is_payload_verified` check, a payload that fails
 inclusion-list constraints is not extended (`fork-choice.md:226`). The rest is Gloas verbatim.
 -/
 forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition Bool := do
-  -- Mirrors the (now-throwing) Gloas body plus the inclusion-list gate: the spec opens with
+  -- Mirrors the Gloas body plus the inclusion-list gate: the spec opens with
   -- `assert store.blocks[root].slot + 1 == get_current_slot(store)`.
   let rootBlock ← FcMap.getOrThrow store.blocks root
-  assert (rootBlock.slot + 1 == getCurrentSlot store)
+  let currentSlot ← getCurrentSlot store
+  let nextSlot ← checkedAdd rootBlock.slot 1 "should_extend_payload: blocks[root].slot + 1"
+  assert (nextSlot == currentSlot)
   if !isPayloadVerified store root then pure false
   -- [New in Heze:EIP7805] do not extend a payload that fails the inclusion-list constraints
   else if !(← isPayloadInclusionListSatisfied store root) then pure false
@@ -330,7 +332,7 @@ forkdef shouldExtendPayload (store : Store map) (root : Root) : StoreTransition 
     else
       let pb ← FcMap.getOrThrow store.blocks proposerRoot
       -- Python's final `or` short-circuits: `is_parent_node_full` (whose
-      -- `store.blocks[pb.parent_root]` read now throws) never runs when
+      -- `store.blocks[pb.parent_root]` read throws) never runs when
       -- `pb.parent_root != root` already decides the disjunction (Gloas parity).
       if pb.parentRoot != root then pure true
       else isParentNodeFull store pb
@@ -353,7 +355,6 @@ inherit updateCheckpoints
 inherit updateUnrealizedCheckpoints
 inherit computePulledUpTip
 inherit onTickPerSlot
-inherit advanceStoreTime
 inherit onTick
 inherit recordBlockTimeliness
 inherit updateProposerBoostRoot
@@ -368,7 +369,10 @@ inherit verifyExecutionPayloadEnvelope
 -- The `is_inclusion_list_satisfied` verdict comes from an external EL over the Engine API
 -- (`consensus-specs/specs/heze/fork-choice.md:54-62`), so it enters through the framework's
 -- `[ExecutionEngine]` seam (`EthCLLib.Spec.Engine`, the canonical home of the optimistic-mock
--- rationale), instantiated at Heze's payload / transaction types.
+-- rationale), instantiated at Heze's payload / transaction types. Scoped to the three
+-- declarations that need it: at file scope the binder would ride on every later declaration,
+-- none of which calls the engine.
+section EngineSeam
 variable [ExecutionEngine ExecutionPayload Transaction]
 
 /-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
@@ -391,7 +395,7 @@ forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : Stat
     (payload : ExecutionPayload) : StoreTransition (Store map) := do
   -- The spec reads `Slot(state.slot - 1)`, a `uint64` subtraction that raises `ValueError` on a
   -- slot-0 state (invalidating the whole envelope). That fault is uncaught by the reference
-  -- runner, so throw `.transition (.arithmetic …)` (a `uncaughtFault`, not an expected rejection),
+  -- runner, so throw `.transition (.arithmetic …)` (an `uncaughtFault`, not an expected rejection),
   -- matching `balanceAfterWithdrawals`, rather than a caught `.assert` or a silent empty set.
   let stateSlot := sszGet state slot
   if stateSlot == 0 then
@@ -429,6 +433,8 @@ forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) 
       blockStates := FcMap.insert store.blockStates envelope.beaconBlockRoot warm,
       payloads := FcMap.insert store.payloads envelope.beaconBlockRoot envelope }
 
+end EngineSeam
+
 inherit storeTargetCheckpointState
 inherit validateOnAttestation
 inherit updateLatestMessages
@@ -453,8 +459,16 @@ forkdef getForkchoiceStore (anchorState : State) (anchorBlock : BeaconBlock) :
   let epoch := currentEpochOf anchorState
   let cp : Checkpoint := { epoch := epoch, root := anchorRoot }
 
+  -- `uint64(anchor_state.genesis_time + SLOT_DURATION_MS * anchor_state.slot // 1000)`
+  -- (`phase0/fork-choice.md:223`): both the product and the sum are checked. `anchor_state`
+  -- comes straight off the wire, so a slot at or above `2^64 / SLOT_DURATION_MS` wraps and
+  -- seeds the store with a wrong clock where pyspec errors.
+  let elapsedMs ← checkedMul Const.slotDurationMs (sszGet anchorState slot)
+    "get_forkchoice_store: SLOT_DURATION_MS * anchor_state.slot"
+  let storeTime ← checkedAdd (sszGet anchorState genesisTime) (elapsedMs / 1000)
+    "get_forkchoice_store: genesis_time + SLOT_DURATION_MS * slot // 1000"
   pure
-    { time := (sszGet anchorState genesisTime) + Const.slotDurationMs * (sszGet anchorState slot) / 1000
+    { time := storeTime
       genesisTime := sszGet anchorState genesisTime
       justifiedCheckpoint := cp, finalizedCheckpoint := cp
       unrealizedJustifiedCheckpoint := cp, unrealizedFinalizedCheckpoint := cp
@@ -490,7 +504,7 @@ MUST NOT modify the store" is automatic here. The inclusion-list store rides ins
 forkdef onInclusionList (signed : SignedInclusionList) : StoreTransition Unit := do
   let store ← get
   let inclusionList := signed.message
-  let isTimely := timeIntoSlotMs store < getInclusionListDueMs
+  let isTimely := (← timeIntoSlotMs store) < getInclusionListDueMs
   set { store with
     inclusionListStore := processInclusionList store.inclusionListStore inclusionList isTimely }
 
@@ -547,27 +561,51 @@ private def pinPilsStore (payloadPresent : Bool) (recorded : Option Bool) :
       | none   => FcMap.empty
     inclusionListStore := InclusionListStore.empty }
 
+/-- What `pinPils` observed: the predicate's verdict, or which class of throw rejected it.
+
+Naming the class is the point. Folding every `.error` to a single marker pins only *that* a
+throw happened, so a regression from the spec's `assert` to an uncaught `.missingKey` would
+still satisfy the pin, and that swap is exactly the difference between a faithful rejection and
+a bug. `pinCommitteeThrows` below holds the same line from the other side, asserting a reject is
+*not* an expected rejection. -/
+private inductive PilsVerdict where
+  /-- The predicate ran clean and answered `b`. -/
+  | verdict (b : Bool)
+  /-- The spec's `assert root ∈ payload_inclusion_list_satisfaction` fired: the expected reject. -/
+  | assertReject
+  /-- Any other throw (a bare `.missingKey` read, a decode miss). Never expected at this gate. -/
+  | otherReject
+  deriving DecidableEq
+
 /-- The predicate's verdict on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
 preset / hasher the `forkdef` parameters want (Lean re-synthesizes them rather than reading the
 store's fixed type), the same pattern the `InclusionListStore` pins in this file use. -/
-private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : Option Bool :=
+private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : PilsVerdict :=
   letI : Preset := minimal
   letI : HasherTag := fastHasherTag
   let store := pinPilsStore payloadPresent recorded
-  -- Run the now-throwing predicate concretely; `none` marks the `assert root ∈ …` reject.
+  -- Run the predicate concretely and match on *which* reject fired: `.assert` is the spec's
+  -- own guard, anything else is our bug.
   match (isPayloadInclusionListSatisfied (map := treeMap) store pinPilsRoot : PinM Bool).run store with
-  | .ok b _    => some b
-  | .error _ _ => none
+  | .ok b _              => .verdict b
+  | .error (.assert _) _ => .assertReject
+  | .error _ _           => .otherReject
 
 -- verified + recorded `false` ⇒ `false` (do not extend this payload).
-#guard pinPils true (some false) = some false
+#guard pinPils true (some false) = .verdict false
 -- verified + recorded `true` ⇒ `true`.
-#guard pinPils true (some true) = some true
+#guard pinPils true (some true) = .verdict true
 -- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
-#guard pinPils false (some true) = some false
+#guard pinPils false (some true) = .verdict false
 -- verified but no recorded entry ⇒ the spec's `assert root ∈ payload_inclusion_list_satisfaction`
--- now *rejects* (a state the invariant rules out) rather than reading a `lookupD` default.
-#guard pinPils true none = none
+-- now *rejects* (a state the invariant rules out) rather than reading a `lookupD` default. The
+-- `.assertReject` (over a bare "it threw") is what a regression to `.missingKey` would break.
+#guard pinPils true none = .assertReject
+-- unverified AND no recorded entry ⇒ still the spec's assert, because
+-- `assert root in store.payload_inclusion_list_satisfaction` precedes the verified check
+-- (`heze/fork-choice.md:199-212`). A model that tested `is_payload_verified` first would answer
+-- `.verdict false` here, and the other three quadrants could not tell the difference.
+#guard pinPils false none = .assertReject
 
 /-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
 
@@ -647,6 +685,18 @@ private def pinRecordSatisfied : Option Bool :=
   | .error _ _  => none
 example : pinRecordSatisfied = some true := by native_decide
 
+/-- The recorded verdict and the gate's answer, or the reject that fired. Keeping `threw`
+separate is the whole point: the *gate* arm is where a tuple collapses, since a throw from
+`isPayloadInclusionListSatisfied` would hand back `(some false, false)`, byte-identical to the
+legitimate refusal this pin exists to check. The record-path arm was already distinguishable
+(`(none, false)`); this makes both so. -/
+private inductive RecordVerdict where
+  /-- The record path completed: the stored bit and the gate's verdict. -/
+  | recorded (value : Option Bool) (gate : Bool)
+  /-- Either the record path or the gate rejected. -/
+  | threw
+  deriving DecidableEq
+
 /-- The discriminating counterpart to `pinRecordSatisfied`: the same record path under a
 *refuting* engine, a local `letI` instance answering `false` in place of the optimistic
 default (`EthCLLib.Spec.Engine` documents the design). The record path writes `false` at a
@@ -655,7 +705,7 @@ covers the branch every conformance vector leaves dead, end-to-end: oracle → r
 verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`, so the membership check
 passes and the recorded bit is what decides. `State` is FFI-backed (`FastBox`), so
 `native_decide`. -/
-private def pinRecordRefuted : Option Bool × Bool :=
+private def pinRecordRefuted : RecordVerdict :=
   letI : Preset := minimal
   letI : Config := minimalConfig
   letI : HasherTag := fastHasherTag
@@ -667,14 +717,14 @@ private def pinRecordRefuted : Option Bool × Bool :=
   let store := pinPilsStore true none
   match (recordPayloadInclusionListSatisfaction (map := treeMap) store state pinPilsRoot
       (default : @EthCLSpecs.Heze.ExecutionPayload minimal) : PinM (Store treeMap)).run store with
-  | .error _ _  => (none, false)
+  | .error _ _  => .threw
   | .ok after _ =>
     let recorded := FcMap.lookup after.payloadInclusionListSatisfaction pinPilsRoot
     match (isPayloadInclusionListSatisfied (map := treeMap) after pinPilsRoot : PinM Bool).run after with
-    | .ok gate _  => (recorded, gate)
-    | .error _ _  => (recorded, false)
+    | .ok gate _  => .recorded recorded gate
+    | .error _ _  => .threw
 -- refuting oracle ⇒ recorded `false`, and the gate rejects the verified payload.
-example : pinRecordRefuted = (some false, false) := by native_decide
+example : pinRecordRefuted = .recorded (some false) false := by native_decide
 
 /-- `on_inclusion_list` threads the slot-timeliness bit into `process_inclusion_list`: a list
 received before `INCLUSION_LIST_DUE_BPS` is filed timely, one at/after the deadline untimely. Runs
@@ -799,41 +849,55 @@ private def pinTimeliness : treeMap Root Bool :=
   FcMap.insert (FcMap.insert FcMap.empty pinDummyRoot true) pinAltRoot false
 
 /-- Run the comprehension over `pinLists` / `pinTimeliness` under the minimal preset, so the
-hash-free `#guard`s below need no ambient instance. `collectInclusionListTransactions` now throws
-(the `timeliness` plain-`Dict` read), so it runs in `Except StoreTransitionError`; `pinTimeliness`
-carries an entry for every `pinLists` key, so the `.error` branch is unreachable here. -/
-private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) : Array Transaction :=
+hash-free `#guard`s below need no ambient instance. `collectInclusionListTransactions` throws on
+the `timeliness` plain-`Dict` read, and `pinTimeliness` carries an entry for every `pinLists`
+key, so the reject is unreachable here. That is exactly why the reject must stay visible in the
+result type: collapsing it to `#[]` would let a throw satisfy any future case that is
+legitimately empty. The `#guard`s below compare through the `Except`. -/
+private def pinCollect (equiv : Array ValidatorIndex) (onlyTimely : Bool) :
+    Except StoreTransitionError (Array Transaction) :=
   letI : Preset := minimal
-  match (collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely :
-      Except StoreTransitionError (Array Transaction)) with
-  | .ok txs  => txs
-  | .error _ => #[]
+  collectInclusionListTransactions pinLists equiv pinTimeliness onlyTimely
+
+/-- `p` applied to the collected transactions, and `false` when the comprehension rejected. The
+reject failing every predicate is the point: folding it to `#[]` instead let a throw satisfy any
+claim about an empty result. -/
+private def pinCollectSat (equiv : Array ValidatorIndex) (onlyTimely : Bool)
+    (p : Array Transaction → Bool) : Bool :=
+  match pinCollect equiv onlyTimely with
+  | .ok txs  => p txs
+  | .error _ => false
 
 -- No equivocators, timeliness ignored: union of {0xAA} and {0xAA, 0xBB}, deduped to two.
-#guard (pinCollect #[] false).size = 2
-#guard (pinCollect #[] false).contains (pinTx 0xAA)
-#guard (pinCollect #[] false).contains (pinTx 0xBB)
+#guard pinCollectSat #[] false (·.size == 2)
+#guard pinCollectSat #[] false (·.contains (pinTx 0xAA))
+#guard pinCollectSat #[] false (·.contains (pinTx 0xBB))
 -- only_timely drops validator 6's untimely list, leaving just {0xAA}.
-#guard (pinCollect #[] true).size = 1
-#guard (pinCollect #[] true).contains (pinTx 0xAA)
+#guard pinCollectSat #[] true (·.size == 1)
+#guard pinCollectSat #[] true (·.contains (pinTx 0xAA))
 -- Equivocator 6 is filtered out regardless of timeliness, leaving just {0xAA}.
-#guard (pinCollect #[6] false).size = 1
-#guard (pinCollect #[6] false).contains (pinTx 0xAA)
+#guard pinCollectSat #[6] false (·.size == 1)
+#guard pinCollectSat #[6] false (·.contains (pinTx 0xAA))
 
 /-- Vectorless reject pin for `get_forkchoice_store`'s opening assert
 (`assert anchor_block.state_root == hash_tree_root(anchor_state)`, `fork-choice.md:141`). The
 default block's all-zero `stateRoot` cannot equal `hash_tree_root` of the default state (a
-non-zero SHA-256 digest), so the seed takes the reject branch and returns `.error`;
-`toOption.isNone` reads that verdict. No conformance vector reaches the mismatch (the harness
-derives anchor block + state from one vector, so `state_root` always matches), so this pin is
-the only witness of the throw. Computes `hash_tree_root` (FFI `Sha256`) → `native_decide`. The
-Fulu and Gloas constructors carry the textually-identical assert. -/
+non-zero SHA-256 digest), so the seed takes the reject branch. No conformance vector reaches the
+mismatch (the harness derives anchor block + state from one vector, so `state_root` always
+matches), so this pin is the only witness of the throw. Computes `hash_tree_root` (FFI `Sha256`)
+→ `native_decide`. The Fulu and Gloas constructors carry the textually-identical assert.
+
+Matches `.assert` specifically rather than reading `toOption.isNone`: the spec's opening guard is
+what should fire here, and a regression to some other throw class is a bug this pin has to catch
+rather than absorb. -/
 private def pinAnchorRejects : Bool :=
   letI : Preset := minimal
   letI : Config := minimalConfig
   letI : HasherTag := fastHasherTag
-  (getForkchoiceStore (SSZ.FastBox (default : @BeaconState minimal))
-      (default : @BeaconBlock minimal) (map := treeMap)).toOption.isNone
+  match getForkchoiceStore (SSZ.FastBox (default : @BeaconState minimal))
+      (default : @BeaconBlock minimal) (map := treeMap) with
+  | .error (.assert _) => true
+  | _                  => false
 example : pinAnchorRejects = true := by native_decide
 
 end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
@@ -5,10 +5,11 @@ import EthCLSpecs.Gloas.Containers
 # `EthCLSpecs.Heze.Inherited`: the inherited containers (everything but the new IL family)
 
 At alpha.11 EIP-7805 adds only the `InclusionList` family; every other Heze container is
-byte-identical to Gloas, so each is `inherit`ed (the capture replays the ancestor's
-field block in `EthCLSpecs.Heze`, giving a fresh twin with the same SSZ encoding). The
-bid, `ExecutionRequests`, and the ePBS containers are Gloas's; the component containers
-walk the lineage to Fulu's captures. `BeaconState` / `BeaconBlock*` are inherited in
+byte-identical to Gloas, so each is `inherit`ed: the ancestor's field block is re-declared
+in `EthCLSpecs.Heze`, giving a distinct type with the same SSZ encoding (the inheritance
+mechanism, `SPEC_AUTHORING_MODEL.md` §8). The bid, `ExecutionRequests`, and the ePBS
+containers come from Gloas; the component containers resolve through Gloas back to the
+definitions captured in Fulu. `BeaconState` / `BeaconBlock*` are inherited in
 `State` / `Block` (they need the `state_preamble` / signed-wrapper steps).
 -/
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Inherited.lean
@@ -1,0 +1,68 @@
+import EthCLSpecs.Heze.Constants
+import EthCLSpecs.Gloas.Containers
+
+/-!
+# `EthCLSpecs.Heze.Inherited`: the inherited containers (everything but the new IL family)
+
+At alpha.11 EIP-7805 adds only the `InclusionList` family; every other Heze container is
+byte-identical to Gloas, so each is `inherit`ed (the capture replays the ancestor's
+field block in `EthCLSpecs.Heze`, giving a fresh twin with the same SSZ encoding). The
+bid, `ExecutionRequests`, and the ePBS containers are Gloas's; the component containers
+walk the lineage to Fulu's captures. `BeaconState` / `BeaconBlock*` are inherited in
+`State` / `Block` (they need the `state_preamble` / signed-wrapper steps).
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+-- Component containers (walk to Fulu's captures).
+inherit Checkpoint
+inherit AttestationData
+inherit Attestation
+inherit IndexedAttestation
+inherit AttesterSlashing
+inherit BLSToExecutionChange
+inherit BeaconBlockHeader
+inherit ConsolidationRequest
+inherit DepositData
+inherit Deposit
+inherit DepositRequest
+inherit Eth1Data
+inherit WithdrawalRequest
+inherit Fork
+inherit HistoricalSummary
+inherit PendingConsolidation
+inherit PendingDeposit
+inherit PendingPartialWithdrawal
+inherit SignedBeaconBlockHeader
+inherit ProposerSlashing
+inherit SignedBLSToExecutionChange
+inherit VoluntaryExit
+inherit SignedVoluntaryExit
+inherit SyncAggregate
+inherit SyncCommittee
+inherit Validator
+inherit Withdrawal
+
+-- ePBS + EIP-8282 containers (declared in Gloas; FOCIL leaves them untouched at alpha.11).
+inherit Builder
+inherit BuilderDepositRequest
+inherit BuilderExitRequest
+inherit BuilderPendingWithdrawal
+inherit BuilderPendingPayment
+inherit ExecutionRequests
+inherit PayloadAttestationData
+inherit PayloadAttestation
+inherit IndexedPayloadAttestation
+inherit PayloadAttestationMessage
+inherit ExecutionPayload
+inherit ExecutionPayloadBid
+inherit SignedExecutionPayloadBid
+inherit ExecutionPayloadEnvelope
+inherit SignedExecutionPayloadEnvelope
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -262,7 +262,7 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
         store := (← checkStepValidity valid
           (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -8,15 +8,18 @@ import EthCLSpecs.Heze.ForkChoice
 /-!
 # `EthCLSpecs.Heze.Interface`: the Heze fork-interface instance
 
-Heze's implementation of `ForkInterface`. At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state
-transition and no *vector-tested* fork-choice change: its overrides run on the existing fork_choice
-vectors but stay Gloas-equivalent (empty inclusion-list store), and the FOCIL-specific behavior
-ships no vector, so every dynamic runner reuses the Gloas spine re-instantiated over Heze types
-(`Heze.EpochProcessing` / `Operations` / `Withdrawals` /
-`Transition` / `ForkChoice`). `runUpgrade` is the Gloas→Heze `fork` format (a pure field
-copy, no onboarding); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
-Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model are
-`outOfScope` (reported `skip` rather than counted as xfail work), matching Fulu / Gloas. Pinned to
+Heze's implementation of `ForkInterface`, the entry points the pyspec runner drives
+(`SPEC_AUTHORING_MODEL.md` §11). At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state transition
+and no vector-tested fork-choice change. Its fork-choice overrides do run on the existing
+fork_choice vectors, but only on the path where the inclusion-list store stays empty, which
+behaves exactly like Gloas; the FOCIL-specific behavior ships no vector. So every dynamic
+runner reuses the Gloas spine re-instantiated over Heze types (`Heze.EpochProcessing` /
+`Operations` / `Withdrawals` / `Transition` / `ForkChoice`).
+
+The Heze-specific entries: `runUpgrade` is the Gloas→Heze `fork` format (a pure field copy,
+see `upgradeToHeze`); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
+Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model report
+`outOfScope`, a deliberate skip rather than xfail work, matching Fulu / Gloas. Pinned to
 v1.7.0-alpha.11.
 -/
 
@@ -45,8 +48,7 @@ private def stateRootImpl (P : Preset) (bytes : ByteArray) :
 
 /-- `runUpgrade` (the `fork` format, Gloas→Heze): decode the Gloas pre-state at preset `P`,
 apply `upgradeToHeze` with the config's `HEZE_FORK_VERSION`, return the Heze post root. A
-pure field copy; no onboarding / PTC recompute (builders are already onboarded in the Gloas
-state). -/
+pure field copy; `upgradeToHeze`'s docstring carries the why. -/
 private def runUpgradeImpl (P : Preset) (forkVersion : Version) (preBytes : ByteArray) :
     Except (RunError StateTransitionError) ByteArray :=
   letI : Preset := P
@@ -187,8 +189,8 @@ private def runBlocksImpl (P : Preset) (C : Config) (preBytes : ByteArray)
 
 /-- `runTransition` (the `transition` format, Gloas→Heze): fold the pre-fork blocks under
 Gloas `state_transition`, advance the Gloas state to the fork-epoch boundary, apply
-`upgradeToHeze` (pure copy, no onboarding), then fold the post-fork blocks under the Heze
-spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
+`upgradeToHeze` (a pure copy, see its docstring), then fold the post-fork blocks under the
+Heze spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
 qualified. -/
 private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
     (preBytes : ByteArray) (blocks : Array ByteArray) (cmeta : CaseMeta) :

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -1,0 +1,402 @@
+import EthCLSpecs.Heze.Upgrade
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Heze.Operations
+import EthCLSpecs.Heze.Withdrawals
+import EthCLSpecs.Heze.Transition
+import EthCLSpecs.Heze.ForkChoice
+
+/-!
+# `EthCLSpecs.Heze.Interface`: the Heze fork-interface instance
+
+Heze's implementation of `ForkInterface`. At v1.7.0-alpha.11 EIP-7805 (FOCIL) adds no state
+transition and no *vector-tested* fork-choice change: its overrides run on the existing fork_choice
+vectors but stay Gloas-equivalent (empty inclusion-list store), and the FOCIL-specific behavior
+ships no vector, so every dynamic runner reuses the Gloas spine re-instantiated over Heze types
+(`Heze.EpochProcessing` / `Operations` / `Withdrawals` /
+`Transition` / `ForkChoice`). `runUpgrade` is the Gloas→Heze `fork` format (a pure field
+copy, no onboarding); `runTransition` is the Gloas→Heze boundary; `runForkChoice` runs the
+Heze ePBS store. `runGenesis` and any `ssz_static` type Heze does not model are
+`outOfScope` (reported `skip` rather than counted as xfail work), matching Fulu / Gloas. Pinned to
+v1.7.0-alpha.11.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLLib.PySpecTests
+open EthCLSpecs.Fulu
+open SizzLean
+open SizzLean.Cache
+open SizzLean.Hasher
+
+namespace EthCLSpecs.Heze.Interface
+
+/-- Pinned upstream release; Heze tracks the same tag as Fulu / Gloas. -/
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
+
+/-- `stateRoot`: decode a Heze `BeaconState` at preset `P` and take its root. -/
+private def stateRootImpl (P : Preset) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := @Heze.BeaconState P) bytes with
+  | .ok v    => .ok (htr v)
+  | .error _ => .error (.decode "BeaconState")
+
+/-- `runUpgrade` (the `fork` format, Gloas→Heze): decode the Gloas pre-state at preset `P`,
+apply `upgradeToHeze` with the config's `HEZE_FORK_VERSION`, return the Heze post root. A
+pure field copy; no onboarding / PTC recompute (builders are already onboarded in the Gloas
+state). -/
+private def runUpgradeImpl (P : Preset) (forkVersion : Version) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := @Gloas.BeaconState P) preBytes with
+  | .ok pre  => .ok (htr (upgradeToHeze forkVersion pre))
+  | .error _ => .error (.decode "Gloas BeaconState")
+
+/-- Decode a Heze `BeaconState` into a `FastBox`, or the runner's `decode` error. -/
+private def decodeState (P : Preset) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (SSZ.Box Sha256 (@Heze.BeaconState P)) :=
+  letI : Preset := P
+  match SSZ.FastBox.deserialize (T := @Heze.BeaconState P) bytes with
+  | .ok box  => .ok box
+  | .error _ => .error (.decode "BeaconState")
+
+/-- `runEpochSubstep`: dispatch the `epoch_processing/<handler>` name to its Heze substep,
+run it over the decoded Heze pre-state, return the post root. Every substep is the Gloas
+one re-instantiated over Heze. -/
+private def runEpochSubstepImpl (P : Preset) (C : Config) (step : EpochStep) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit :=
+    match step with
+    | .slashingsReset               => processSlashingsReset
+    | .randaoMixesReset             => processRandaoMixesReset
+    | .eth1DataReset                => processEth1DataReset
+    | .historicalSummariesUpdate    => processHistoricalSummariesUpdate
+    | .participationFlagUpdates     => processParticipationFlagUpdates
+    | .justificationAndFinalization => processJustificationAndFinalization
+    | .inactivityUpdates            => processInactivityUpdates
+    | .rewardsAndPenalties          => processRewardsAndPenalties
+    | .registryUpdates              => processRegistryUpdates
+    | .slashings                    => processSlashings
+    | .effectiveBalanceUpdates      => processEffectiveBalanceUpdates
+    | .pendingDeposits              => processPendingDeposits
+    | .pendingDepositsChurn         => processPendingDeposits
+    | .pendingConsolidations        => processPendingConsolidations
+    | .builderPendingPayments       => processBuilderPendingPayments
+    | .syncCommitteeUpdates         => processSyncCommitteeUpdates
+    | .proposerLookahead            => processProposerLookahead
+    | .ptcWindow                    => processPtcWindow
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runRewards`: the four reward-delta blobs computed by the inherited Heze delta
+functions. The `Deltas` container is Fulu's (fork-agnostic). -/
+private def runRewardsImpl (P : Preset) (C : Config) (preBytes : ByteArray) :
+    Except (RunError StateTransitionError) (Array ByteArray) := do
+  let state ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  let mkDeltas : Array Gwei × Array Gwei → ByteArray := fun rp =>
+    SSZ.serialize ({ rewards := sszOfArray rp.1, penalties := sszOfArray rp.2 } : Fulu.Deltas)
+  let n := (sszGet state validators).size
+  let zeros := Array.replicate n (0 : Gwei)
+  RunError.ofSpec do
+    let d0 ← liftErr (getFlagIndexDeltas state 0)
+    let d1 ← liftErr (getFlagIndexDeltas state 1)
+    let d2 ← liftErr (getFlagIndexDeltas state 2)
+    pure #[mkDeltas d0, mkDeltas d1, mkDeltas d2, mkDeltas (zeros, getInactivityPenaltyDeltas state)]
+
+/-- Decode a plain (non-boxed) SSZ operation value. -/
+private def decodeOp (T : Type) [SizzLean.SSZRepr T] (b : ByteArray) :
+    Except (RunError StateTransitionError) T :=
+  match SSZ.deserialize (T := T) b with
+  | .ok v    => .ok v
+  | .error _ => .error (.decode "operation")
+
+/-- `runOperation`: dispatch every operation handler over the decoded Heze pre-state. Each
+handler is the Gloas one re-instantiated over Heze. -/
+private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
+    (preBytes opBytes : ByteArray) (cmeta : CaseMeta) : Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let dispatch : Except (RunError StateTransitionError) (EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit) :=
+    match kind with
+    | .proposerSlashing       => (decodeOp (@ProposerSlashing P) opBytes).map processProposerSlashing
+    | .attesterSlashing       => (decodeOp (@AttesterSlashing P) opBytes).map processAttesterSlashing
+    | .attestation            => (decodeOp (@Attestation P) opBytes).map processAttestation
+    | .payloadAttestation     => (decodeOp (@PayloadAttestation P) opBytes).map processPayloadAttestation
+    | .executionPayloadBid    => (decodeOp (@SignedExecutionPayloadBid P) opBytes).map processExecutionPayloadBid
+    | .parentExecutionPayload => (decodeOp (@BeaconBlock P) opBytes).map processParentExecutionPayload
+    | .blockHeader            => (decodeOp (@BeaconBlock P) opBytes).map processBlockHeader
+    | .withdrawals            => .ok processWithdrawals
+    | .voluntaryExit          => (decodeOp (@SignedVoluntaryExit P) opBytes).map processVoluntaryExit
+    | .voluntaryExitChurn     => (decodeOp (@SignedVoluntaryExit P) opBytes).map processVoluntaryExit
+    | .blsToExecutionChange   => (decodeOp (@SignedBLSToExecutionChange P) opBytes).map processBlsToExecutionChange
+    | .depositRequest         => (decodeOp (@DepositRequest P) opBytes).map processDepositRequest
+    | .withdrawalRequest      => (decodeOp (@WithdrawalRequest P) opBytes).map processWithdrawalRequest
+    | .consolidationRequest   => (decodeOp (@ConsolidationRequest P) opBytes).map processConsolidationRequest
+    | .builderDepositRequest  => (decodeOp (@Heze.BuilderDepositRequest P) opBytes).map processBuilderDepositRequest
+    | .builderExitRequest     => (decodeOp (@Heze.BuilderExitRequest P) opBytes).map processBuilderExitRequest
+    | .syncAggregate          => (decodeOp (@SyncAggregate P) opBytes).map processSyncAggregate
+    | .deposit | .executionPayload =>
+        .error (.spec (.todo s!"heze operations/{reprStr kind}: not a standalone ePBS operation"))
+  match dispatch with
+  | .error e   => .error e
+  | .ok action =>
+    RunError.ofSpec (runToRoot box0 action)
+
+/-- `runSlots`: advance the decoded Heze pre-state by `n` empty slots. -/
+private def runSlotsImpl (P : Preset) (C : Config) (preBytes : ByteArray) (n : Nat) :
+    Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+    let state ← get
+    processSlots ((sszGet state slot) + UInt64.ofNat n)
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runBlocks` (`sanity/blocks`, `finality`, `random`): fold the Heze `state_transition`
+over the decoded signed blocks. -/
+private def runBlocksImpl (P : Preset) (C : Config) (preBytes : ByteArray)
+    (blocks : Array ByteArray) (cmeta : CaseMeta) : Except (RunError StateTransitionError) ByteArray := do
+  let box0 ← decodeState P preBytes
+  let signedBlocks ← blocks.mapM (fun bb =>
+    match SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bb with
+    | .ok sb   => .ok sb
+    | .error _ => .error (RunError.decode "Heze SignedBeaconBlock"))
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let action : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+    for sb in signedBlocks do stateTransition sb
+  RunError.ofSpec (runToRoot box0 action)
+
+/-- `runTransition` (the `transition` format, Gloas→Heze): fold the pre-fork blocks under
+Gloas `state_transition`, advance the Gloas state to the fork-epoch boundary, apply
+`upgradeToHeze` (pure copy, no onboarding), then fold the post-fork blocks under the Heze
+spine. Unqualified spine names resolve to the Heze copies; the pre-fork Gloas calls are
+qualified. -/
+private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
+    (preBytes : ByteArray) (blocks : Array ByteArray) (cmeta : CaseMeta) :
+    Except (RunError StateTransitionError) ByteArray :=
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.forBlsSetting cmeta.blsSetting
+  let forkEpoch := cmeta.forkEpoch.getD 0
+  let boundary : Slot := UInt64.ofNat (forkEpoch * Const.slotsPerEpoch)
+  let nPre := match cmeta.forkBlock with | some n => n + 1 | none => 0
+  match SSZ.deserialize (T := @Gloas.BeaconState P) preBytes with
+  | .error _ => .error (.decode "Gloas BeaconState")
+  | .ok preGloas => do
+    let preBlocks ← (List.range nPre).toArray.mapM (fun i =>
+      match blocks[i]? with
+      | none    => Except.error (RunError.spec (.outOfBounds i blocks.size))
+      | some bb => match SSZ.deserialize (T := @Gloas.SignedBeaconBlock P) bb with
+        | .ok sb   => Except.ok sb
+        | .error _ => Except.error (RunError.decode "Gloas SignedBeaconBlock"))
+    let postBlocks ← (blocks.extract nPre blocks.size).mapM (fun bb =>
+      match SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bb with
+      | .ok sb   => Except.ok sb
+      | .error _ => Except.error (RunError.decode "Heze SignedBeaconBlock"))
+    let gloasBox0 : SSZ.Box Sha256 (@Gloas.BeaconState P) := SSZ.FastBox preGloas
+    let gloasAction : EStateM StateTransitionError (SSZ.Box Sha256 (@Gloas.BeaconState P)) Unit := do
+      for sb in preBlocks do Gloas.stateTransition sb
+      if (sszGet (← get) slot) < boundary then Gloas.processSlots boundary
+    match gloasAction.run gloasBox0 with
+    | .error e _ => Except.error (RunError.spec e)
+    | .ok _ gloasSt =>
+      let hezeBox0 : SSZ.Box Sha256 (@Heze.BeaconState P) := SSZ.FastBox (upgradeToHeze forkVersion gloasSt.view)
+      let hezeAction : EStateM StateTransitionError (SSZ.Box Sha256 (@Heze.BeaconState P)) Unit := do
+        for sb in postBlocks do
+          if (sszGet (← get) slot) < sb.message.slot then processSlots sb.message.slot
+          if cmeta.blsSetting != 2 then assert (verifyBlockSignature (← get) sb)
+          processBlock sb.message
+          let root ← getStateRoot
+          assert (sb.message.stateRoot == bytesToRoot root)
+      RunError.ofSpec (runToRoot hezeBox0 hezeAction)
+
+/-- Fold the decoded fork-choice `steps` over the Heze store. Identical shape to Gloas's
+interpreter, re-instantiated over Heze types: a `block` step runs `on_block` then replays
+the block's own attestations / attester-slashings; `execution_payload` /
+`payload_attestation_message` drive the two ePBS handlers; the checks read the head node's
+payload status and the per-block PTC vote arrays. -/
+private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
+    (P : Preset) (store0 : Store hashMap) (steps : Array FcStep) : Except StoreTransitionError Unit := do
+  let mut store : Store hashMap := store0
+  for step in steps do
+    match step with
+    | .tick t =>
+      store := (← checkStepValidity store true
+        (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
+    | .block bytes _columns valid =>
+      let outcome := decodeStepOr (α := @Heze.SignedBeaconBlock P) bytes "block" fun sb =>
+        let action : EStateM StoreTransitionError (Store hashMap) Unit := do
+          onBlock (map := hashMap) sb
+          for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+          for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+        runOn store action
+      store := (← checkStepValidity store valid outcome)
+    | .attestation bytes valid =>
+      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" fun a =>
+        runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .attesterSlashing bytes valid =>
+      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" fun a =>
+        runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .executionPayload bytes valid =>
+      let outcome := decodeStepOr (α := @Heze.SignedExecutionPayloadEnvelope P) bytes "envelope" fun env =>
+        runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .payloadAttestationMessage bytes valid =>
+      let outcome := decodeStepOr (α := @Heze.PayloadAttestationMessage P) bytes "ptc message" fun msg =>
+        runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
+      store := (← checkStepValidity store valid outcome)
+    | .checkHead root slot =>
+      let head := getHead store
+      assert (head.root == root)
+      let headSlot := match FcMap.lookup store.blocks head.root with | some b => b.slot.toNat | none => 0
+      assert (headSlot == slot)
+    | .checkHeadPayloadStatus status =>
+      assert ((getHead store).payloadStatus.toNat == status)
+    | .checkPayloadTimelinessVote blockRoot votes =>
+      assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
+    | .checkPayloadDataAvailabilityVote blockRoot votes =>
+      assert (FcMap.lookupD store.payloadDataAvailabilityVote (bytesToRoot blockRoot) == votes)
+    | .checkJustified epoch root =>
+      assert (store.justifiedCheckpoint.epoch.toNat == epoch)
+      assert (store.justifiedCheckpoint.root == root)
+    | .checkFinalized epoch root =>
+      assert (store.finalizedCheckpoint.epoch.toNat == epoch)
+      assert (store.finalizedCheckpoint.root == root)
+    | .checkBoost root =>
+      assert (store.proposerBoostRoot == root)
+    | .checkTime t => assert (store.time.toNat == t)
+    | .checkGenesisTime t => assert (store.genesisTime.toNat == t)
+    | .unsupported reason => throw (StoreTransitionError.todo reason)
+    -- `get_proposer_head` is Gloas-Modified but not ported, and no alpha.11 vector exercises it;
+    -- surface it as unmodeled (a `todo` xfail) rather than passing it vacuously. This arm makes
+    -- the match exhaustive over `FcStep`, so a newly added constructor becomes a build error rather
+    -- than a silent pass through a catch-all.
+    | .checkProposerHead _ => throw (StoreTransitionError.todo "get_proposer_head check: not modeled")
+  pure ()
+
+/-- `runForkChoice` (Heze): decode the anchor state / block, build the ePBS store, and run
+the step interpreter. -/
+private def runForkChoiceImpl (P : Preset) (C : Config) (anchorStateBytes anchorBlockBytes : ByteArray)
+    (steps : Array FcStep) : Except (RunError StoreTransitionError) Unit :=
+  letI : Preset := P
+  letI : Config := C
+  letI : HasherTag := fastHasherTag
+  letI : CryptoBackend := CryptoBackend.realBackend
+  match SSZ.FastBox.deserialize (T := @Heze.BeaconState P) anchorStateBytes,
+        SSZ.deserialize (T := @Heze.BeaconBlock P) anchorBlockBytes with
+  | .error _, _ => .error (.decode "fork_choice anchor state")
+  | _, .error _ => .error (.decode "fork_choice anchor block")
+  | .ok anchorState, .ok anchorBlock =>
+    RunError.ofSpec (fcInterpretHeze P (getForkchoiceStore anchorState anchorBlock) steps)
+
+/-- The `ssz_static` per-type kernel: decode `bytes` as `T`, return its root paired with
+the round-trip check (`reserialize == bytes`). -/
+private def runStatic (T : Type) [SizzLean.SSZRepr T] (typeName : String) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (ByteArray × Bool) :=
+  letI : HasherTag := fastHasherTag
+  match SSZ.deserialize (T := T) bytes with
+  | .ok v    => .ok ((htr v : ByteArray), SSZ.serialize v == bytes)
+  | .error _ => .error (.decode typeName)
+
+/-- `sszStatic`: the Gloas set retargeted to the Heze namespace, plus the FOCIL-new
+`InclusionList` / `SignedInclusionList`. Types Heze does not model report `.outOfScope`
+(skip), matching Fulu / Gloas. -/
+private def sszStaticImpl (P : Preset) (typeName : String) (bytes : ByteArray) :
+    Except (RunError StateTransitionError) (ByteArray × Bool) :=
+  match typeName with
+  | "AttestationData"            => runStatic (@Heze.AttestationData P) typeName bytes
+  | "Attestation"                => runStatic (@Heze.Attestation P) typeName bytes
+  | "AttesterSlashing"           => runStatic (@Heze.AttesterSlashing P) typeName bytes
+  | "BeaconBlock"                => runStatic (@Heze.BeaconBlock P) typeName bytes
+  | "BeaconBlockBody"            => runStatic (@Heze.BeaconBlockBody P) typeName bytes
+  | "BeaconBlockHeader"          => runStatic (@Heze.BeaconBlockHeader P) typeName bytes
+  | "BeaconState"                => runStatic (@Heze.BeaconState P) typeName bytes
+  | "BLSToExecutionChange"       => runStatic (@Heze.BLSToExecutionChange P) typeName bytes
+  | "Builder"                    => runStatic (@Heze.Builder P) typeName bytes
+  | "BuilderDepositRequest"      => runStatic (@Heze.BuilderDepositRequest P) typeName bytes
+  | "BuilderExitRequest"         => runStatic (@Heze.BuilderExitRequest P) typeName bytes
+  | "BuilderPendingPayment"      => runStatic (@Heze.BuilderPendingPayment P) typeName bytes
+  | "BuilderPendingWithdrawal"   => runStatic (@Heze.BuilderPendingWithdrawal P) typeName bytes
+  | "Checkpoint"                 => runStatic (@Heze.Checkpoint P) typeName bytes
+  | "ConsolidationRequest"       => runStatic (@Heze.ConsolidationRequest P) typeName bytes
+  | "Deposit"                    => runStatic (@Heze.Deposit P) typeName bytes
+  | "DepositData"                => runStatic (@Heze.DepositData P) typeName bytes
+  | "DepositRequest"             => runStatic (@Heze.DepositRequest P) typeName bytes
+  | "Eth1Data"                   => runStatic (@Heze.Eth1Data P) typeName bytes
+  | "ExecutionPayload"           => runStatic (@Heze.ExecutionPayload P) typeName bytes
+  | "ExecutionPayloadBid"        => runStatic (@Heze.ExecutionPayloadBid P) typeName bytes
+  | "ExecutionPayloadEnvelope"   => runStatic (@Heze.ExecutionPayloadEnvelope P) typeName bytes
+  | "ExecutionRequests"          => runStatic (@Heze.ExecutionRequests P) typeName bytes
+  | "Fork"                       => runStatic (@Heze.Fork P) typeName bytes
+  | "HistoricalSummary"          => runStatic (@Heze.HistoricalSummary P) typeName bytes
+  | "InclusionList"              => runStatic (@Heze.InclusionList P) typeName bytes
+  | "IndexedAttestation"         => runStatic (@Heze.IndexedAttestation P) typeName bytes
+  | "IndexedPayloadAttestation"  => runStatic (@Heze.IndexedPayloadAttestation P) typeName bytes
+  | "PayloadAttestation"         => runStatic (@Heze.PayloadAttestation P) typeName bytes
+  | "PayloadAttestationData"     => runStatic (@Heze.PayloadAttestationData P) typeName bytes
+  | "PayloadAttestationMessage"  => runStatic (@Heze.PayloadAttestationMessage P) typeName bytes
+  | "PendingConsolidation"       => runStatic (@Heze.PendingConsolidation P) typeName bytes
+  | "PendingDeposit"             => runStatic (@Heze.PendingDeposit P) typeName bytes
+  | "PendingPartialWithdrawal"   => runStatic (@Heze.PendingPartialWithdrawal P) typeName bytes
+  | "ProposerSlashing"           => runStatic (@Heze.ProposerSlashing P) typeName bytes
+  | "SyncAggregate"              => runStatic (@Heze.SyncAggregate P) typeName bytes
+  | "SyncCommittee"              => runStatic (@Heze.SyncCommittee P) typeName bytes
+  | "Validator"                  => runStatic (@Heze.Validator P) typeName bytes
+  | "VoluntaryExit"              => runStatic (@Heze.VoluntaryExit P) typeName bytes
+  | "Withdrawal"                 => runStatic (@Heze.Withdrawal P) typeName bytes
+  | "WithdrawalRequest"          => runStatic (@Heze.WithdrawalRequest P) typeName bytes
+  | "SignedBeaconBlock"          => runStatic (@Heze.SignedBeaconBlock P) typeName bytes
+  | "SignedBeaconBlockHeader"    => runStatic (@Heze.SignedBeaconBlockHeader P) typeName bytes
+  | "SignedBLSToExecutionChange" => runStatic (@Heze.SignedBLSToExecutionChange P) typeName bytes
+  | "SignedExecutionPayloadBid"      => runStatic (@Heze.SignedExecutionPayloadBid P) typeName bytes
+  | "SignedExecutionPayloadEnvelope" => runStatic (@Heze.SignedExecutionPayloadEnvelope P) typeName bytes
+  | "SignedInclusionList"        => runStatic (@Heze.SignedInclusionList P) typeName bytes
+  | "SignedVoluntaryExit"        => runStatic (@Heze.SignedVoluntaryExit P) typeName bytes
+  | _ => .error (.spec (.outOfScope s!"ssz_static/{typeName}: not modeled by EthCLSpecs.Heze"))
+
+/-- Heze's fork-interface instance at preset `P` / config `C` with `HEZE_FORK_VERSION`.
+Every in-scope entry is driven via the inherited Gloas spine over Heze state; `runUpgrade`
+is the pure Gloas→Heze copy and `runTransition` the Gloas→Heze boundary. `runGenesis` is
+`outOfScope` (not modeled; no genesis vectors at the pin), as in Fulu / Gloas. -/
+@[reducible] def hezeInterfaceFor (P : Preset) (C : Config) (forkVersion : Version) : ForkInterface where
+  stateRoot       := stateRootImpl P
+  sszStatic       := sszStaticImpl P
+  runUpgrade      := runUpgradeImpl P forkVersion
+  runEpochSubstep := runEpochSubstepImpl P C
+  runRewards      := runRewardsImpl P C
+  runForkChoice   := runForkChoiceImpl P C
+  runOperation    := runOperationImpl P C
+  runBlocks       := runBlocksImpl P C
+  runSlots        := runSlotsImpl P C
+  runGenesis      := fun _ _   => .error (.spec (.outOfScope "heze genesis: out of scope (not modeled)"))
+  runTransition   := runTransitionImpl P C forkVersion
+
+/-- The `minimal`-preset / config Heze interface. -/
+@[reducible] def hezeInterface : ForkInterface := hezeInterfaceFor minimal minimalConfig hezeForkVersionMinimal
+
+/-- The `mainnet`-preset / config Heze interface (on demand). -/
+@[reducible] def hezeInterfaceMainnet : ForkInterface := hezeInterfaceFor mainnet mainnetConfig hezeForkVersionMainnet
+
+end EthCLSpecs.Heze.Interface

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -232,6 +232,14 @@ private def runTransitionImpl (P : Preset) (C : Config) (forkVersion : Version)
           assert (sb.message.stateRoot == bytesToRoot root)
       RunError.ofSpec (runToRoot hezeBox0 hezeAction)
 
+/-- Run `getHead` over the snapshot store as a pure query (`runQuery` discards the final
+store; `getHead` only reads it). Shared by the `checkHead` / `checkHeadPayloadStatus` arms,
+which each need the head node against the current fold state. -/
+private def queryHead [Preset] [Config] [HasherTag] (store : Store hashMap) :
+    Except StoreTransitionError ForkChoiceNode :=
+  runQuery store (getHead (map := hashMap) store :
+    EStateM StoreTransitionError (Store hashMap) ForkChoiceNode)
+
 /-- Fold the decoded fork-choice `steps` over the Heze store. Identical shape to Gloas's
 interpreter, re-instantiated over Heze types: a `block` step runs `on_block` then replays
 the block's own attestations / attester-slashings; `execution_payload` /
@@ -270,12 +278,15 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
       store := (← checkStepValidity store valid outcome)
     | .checkHead root slot =>
-      let head := getHead store
+      let head ← queryHead store
       assert (head.root == root)
-      let headSlot := match FcMap.lookup store.blocks head.root with | some b => b.slot.toNat | none => 0
-      assert (headSlot == slot)
+      -- `getOrThrow` is monad-polymorphic, and the fold's own monad is already
+      -- `Except StoreTransitionError`, so the read binds directly (no `runQuery` detour).
+      let headBlock ← FcMap.getOrThrow store.blocks head.root
+      assert (headBlock.slot.toNat == slot)
     | .checkHeadPayloadStatus status =>
-      assert ((getHead store).payloadStatus.toNat == status)
+      let head ← queryHead store
+      assert (head.payloadStatus.toNat == status)
     | .checkPayloadTimelinessVote blockRoot votes =>
       assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
     | .checkPayloadDataAvailabilityVote blockRoot votes =>

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -322,7 +322,9 @@ private def runForkChoiceImpl (P : Preset) (C : Config) (anchorStateBytes anchor
   | .error _, _ => .error (.decode "fork_choice anchor state")
   | _, .error _ => .error (.decode "fork_choice anchor block")
   | .ok anchorState, .ok anchorBlock =>
-    RunError.ofSpec (fcInterpretHeze P (getForkchoiceStore anchorState anchorBlock) steps)
+    RunError.ofSpec (do
+      let store ← getForkchoiceStore anchorState anchorBlock
+      fcInterpretHeze P store steps)
 
 /-- The `ssz_static` per-type kernel: decode `bytes` as `T`, return its root paired with
 the round-trip check (`reserialize == bytes`). -/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -251,32 +251,42 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity store true
+      store := (← checkStepValidity true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes _columns valid =>
-      let outcome := decodeStepOr (α := @Heze.SignedBeaconBlock P) bytes "block" fun sb =>
-        let action : EStateM StoreTransitionError (Store hashMap) Unit := do
-          onBlock (map := hashMap) sb
-          for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
-          for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-        runOn store action
-      store := (← checkStepValidity store valid outcome)
+      -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
+      -- invalid block returns right after `on_block` rejects (`:393`), so its own attestations /
+      -- attester-slashings replay only on the valid path (`:400-406`), each `valid = True`. So
+      -- check `on_block` against `valid`, then replay the sub-steps only when the block was
+      -- accepted. (Combining them would let a sub-attestation reject stand in for `on_block`'s on
+      -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
+      match SizzLean.SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bytes with
+      | .error _ =>
+        store := (← checkStepValidity valid (.error (.assert "fork_choice: block decode failed", store)))
+      | .ok sb =>
+        store := (← checkStepValidity valid
+          (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))
+        if valid then
+          let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
+            for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
+            for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
+          store := (← checkStepValidity true (runOn store subAction))
     | .attestation bytes valid =>
-      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" fun a =>
+      let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .attesterSlashing bytes valid =>
-      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" fun a =>
+      let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .executionPayload bytes valid =>
-      let outcome := decodeStepOr (α := @Heze.SignedExecutionPayloadEnvelope P) bytes "envelope" fun env =>
+      let outcome := decodeStepOr (α := @Heze.SignedExecutionPayloadEnvelope P) bytes "envelope" store fun env =>
         runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .payloadAttestationMessage bytes valid =>
-      let outcome := decodeStepOr (α := @Heze.PayloadAttestationMessage P) bytes "ptc message" fun msg =>
+      let outcome := decodeStepOr (α := @Heze.PayloadAttestationMessage P) bytes "ptc message" store fun msg =>
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity store valid outcome)
+      store := (← checkStepValidity valid outcome)
     | .checkHead root slot =>
       let head ← queryHead store
       assert (head.root == root)

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Interface.lean
@@ -251,7 +251,7 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
   for step in steps do
     match step with
     | .tick t =>
-      store := (← checkStepValidity true
+      store := (← checkStepValidity .tick true
         (runOn store (onTick (map := hashMap) (UInt64.ofNat t) : EStateM StoreTransitionError (Store hashMap) Unit)))
     | .block bytes _columns valid =>
       -- pyspec `add_block` (`fork_choice.py:382-406`) runs `on_block` ALONE against `valid`: an
@@ -262,31 +262,31 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
       -- a `valid: false` step.) A decode failure is the step's reject, as `decodeStepOr` gives.
       match SizzLean.SSZ.deserialize (T := @Heze.SignedBeaconBlock P) bytes with
       | .error _ =>
-        store := (← checkStepValidity valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
+        store := (← checkStepValidity .block valid (.error (.decodeFailure "fork_choice: block decode failed", store)))
       | .ok sb =>
-        store := (← checkStepValidity valid
+        store := (← checkStepValidity .block valid
           (runOn store (onBlock (map := hashMap) sb : EStateM StoreTransitionError (Store hashMap) Unit)))
         if valid then
           let subAction : EStateM StoreTransitionError (Store hashMap) Unit := do
             for a in sb.message.body.attestations do onAttestation (map := hashMap) a true
             for a in sb.message.body.attesterSlashings do onAttesterSlashing (map := hashMap) a
-          store := (← checkStepValidity true (runOn store subAction))
+          store := (← checkStepValidity .attestation true (runOn store subAction))
     | .attestation bytes valid =>
       let outcome := decodeStepOr (α := @Attestation P) bytes "attestation" store fun a =>
         runOn store (onAttestation (map := hashMap) a false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attestation valid outcome)
     | .attesterSlashing bytes valid =>
       let outcome := decodeStepOr (α := @AttesterSlashing P) bytes "attester_slashing" store fun a =>
         runOn store (onAttesterSlashing (map := hashMap) a : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .attesterSlashing valid outcome)
     | .executionPayload bytes valid =>
       let outcome := decodeStepOr (α := @Heze.SignedExecutionPayloadEnvelope P) bytes "envelope" store fun env =>
         runOn store (onExecutionPayloadEnvelope (map := hashMap) env : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .executionPayload valid outcome)
     | .payloadAttestationMessage bytes valid =>
       let outcome := decodeStepOr (α := @Heze.PayloadAttestationMessage P) bytes "ptc message" store fun msg =>
         runOn store (onPayloadAttestationMessage (map := hashMap) msg false : EStateM StoreTransitionError (Store hashMap) Unit)
-      store := (← checkStepValidity valid outcome)
+      store := (← checkStepValidity .payloadAttestationMessage valid outcome)
     | .checkHead root slot =>
       let head ← queryHead store
       assert (head.root == root)
@@ -298,9 +298,15 @@ private def fcInterpretHeze [Preset] [Config] [HasherTag] [CryptoBackend]
       let head ← queryHead store
       assert (head.payloadStatus.toNat == status)
     | .checkPayloadTimelinessVote blockRoot votes =>
-      assert (FcMap.lookupD store.payloadTimelinessVote (bytesToRoot blockRoot) == votes)
+      -- `add_payload_vote_checks` subscripts a plain `Dict` (`fork_choice.py:517-519`),
+      -- so a missing key raises; the spec-side reads of this same map already throw.
+      let recorded ← FcMap.getOrThrow store.payloadTimelinessVote (bytesToRoot blockRoot)
+      assert (recorded == votes)
     | .checkPayloadDataAvailabilityVote blockRoot votes =>
-      assert (FcMap.lookupD store.payloadDataAvailabilityVote (bytesToRoot blockRoot) == votes)
+      -- `add_payload_vote_checks` subscripts a plain `Dict` (`fork_choice.py:517-519`),
+      -- so a missing key raises; the spec-side reads of this same map already throw.
+      let recorded ← FcMap.getOrThrow store.payloadDataAvailabilityVote (bytesToRoot blockRoot)
+      assert (recorded == votes)
     | .checkJustified epoch root =>
       assert (store.justifiedCheckpoint.epoch.toNat == epoch)
       assert (store.justifiedCheckpoint.root == root)

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
@@ -1,0 +1,71 @@
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Gloas.Operations
+
+/-!
+# `EthCLSpecs.Heze.Operations`: the inherited operation handlers (Gloas over Heze state)
+
+EIP-7805 changes no block operation. Every Gloas operation handler (the inherited
+non-ePBS ones and the ePBS-modified / EIP-8282 builder ones) is `inherit`ed over Heze
+state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas (not captured by
+`forkdef`), so it is restated here before its first use.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+/-- `withdrawal_credentials[12:]` as a 20-byte execution address. Restated from Gloas
+(a plain `def` rather than an inheritable `forkdef`). -/
+private def addressOfCred (wc : Bytes32) : ExecutionAddress := Vector.ofFn (fun i : Fin 20 => wc[12 + i.val])
+
+inherit isSlashableAttestationData
+inherit isValidIndexedAttestation
+inherit isValidSwitchToCompoundingRequest
+inherit getAttestingIndices
+inherit processAttesterSlashing
+inherit processBlockHeader
+inherit processBlsToExecutionChange
+inherit processWithdrawalRequest
+inherit processConsolidationRequest
+inherit processDepositRequest
+inherit processVoluntaryExit
+inherit processSyncAggregate
+inherit isBuilderIndex
+inherit toBuilderIndex
+inherit isActiveBuilder
+inherit getPendingBalanceToWithdrawForBuilder
+inherit builderPaymentIndex
+inherit isBuilderWithdrawalCredential
+inherit isPendingValidator
+inherit initiateBuilderExit
+inherit getIndexForNewBuilder
+inherit addBuilderToRegistry
+inherit applyDepositForBuilder
+inherit onboardBuildersFromPendingDeposits
+inherit isValidBuilderDepositSignature
+inherit processBuilderDepositRequest
+inherit processBuilderExitRequest
+inherit processProposerSlashing
+inherit isAttestationSameSlot
+inherit getAttestationParticipationFlagIndices
+inherit processAttestation
+inherit getPtc
+inherit getIndexedPayloadAttestation
+inherit isValidIndexedPayloadAttestation
+inherit processPayloadAttestation
+inherit convertBuilderIndexToValidatorIndex
+inherit canBuilderCoverBid
+inherit verifyExecutionPayloadBidSignature
+inherit settleBuilderPayment
+inherit processExecutionPayloadBid
+inherit applyParentExecutionPayload
+inherit processParentExecutionPayload
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Operations.lean
@@ -6,8 +6,9 @@ import EthCLSpecs.Gloas.Operations
 
 EIP-7805 changes no block operation. Every Gloas operation handler (the inherited
 non-ePBS ones and the ePBS-modified / EIP-8282 builder ones) is `inherit`ed over Heze
-state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas (not captured by
-`forkdef`), so it is restated here before its first use.
+state, in Gloas's order. `addressOfCred` is a plain `def` in Gloas, and only the capturing
+declaration forms (`forkdef` / `forkcontainer` / `forkstruct`, `SPEC_AUTHORING_MODEL.md`
+§8.5) are stored for `inherit` to replay, so it is restated here before its first use.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -26,11 +26,15 @@ state_section
 signature by its committee member's key under `DOMAIN_INCLUSION_LIST_COMMITTEE` at the
 message's epoch. Mirrors the Python step-for-step: read `message`, the validator `pubkey` at
 `validator_index`, the domain, `compute_signing_root(message, domain)`, then `bls.Verify`.
-`blsVerify` is the residual trust boundary (the `[CryptoBackend]` seam): no pure assertion
-pins it, the same treatment Gloas gives `verify_execution_payload_bid_signature` and the
-builder-deposit signature predicate. It has no in-model caller by design. The spec's sole
-consumer is the p2p `inclusion_list` gossip `[REJECT]` (`p2p-interface.md:100`), and EthCLSpecs
-models the state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
+
+The signature check itself, `blsVerifySigned`, goes through the `[CryptoBackend]` seam
+(`FRAMEWORK_ARCHITECTURE.md` §1), and no build-enforced pin fixes its verdict. That is the
+same trust boundary every signature predicate keeps (Gloas's bid and builder-deposit
+signatures included).
+
+The predicate has no in-model caller, by design. Its sole consumer in the spec is the p2p
+`inclusion_list` gossip `[REJECT]` rule (`p2p-interface.md:100`), and EthCLSpecs models the
+state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
 conformance scope). `on_inclusion_list` carries no signature check of its own
 (`fork-choice.md:256-267`), so the fork-choice path mirrors the spec faithfully. Kept as the
 beacon-chain surface for spec-completeness. -/

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -1,0 +1,53 @@
+import EthCLSpecs.Heze.EpochProcessing
+import EthCLSpecs.Heze.Containers
+
+/-!
+# `EthCLSpecs.Heze.Signing`: the EIP-7805 (FOCIL) inclusion-list signature predicate
+
+Heze inherits the domain accessor and the rest of the signing surface from Fulu; this file adds
+the one new predicate EIP-7805 introduces. `is_valid_inclusion_list_signature` (the "Predicates"
+section, `consensus-specs/specs/heze/beacon-chain.md:76-87`) checks a `SignedInclusionList`'s BLS
+signature under `DOMAIN_INCLUSION_LIST_COMMITTEE`. `blsVerifySigned` is the residual trust
+boundary (the `[CryptoBackend]` seam), as for every other signature predicate; no pure assertion
+pins it. FOCIL adds no state transition, so this is a pure predicate rather than a transition step.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+/-- `is_valid_inclusion_list_signature(state, signed_inclusion_list)` (EIP-7805,
+`consensus-specs/specs/heze/beacon-chain.md:76-87`): the `InclusionList` carries a valid BLS
+signature by its committee member's key under `DOMAIN_INCLUSION_LIST_COMMITTEE` at the
+message's epoch. Mirrors the Python step-for-step: read `message`, the validator `pubkey` at
+`validator_index`, the domain, `compute_signing_root(message, domain)`, then `bls.Verify`.
+`blsVerify` is the residual trust boundary (the `[CryptoBackend]` seam): no pure assertion
+pins it, the same treatment Gloas gives `verify_execution_payload_bid_signature` and the
+builder-deposit signature predicate. It has no in-model caller by design. The spec's sole
+consumer is the p2p `inclusion_list` gossip `[REJECT]` (`p2p-interface.md:100`), and EthCLSpecs
+models the state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
+conformance scope). `on_inclusion_list` carries no signature check of its own
+(`fork-choice.md:256-267`), so the fork-choice path mirrors the spec faithfully. Kept as the
+beacon-chain surface for spec-completeness. -/
+forkdef isValidInclusionListSignature (state : State) (signed : SignedInclusionList) : Bool :=
+  let message := signed.message
+  let index := message.validatorIndex
+  let vs := sszGet state validators
+  -- `validator_index` arrives off the wire, so bound it: the spec's `state.validators[index]`
+  -- raises `IndexError` for an out-of-range index, rejecting the list. Reject explicitly rather
+  -- than reading the `Inhabited` default (zero-pubkey) validator through `[…]!`.
+  if index.toNat < vs.size then
+    let pubkey := (vs[index.toNat]!).pubkey
+    let domain := getDomain state Const.domainInclusionListCommittee (computeEpochAtSlot message.slot)
+    blsVerifySigned pubkey message domain signed.signature
+  else
+    false
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -9,7 +9,9 @@ the one new predicate EIP-7805 introduces. `is_valid_inclusion_list_signature` (
 section, `consensus-specs/specs/heze/beacon-chain.md:76-87`) checks a `SignedInclusionList`'s BLS
 signature under `DOMAIN_INCLUSION_LIST_COMMITTEE`. `blsVerifySigned` is the residual trust
 boundary (the `[CryptoBackend]` seam), as for every other signature predicate; no pure assertion
-pins it. FOCIL adds no state transition, so this is a pure predicate rather than a transition step.
+pins it. FOCIL adds no state transition, so this is a predicate rather than a transition step,
+though it throws on an out-of-range `validator_index` (the spec's `state.validators[index]`
+`IndexError`) rather than returning a verdict there.
 -/
 
 set_option autoImplicit false
@@ -37,20 +39,23 @@ The predicate has no in-model caller, by design. Its sole consumer in the spec i
 state-transition and fork-choice layers, not p2p gossip (`networking` is out of the
 conformance scope). `on_inclusion_list` carries no signature check of its own
 (`fork-choice.md:256-267`), so the fork-choice path mirrors the spec faithfully. Kept as the
-beacon-chain surface for spec-completeness. -/
-forkdef isValidInclusionListSignature (state : State) (signed : SignedInclusionList) : Bool :=
+beacon-chain surface for spec-completeness.
+
+It throws (`StateTransition`) rather than returning a `Bool` purely, because `state.validators[index]`
+is a bare list index in the spec, raising `IndexError` on an out-of-range `validator_index`, not
+returning `False`. -/
+forkdef isValidInclusionListSignature (state : State) (signed : SignedInclusionList) :
+    StateTransition Bool := do
   let message := signed.message
   let index := message.validatorIndex
-  let vs := sszGet state validators
-  -- `validator_index` arrives off the wire, so bound it: the spec's `state.validators[index]`
-  -- raises `IndexError` for an out-of-range index, rejecting the list. Reject explicitly rather
-  -- than reading the `Inhabited` default (zero-pubkey) validator through `[…]!`.
-  if index.toNat < vs.size then
-    let pubkey := (vs[index.toNat]!).pubkey
-    let domain := getDomain state Const.domainInclusionListCommittee (computeEpochAtSlot message.slot)
-    blsVerifySigned pubkey message domain signed.signature
-  else
-    false
+  -- `validator_index` arrives off the wire, so the spec's `state.validators[index]` raises
+  -- `IndexError` for an out-of-range index rather than yielding a verdict: `sszGetIdx`
+  -- (→ `outOfBounds`), the monadic safe read, in place of an `if index < size` guard that would
+  -- mask the raise as a `false` and read the `Inhabited` default (zero-pubkey) validator.
+  let validator ← sszGetIdx (sszGet state validators) index.toNat
+  let pubkey := validator.pubkey
+  let domain := getDomain state Const.domainInclusionListCommittee (computeEpochAtSlot message.slot)
+  return blsVerifySigned pubkey message domain signed.signature
 
 end
 

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
@@ -1,0 +1,25 @@
+import EthCLSpecs.Heze.Containers.InclusionList
+
+/-!
+# `EthCLSpecs.Heze.State`: the Heze `BeaconState` (inherited from Gloas)
+
+At alpha.11 Heze does not change `BeaconState`, so `inherit BeaconState` replays Gloas's
+field block here unchanged. `state_preamble` declares the boxed `State` and `modifyState`.
+The `Containers.InclusionList` import is the load-order entry: it transitively pulls
+`Heze.Inherited` (the inherited containers) and the `fork Heze from Gloas` lineage that
+`inherit` resolves against. It is load-bearing; do not drop it.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+inherit BeaconState
+
+-- The once-per-fork preamble: declares `State` (the boxed `BeaconState`) and `modifyState`.
+state_preamble BeaconState
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
@@ -7,8 +7,9 @@ import EthCLSpecs.Gloas.Transition
 EIP-7805 (FOCIL) leaves the EIP-7732 block spine unchanged. `process_slot` /
 `process_epoch` / `process_slots` / `process_operations` / `process_block` /
 `state_transition` (and the unchanged `process_randao` / `process_eth1_data` /
-`verify_block_signature`) are all `inherit`ed over Heze state; their sub-calls late-bind
-to the Heze copies from the earlier spine files.
+`verify_block_signature`) are all `inherit`ed over Heze state. When `inherit` replays each
+definition here, its unqualified callee names resolve to the Heze versions declared in the
+files above, the transition "spine", and never to the Gloas originals.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Transition.lean
@@ -1,0 +1,35 @@
+import EthCLSpecs.Heze.Withdrawals
+import EthCLSpecs.Gloas.Transition
+
+/-!
+# `EthCLSpecs.Heze.Transition`: the inherited state-transition spine (Gloas over Heze)
+
+EIP-7805 (FOCIL) leaves the EIP-7732 block spine unchanged. `process_slot` /
+`process_epoch` / `process_slots` / `process_operations` / `process_block` /
+`state_transition` (and the unchanged `process_randao` / `process_eth1_data` /
+`verify_block_signature`) are all `inherit`ed over Heze state; their sub-calls late-bind
+to the Heze copies from the earlier spine files.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit processRandao
+inherit processEth1Data
+inherit verifyBlockSignature
+inherit processSlot
+inherit processEpoch
+inherit processSlots
+inherit processOperations
+inherit processBlock
+inherit stateTransition
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
@@ -1,0 +1,126 @@
+import EthCLSpecs.Heze.Containers
+
+/-!
+# `EthCLSpecs.Heze.Upgrade`: the Gloas → Heze fork upgrade (EIP-7805)
+
+`upgradeToHeze` reads a finished Gloas state and constructs the Heze one, the single
+sanctioned cross-fork reference. At alpha.11 it is a near-passthrough: every
+`BeaconState` field carries across and only the fork version bumps. Because Heze's
+containers are fresh namespace twins of Gloas's, each container field is copied through
+a field-by-field `cv*` converter, the mechanical price of the flat namespace. No builder
+onboarding / PTC recompute (the upgrade is a pure copy).
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+/-! ## Component-container conversion at the fork boundary -/
+
+private def cvBeaconBlockHeader [Preset] (v : Gloas.BeaconBlockHeader) : BeaconBlockHeader :=
+  { slot := v.slot, proposerIndex := v.proposerIndex, parentRoot := v.parentRoot,
+    stateRoot := v.stateRoot, bodyRoot := v.bodyRoot }
+private def cvEth1Data [Preset] (v : Gloas.Eth1Data) : Eth1Data :=
+  { depositRoot := v.depositRoot, depositCount := v.depositCount, blockHash := v.blockHash }
+private def cvCheckpoint [Preset] (v : Gloas.Checkpoint) : Checkpoint :=
+  { epoch := v.epoch, root := v.root }
+private def cvValidator [Preset] (v : Gloas.Validator) : Validator :=
+  { pubkey := v.pubkey, withdrawalCredentials := v.withdrawalCredentials,
+    effectiveBalance := v.effectiveBalance, slashed := v.slashed,
+    activationEligibilityEpoch := v.activationEligibilityEpoch,
+    activationEpoch := v.activationEpoch, exitEpoch := v.exitEpoch,
+    withdrawableEpoch := v.withdrawableEpoch }
+private def cvSyncCommittee [Preset] (v : Gloas.SyncCommittee) : SyncCommittee :=
+  { pubkeys := v.pubkeys, aggregatePubkey := v.aggregatePubkey }
+private def cvHistoricalSummary [Preset] (v : Gloas.HistoricalSummary) : HistoricalSummary :=
+  { blockSummaryRoot := v.blockSummaryRoot, stateSummaryRoot := v.stateSummaryRoot }
+private def cvPendingDeposit [Preset] (v : Gloas.PendingDeposit) : PendingDeposit :=
+  { pubkey := v.pubkey, withdrawalCredentials := v.withdrawalCredentials, amount := v.amount,
+    signature := v.signature, slot := v.slot }
+private def cvPendingPartialWithdrawal [Preset] (v : Gloas.PendingPartialWithdrawal) :
+    PendingPartialWithdrawal :=
+  { validatorIndex := v.validatorIndex, amount := v.amount, withdrawableEpoch := v.withdrawableEpoch }
+private def cvPendingConsolidation [Preset] (v : Gloas.PendingConsolidation) : PendingConsolidation :=
+  { sourceIndex := v.sourceIndex, targetIndex := v.targetIndex }
+private def cvBuilder [Preset] (v : Gloas.Builder) : Builder :=
+  { pubkey := v.pubkey, version := v.version, executionAddress := v.executionAddress,
+    balance := v.balance, depositEpoch := v.depositEpoch, withdrawableEpoch := v.withdrawableEpoch }
+private def cvBuilderPendingWithdrawal [Preset] (v : Gloas.BuilderPendingWithdrawal) :
+    BuilderPendingWithdrawal :=
+  { feeRecipient := v.feeRecipient, amount := v.amount, builderIndex := v.builderIndex }
+private def cvBuilderPendingPayment [Preset] (v : Gloas.BuilderPendingPayment) : BuilderPendingPayment :=
+  { weight := v.weight, withdrawal := cvBuilderPendingWithdrawal v.withdrawal,
+    proposerIndex := v.proposerIndex }
+private def cvWithdrawal [Preset] (v : Gloas.Withdrawal) : Withdrawal :=
+  { index := v.index, validatorIndex := v.validatorIndex, address := v.address, amount := v.amount }
+
+/-- Convert the Gloas bid to the Heze bid. At alpha.11 the bid is unchanged, so this is a
+plain 12-field copy. -/
+private def cvExecutionPayloadBid [Preset] (v : Gloas.ExecutionPayloadBid) : ExecutionPayloadBid :=
+  { parentBlockHash := v.parentBlockHash, parentBlockRoot := v.parentBlockRoot,
+    blockHash := v.blockHash, prevRandao := v.prevRandao, feeRecipient := v.feeRecipient,
+    gasLimit := v.gasLimit, builderIndex := v.builderIndex, slot := v.slot, value := v.value,
+    executionPayment := v.executionPayment, blobKzgCommitments := v.blobKzgCommitments,
+    executionRequestsRoot := v.executionRequestsRoot }
+
+/-- The fork upgrade `upgrade_to_heze(pre)`: builds the Heze state from a finished Gloas
+one. At alpha.11 every field carries across; only the fork version changes
+(`previous := pre.fork.current`, `current := HEZE_FORK_VERSION`, `epoch := get_current_epoch(pre)`).
+`hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by the runner. -/
+def upgradeToHeze [Preset] (hezeForkVersion : Version) (pre : Gloas.BeaconState) :
+    Heze.BeaconState :=
+  let epoch : Epoch := pre.slot / UInt64.ofNat Const.slotsPerEpoch
+  { genesisTime                   := pre.genesisTime
+    genesisValidatorsRoot         := pre.genesisValidatorsRoot
+    slot                          := pre.slot
+    forkData                      :=
+      { previousVersion := pre.forkData.currentVersion
+        currentVersion  := hezeForkVersion
+        epoch           := epoch }
+    latestBlockHeader             := cvBeaconBlockHeader pre.latestBlockHeader
+    blockRoots                    := pre.blockRoots
+    stateRoots                    := pre.stateRoots
+    historicalRoots               := pre.historicalRoots
+    eth1Data                      := cvEth1Data pre.eth1Data
+    eth1DataVotes                 := pre.eth1DataVotes.mapCap cvEth1Data
+    eth1DepositIndex              := pre.eth1DepositIndex
+    validators                    := pre.validators.mapCap cvValidator
+    balances                      := pre.balances
+    randaoMixes                   := pre.randaoMixes
+    slashings                     := pre.slashings
+    previousEpochParticipation    := pre.previousEpochParticipation
+    currentEpochParticipation     := pre.currentEpochParticipation
+    justificationBits             := pre.justificationBits
+    previousJustifiedCheckpoint   := cvCheckpoint pre.previousJustifiedCheckpoint
+    currentJustifiedCheckpoint    := cvCheckpoint pre.currentJustifiedCheckpoint
+    finalizedCheckpoint           := cvCheckpoint pre.finalizedCheckpoint
+    inactivityScores              := pre.inactivityScores
+    currentSyncCommittee          := cvSyncCommittee pre.currentSyncCommittee
+    nextSyncCommittee             := cvSyncCommittee pre.nextSyncCommittee
+    latestBlockHash               := pre.latestBlockHash
+    nextWithdrawalIndex           := pre.nextWithdrawalIndex
+    nextWithdrawalValidatorIndex  := pre.nextWithdrawalValidatorIndex
+    historicalSummaries           := pre.historicalSummaries.mapCap cvHistoricalSummary
+    depositRequestsStartIndex     := pre.depositRequestsStartIndex
+    depositBalanceToConsume       := pre.depositBalanceToConsume
+    exitBalanceToConsume          := pre.exitBalanceToConsume
+    earliestExitEpoch             := pre.earliestExitEpoch
+    consolidationBalanceToConsume := pre.consolidationBalanceToConsume
+    earliestConsolidationEpoch    := pre.earliestConsolidationEpoch
+    pendingDeposits               := pre.pendingDeposits.mapCap cvPendingDeposit
+    pendingPartialWithdrawals     := pre.pendingPartialWithdrawals.mapCap cvPendingPartialWithdrawal
+    pendingConsolidations         := pre.pendingConsolidations.mapCap cvPendingConsolidation
+    proposerLookahead             := pre.proposerLookahead
+    builders                      := pre.builders.mapCap cvBuilder
+    nextWithdrawalBuilderIndex    := pre.nextWithdrawalBuilderIndex
+    executionPayloadAvailability  := pre.executionPayloadAvailability
+    builderPendingPayments        := pre.builderPendingPayments.map cvBuilderPendingPayment
+    builderPendingWithdrawals     := pre.builderPendingWithdrawals.mapCap cvBuilderPendingWithdrawal
+    latestExecutionPayloadBid     := cvExecutionPayloadBid pre.latestExecutionPayloadBid
+    payloadExpectedWithdrawals    := pre.payloadExpectedWithdrawals.mapCap cvWithdrawal
+    ptcWindow                     := pre.ptcWindow }
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Upgrade.lean
@@ -8,7 +8,8 @@ sanctioned cross-fork reference. At alpha.11 it is a near-passthrough: every
 `BeaconState` field carries across and only the fork version bumps. Because Heze's
 containers are fresh namespace twins of Gloas's, each container field is copied through
 a field-by-field `cv*` converter, the mechanical price of the flat namespace. No builder
-onboarding / PTC recompute (the upgrade is a pure copy).
+onboarding and no PTC recompute: builders were onboarded and the PTC window built at the
+Gloas fork, and EIP-7805 adds no `BeaconState` field, so the upgrade is a pure copy.
 -/
 
 set_option autoImplicit false
@@ -69,7 +70,9 @@ private def cvExecutionPayloadBid [Preset] (v : Gloas.ExecutionPayloadBid) : Exe
 /-- The fork upgrade `upgrade_to_heze(pre)`: builds the Heze state from a finished Gloas
 one. At alpha.11 every field carries across; only the fork version changes
 (`previous := pre.fork.current`, `current := HEZE_FORK_VERSION`, `epoch := get_current_epoch(pre)`).
-`hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by the runner. -/
+No builder onboarding or PTC recompute is needed: both already happened at the Gloas fork
+and live in the pre-state. `hezeForkVersion` is the config's `HEZE_FORK_VERSION`, passed by
+the runner. -/
 def upgradeToHeze [Preset] (hezeForkVersion : Version) (pre : Gloas.BeaconState) :
     Heze.BeaconState :=
   let epoch : Epoch := pre.slot / UInt64.ofNat Const.slotsPerEpoch

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -29,12 +29,20 @@ withdrawal credentials. Restated (a plain `def` rather than an inheritable `fork
 def addressOf (v : Validator) : ExecutionAddress :=
   Vector.ofFn (fun i : Fin 20 => vget v.withdrawalCredentials (12 + i.val))
 
-/-- `get_balance_after_withdrawals` over `Heze.State`: the balance net of any
-already-queued withdrawals for `vi`. Restated (a plain `def` rather than a `forkdef`). -/
-def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) : Gwei :=
+/-- `get_balance_after_withdrawals` over `Heze.State` (`capella/beacon-chain.md:378`): the
+balance net of any already-queued withdrawals for `vi`. Restated (a plain `def` rather than a
+`forkdef`). Throwing, mirroring the Gloas copy: `state.balances[validator_index]` is a bare list
+index (`IndexError` → `sszGetIdx` → `outOfBounds`), and `- withdrawn` is a bare `uint64`
+subtraction whose underflow raises `ValueError`, uncaught by the reference runner
+(`context.py:429-433`), so it throws the uncaught `.arithmetic` reject, not a caught `.assert`.
+See `Gloas.balanceAfterWithdrawals`. -/
+def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
+    StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
-  let bal := sszGet state balances[vi.toNat]!
-  if withdrawn > bal then 0 else bal - withdrawn
+  let bal ← sszGetIdx (sszGet state balances) vi.toNat
+  if withdrawn > bal then
+    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
+  return bal - withdrawn
 
 inherit getBuilderWithdrawals
 inherit getPendingPartialWithdrawals

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -1,0 +1,48 @@
+import EthCLSpecs.Heze.Operations
+import EthCLSpecs.Gloas.Withdrawals
+
+/-!
+# `EthCLSpecs.Heze.Withdrawals`: the inherited builder-aware withdrawal sweep
+
+EIP-7805 changes no withdrawal logic. Gloas's `process_withdrawals` and its sweep helpers
+are `inherit`ed over Heze state. `addressOf` / `balanceAfterWithdrawals` are plain `def`s
+in Gloas (not captured `forkdef`s), so they are restated for the Heze validator / state
+before the sweep helpers that use them.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Heze
+
+state_section
+
+inherit isFullyWithdrawable
+inherit isPartiallyWithdrawable
+inherit isEligibleForPartialWithdrawals
+
+/-- `addressOf` over `Heze.Validator`: the 20-byte execution address in the validator's
+withdrawal credentials. Restated (a plain `def` rather than an inheritable `forkdef`). -/
+def addressOf (v : Validator) : ExecutionAddress :=
+  Vector.ofFn (fun i : Fin 20 => vget v.withdrawalCredentials (12 + i.val))
+
+/-- `get_balance_after_withdrawals` over `Heze.State`: the balance net of any
+already-queued withdrawals for `vi`. Restated (a plain `def` rather than a `forkdef`). -/
+def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) : Gwei :=
+  let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
+  let bal := sszGet state balances[vi.toNat]!
+  if withdrawn > bal then 0 else bal - withdrawn
+
+inherit getBuilderWithdrawals
+inherit getPendingPartialWithdrawals
+inherit getBuildersSweepWithdrawals
+inherit getValidatorsSweepWithdrawals
+inherit getExpectedWithdrawals
+inherit applyWithdrawals
+inherit processWithdrawals
+
+end
+
+end EthCLSpecs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -6,8 +6,9 @@ import EthCLSpecs.Gloas.Withdrawals
 
 EIP-7805 changes no withdrawal logic. Gloas's `process_withdrawals` and its sweep helpers
 are `inherit`ed over Heze state. `addressOf` / `balanceAfterWithdrawals` are plain `def`s
-in Gloas (not captured `forkdef`s), so they are restated for the Heze validator / state
-before the sweep helpers that use them.
+in Gloas, which the capture does not cover (only `forkdef` / `forkcontainer` / `forkstruct`
+replay, `SPEC_AUTHORING_MODEL.md` §8.5), so they are restated for the Heze validator /
+state before the sweep helpers that use them.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -34,8 +34,13 @@ balance net of any already-queued withdrawals for `vi`. Restated (a plain `def` 
 `forkdef`). Throwing, mirroring the Gloas copy: `state.balances[validator_index]` is a bare list
 index (`IndexError` → `sszGetIdx` → `outOfBounds`), and `- withdrawn` is a bare `uint64`
 subtraction whose underflow raises `ValueError`, uncaught by the reference runner
-(`context.py:429-433`), so it throws the uncaught `.arithmetic` reject, not a caught `.assert`.
-See `Gloas.balanceAfterWithdrawals`. -/
+(`context.py:424-435`), so it throws the uncaught `.arithmetic` reject, not a caught `.assert`.
+See `Gloas.balanceAfterWithdrawals`.
+
+The `withdrawn` accumulator is the Fulu divergence restated a third time, deferred with it:
+pyspec's `sum(...)` adds unbounded ints, this fold wraps on `UInt64`, so a true sum ≥ 2^64
+wraps past the `withdrawn > bal` guard and returns a wrong balance where pyspec raises.
+`checkedAdd` (`Spec/Errors.lean`) is the fix when it is taken up. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
   let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -46,9 +46,7 @@ def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Wi
       checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
     else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
-  if withdrawn > bal then
-    throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")
-  return bal - withdrawn
+  checkedSub bal withdrawn "get_balance_after_withdrawals: balances[i] - withdrawn"
 
 inherit getBuilderWithdrawals
 inherit getPendingPartialWithdrawals

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Withdrawals.lean
@@ -37,13 +37,14 @@ subtraction whose underflow raises `ValueError`, uncaught by the reference runne
 (`context.py:424-435`), so it throws the uncaught `.arithmetic` reject, not a caught `.assert`.
 See `Gloas.balanceAfterWithdrawals`.
 
-The `withdrawn` accumulator is the Fulu divergence restated a third time, deferred with it:
-pyspec's `sum(...)` adds unbounded ints, this fold wraps on `UInt64`, so a true sum ≥ 2^64
-wraps past the `withdrawn > bal` guard and returns a wrong balance where pyspec raises.
-`checkedAdd` (`Spec/Errors.lean`) is the fix when it is taken up. -/
+The `withdrawn` accumulator folds through `checkedAdd`, as in Fulu and Gloas; pyspec's
+`sum(...)` raises during its own accumulation. See `Fulu.balanceAfterWithdrawals`. -/
 def balanceAfterWithdrawals (state : State) (vi : ValidatorIndex) (ws : Array Withdrawal) :
     StateTransition Gwei := do
-  let withdrawn := ws.foldl (fun acc w => if w.validatorIndex == vi then acc + w.amount else acc) 0
+  let withdrawn ← ws.foldlM (init := (0 : Gwei)) fun acc w =>
+    if w.validatorIndex == vi then
+      checkedAdd acc w.amount "get_balance_after_withdrawals: sum(withdrawal.amount)"
+    else pure acc
   let bal ← sszGetIdx (sszGet state balances) vi.toNat
   if withdrawn > bal then
     throw (StateTransitionError.arithmetic "get_balance_after_withdrawals: balances[i] - withdrawn underflow")

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -165,13 +165,21 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
       | "boost"             => steps := steps.push (.checkBoost (hexToBytes parts[1]!))
       | "time"              => steps := steps.push (.checkTime parts[1]!.toNat!)
       | "genesis_time"      => steps := steps.push (.checkGenesisTime parts[1]!.toNat!)
-      | "unsupported"       => steps := steps.push (.unsupported "get_proposer_head / should_override check")
-      | _                   => pure ()
+      | "unsupported"       =>
+        -- `harness.py` passes the specific descriptor (`should_override_forkchoice_update`, or an
+        -- unrecognized step key like `on_inclusion_list`), so the xfail reason is accurate.
+        let reason := if parts.size > 1 then String.intercalate " " (parts.toList.drop 1) else "unmodeled step"
+        steps := steps.push (.unsupported s!"unsupported fork-choice step: {reason}")
+      -- An unrecognized token surfaces as `unsupported` (a `todo` xfail) rather than silently
+      -- dropping the step; `harness.py` already maps unknown steps.yaml keys to `unsupported`,
+      -- so this is the second line of defense.
+      | other               => steps := steps.push (.unsupported s!"unrecognized fork-choice step: {other}")
 
   match iface.runForkChoice anchorState anchorBlock steps with
   | .ok ()   => return "pass\tpassing\t"
   | .error e =>
-    -- Classify the runner error: a `spec todo` is out-of-scope, everything else (a
+    -- Classify the runner error: a `spec todo` is the xfail work-queue, a `spec
+    -- outOfScope` a deliberate skip, everything else (a
     -- decode failure, a check mismatch, an unexpected rejection, a missing store key) is
     -- a bug on the fork-choice path (per-step `valid:false` rejections are resolved inside
     -- the interpreter and never reach here).
@@ -211,7 +219,7 @@ partial def serve (iface : ForkInterface) : IO UInt32 := do
   let stdin ← IO.getStdin
   let stdout ← IO.getStdout
   let rec loop : IO UInt32 := do
-    -- Strip only the line ending, not interior / trailing tabs (the final
+    -- Strip the line ending while keeping interior / trailing tabs (the final
     -- `inputPaths` field is empty, hence a trailing tab, when a case has no inputs).
     let line := ((← stdin.getLine).dropEndWhile (fun c => c == '\n' || c == '\r')).toString
     if line.isEmpty then
@@ -228,32 +236,71 @@ def toHex (b : ByteArray) : String :=
     let s := String.ofList (Nat.toDigits 16 x.toNat)
     if s.length == 1 then "0" ++ s else s)
 
+/-- Resolve a fork name to its minimal-preset interface; `none` for an unknown name.
+`main` uses this to error on a bad fork argument instead of inheriting
+`pickInterface`'s silent Fulu default (kept only for the documented no-argument
+invocation). -/
+def forkInterface? (forkName : String) : Option ForkInterface :=
+  match forkName with
+  | "fulu"  => some EthCLSpecs.Fulu.Interface.fuluInterface
+  | "gloas" => some EthCLSpecs.Gloas.Interface.gloasInterface
+  | "heze"  => some EthCLSpecs.Heze.Interface.hezeInterface
+  | _       => none
+
 /-- Select a fork's interface at a preset. -/
 @[reducible] def pickInterface (forkName preset : String) : ForkInterface :=
   match forkName, preset with
   | "gloas", "mainnet" => EthCLSpecs.Gloas.Interface.gloasInterfaceMainnet
   | "gloas", _         => EthCLSpecs.Gloas.Interface.gloasInterface
+  | "heze",  "mainnet" => EthCLSpecs.Heze.Interface.hezeInterfaceMainnet
+  | "heze",  _         => EthCLSpecs.Heze.Interface.hezeInterface
   | _,       "mainnet" => EthCLSpecs.Fulu.Interface.fuluInterfaceMainnet
   | _,       _         => EthCLSpecs.Fulu.Interface.fuluInterface
+
+/-- Serve at a named fork/preset, erroring on the names `pickInterface` would silently
+default. An unknown fork or preset here is a typo'd invocation (the pytest harness passes
+exact names), and silently decoding another fork's SSZ shows up as a wall of opaque decode
+failures instead of one clear message. -/
+def serveKnown (forkName preset : String) : IO UInt32 := do
+  if (forkInterface? forkName).isNone then
+    IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2
+  else if preset != "minimal" && preset != "mainnet" then
+    IO.eprintln s!"unknown preset: {preset} (expected minimal / mainnet)"; return 2
+  else
+    serve (pickInterface forkName preset)
 
 end EthCLSpecs.PySpecTests
 
 /-- The exe entry point. `pyspec_server [fork [preset]]` runs the server loop at
-the named fork's interface and preset (`fulu` / `minimal` defaults). The
-`stateroot [fork] <path>` mode decodes a `BeaconState` and prints its root (a
-decode / container-layer sanity check). -/
+the named fork's interface and preset; the no-argument invocation defaults to
+`fulu` / `minimal`, and a named-but-unknown fork or preset is an error rather
+than a silent Fulu fallback. The `stateroot [fork] <path>` mode decodes a
+`BeaconState` and prints its root (a decode / container-layer sanity check). -/
 def main (args : List String) : IO UInt32 := do
   match args with
   | ["stateroot", path] =>
-    let bytes ← IO.FS.readBinFile path
-    match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
-    | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
-    | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  | ["stateroot", "gloas", path] =>
-    let bytes ← IO.FS.readBinFile path
-    match EthCLSpecs.Gloas.Interface.gloasInterface.stateRoot bytes with
-    | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
-    | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  | [forkName, preset] => EthCLSpecs.PySpecTests.serve (EthCLSpecs.PySpecTests.pickInterface forkName preset)
-  | [forkName]         => EthCLSpecs.PySpecTests.serve (EthCLSpecs.PySpecTests.pickInterface forkName "minimal")
-  | _                  => EthCLSpecs.PySpecTests.serve EthCLSpecs.Fulu.Interface.fuluInterface
+    -- `stateroot <fork>` with the path forgotten lands here with `path` bound to the
+    -- fork name (and would decode a file of that name as Fulu); catch it explicitly.
+    if (EthCLSpecs.PySpecTests.forkInterface? path).isSome then
+      IO.eprintln s!"stateroot: missing <path> after fork name {path}"; return 2
+    else
+      let bytes ← IO.FS.readBinFile path
+      match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
+      | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
+      | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
+  -- `fork` is a registered token of the spec DSL (the `forkstruct` family), so the
+  -- binder is `forkName`, matching the serve arms below.
+  | ["stateroot", forkName, path] =>
+    match EthCLSpecs.PySpecTests.forkInterface? forkName with
+    | none => IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2
+    | some iface =>
+      let bytes ← IO.FS.readBinFile path
+      match iface.stateRoot bytes with
+      | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
+      | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
+  | [forkName, preset] => EthCLSpecs.PySpecTests.serveKnown forkName preset
+  | [forkName]         => EthCLSpecs.PySpecTests.serveKnown forkName "minimal"
+  | []                 => EthCLSpecs.PySpecTests.serve EthCLSpecs.Fulu.Interface.fuluInterface
+  | _ =>
+    IO.eprintln "usage: pyspec_server [fork [preset]] | pyspec_server stateroot [fork] <path>"
+    return 2

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -178,8 +178,8 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
   match iface.runForkChoice anchorState anchorBlock steps with
   | .ok ()   => return "pass\tpassing\t"
   | .error e =>
-    -- Classify the runner error: a `spec todo` is the xfail work-queue, a `spec
-    -- outOfScope` a deliberate skip, everything else (a
+    -- Classify the runner error: a `spec todo` means unfinished work (reported `xfail`), a
+    -- `spec outOfScope` means deliberately unmodeled (reported `skip`); everything else (a
     -- decode failure, a check mismatch, an unexpected rejection, a missing store key) is
     -- a bug on the fork-choice path (per-step `valid:false` rejections are resolved inside
     -- the interpreter and never reach here).
@@ -288,8 +288,8 @@ def main (args : List String) : IO UInt32 := do
       match EthCLSpecs.Fulu.Interface.fuluInterface.stateRoot bytes with
       | .ok root => IO.println (EthCLSpecs.PySpecTests.toHex root); return 0
       | .error e => IO.eprintln s!"decode failed: {repr e}"; return 1
-  -- `fork` is a registered token of the spec DSL (the `forkstruct` family), so the
-  -- binder is `forkName`, matching the serve arms below.
+  -- The pattern binder cannot be named `fork`, because `fork` is a keyword of the spec
+  -- DSL; use `forkName`, as in the serve arms below.
   | ["stateroot", forkName, path] =>
     match EthCLSpecs.PySpecTests.forkInterface? forkName with
     | none => IO.eprintln s!"unknown fork: {forkName} (expected fulu / gloas / heze)"; return 2

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -184,16 +184,22 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
     -- a bug on the fork-choice path (per-step `valid:false` rejections are resolved inside
     -- the interpreter and never reach here).
     let detail := (match e with
-      | .decode what           => s!"{what} decode failed"
-      | .spec (.assert d)      => d
-      | .spec (.todo d)        => d
-      | .spec (.outOfScope d)  => d
-      | .spec (.missingKey _)  => "missing store key"
-      | .spec (.transition te) => reprStr te).replace "\t" " " |>.replace "\n" " "
-    match e with
-    | .spec (.todo _)       => return s!"fail\ttodo\t{detail}"
-    | .spec (.outOfScope _) => return s!"fail\tskip\t{detail}"
-    | _                     => return s!"fail\tbug\t{detail}"
+      | .decode what             => s!"{what} decode failed"
+      | .spec (.assert d)        => d
+      | .spec (.todo d)          => d
+      | .spec (.outOfScope d)    => d
+      | .spec (.missingKey _)    => "missing store key"
+      | .spec (.decodeFailure d) => d
+      | .spec (.transition te)   => reprStr te).replace "\t" " " |>.replace "\n" " "
+    -- Route the verdict through `RunError.classify` (which recurses into `.transition`), so a
+    -- nested state-transition `.todo` / `.outOfScope` reached on a fork-choice step reports as
+    -- xfail / skip rather than a bug. Everything else (decode/container bug, unexpected assert,
+    -- missing key, uncaught fault) is a bug on the fork-choice path; per-step `valid:false`
+    -- rejections are resolved inside the interpreter and never reach here.
+    match e.classify with
+    | .todo       => return s!"fail\ttodo\t{detail}"
+    | .outOfScope => return s!"fail\tskip\t{detail}"
+    | _           => return s!"fail\tbug\t{detail}"
 
 /-- Process one request line into a result line, against a given fork's interface.
 Exceptions become a `fail ⇥ bug` result so a single bad case never crashes the

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -33,8 +33,25 @@ From this directory, with the repo venv:
 caching backend for the plain FFI (caching is on by default). Useful for comparing
 cache-on against cache-off timings.
 
-The pin (`--tag`, default `v1.7.0-alpha.10`) selects the release; the archive is
+The pin (`--tag`, default `v1.7.0-alpha.11`) selects the release; the archive is
 downloaded once and cached.
+
+### Re-pinning checklist
+
+Bumping the pin touches more than the constant. In one pass:
+
+1. Bump `PINNED_VERSION` (`harness.py`) and each fork's `pyspecPinnedVersion`
+   (`Interface.lean`) together.
+2. Re-run the full sweep (`just ethcl-pyspec-full`) at both presets.
+3. Revalidate the spec-markdown line anchors (`<file>.md:NN`) in
+   `../docs/DISCREPANCIES.md` and the fork `.lean` docstrings against the new tag,
+   along with the recorded divergences themselves (the spec text may have moved
+   or fixed the branch a divergence pins).
+4. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
+   alpha.10→alpha.11 bump left six behind.
+5. Diff the corpus for new runners or handlers (new directories under
+   `tests/<preset>/<fork>/`); either collect them or name the exclusion in the
+   `IN_SCOPE_RUNNERS` allowlist comment, never leave one silently uncollected.
 
 ## Status
 

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -49,8 +49,7 @@ Bumping the pin touches more than the constant. In one pass:
 4. Re-check each recorded divergence itself (`IMPLEMENTATION_NOTES.md`, the
    per-fork divergence entries): the new spec text may have moved, or may have
    fixed the branch a divergence pins.
-5. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
-   alpha.10→alpha.11 bump left six behind.
+5. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`).
 6. Diff the corpus for new runners or handlers (new directories under
    `tests/<preset>/<fork>/`); either collect them or name the exclusion in the
    `IN_SCOPE_RUNNERS` allowlist comment, never leave one silently uncollected.

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -44,12 +44,14 @@ Bumping the pin touches more than the constant. In one pass:
    (`Interface.lean`) together.
 2. Re-run the full sweep (`just ethcl-pyspec-full`) at both presets.
 3. Revalidate the spec-markdown line anchors (`<file>.md:NN`) in
-   `../docs/DISCREPANCIES.md` and the fork `.lean` docstrings against the new tag,
-   along with the recorded divergences themselves (the spec text may have moved
-   or fixed the branch a divergence pins).
-4. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
+   `../docs/IMPLEMENTATION_NOTES.md`, `../docs/DISCREPANCIES.md`, and the fork
+   `.lean` docstrings against the new tag.
+4. Re-check each recorded divergence itself (`IMPLEMENTATION_NOTES.md`, the
+   per-fork divergence entries): the new spec text may have moved, or may have
+   fixed the branch a divergence pins.
+5. Sweep every doc for citations of the old tag (`grep -rn '<old-tag>'`); the
    alpha.10→alpha.11 bump left six behind.
-5. Diff the corpus for new runners or handlers (new directories under
+6. Diff the corpus for new runners or handlers (new directories under
    `tests/<preset>/<fork>/`); either collect them or name the exclusion in the
    `IN_SCOPE_RUNNERS` allowlist comment, never leave one silently uncollected.
 

--- a/packages/EthCLSpecs/PySpecTests/conftest.py
+++ b/packages/EthCLSpecs/PySpecTests/conftest.py
@@ -10,6 +10,7 @@ Run:
     pytest -n auto               # sharded across cores via xdist
     pytest --subset=0            # the full in-scope suite
     pytest --fork=gloas          # the Gloas vectors
+    pytest --fork=heze           # the Heze vectors
 """
 
 import pytest
@@ -20,7 +21,7 @@ from harness import ServerClient, ensure_archive, walk_cases, PINNED_VERSION
 def pytest_addoption(parser):
     parser.addoption("--preset", default="minimal",
                      help="consensus-spec-tests preset (minimal / mainnet)")
-    parser.addoption("--fork", default="fulu", help="fork to run (fulu / gloas)")
+    parser.addoption("--fork", default="fulu", help="fork to run (fulu / gloas / heze)")
     parser.addoption("--subset", type=int, default=2,
                      help="cases per (runner,handler); 0 = the full suite")
     parser.addoption("--tag", default=PINNED_VERSION,

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -24,21 +24,43 @@ import cramjam
 import yaml
 
 # The pinned release: the latest consensus-specs release, confirmed to
-# carry both Fulu and Gloas minimal vectors (matches
+# carry the Fulu, Gloas, and Heze minimal vectors (matches
 # EthCLSpecs.Fulu.Interface.pyspecPinnedVersion).
 PINNED_VERSION = "v1.7.0-alpha.11"
 CACHE_DIR = Path.home() / ".cache" / "sizzlean"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# In-scope (runner, handler-is-path-segment) formats for Fulu and Gloas.
+# In-scope (runner, handler-is-path-segment) formats for Fulu, Gloas, and Heze.
 # `ssz_static` runs the per-fork consensus-container vectors (decode →
 # hash-tree-root → round-trip) against the container types EthCLSpecs declares;
 # the fork-agnostic `ssz_generic` primitive vectors live in SizzLean instead.
 # `bls`, `kzg`, `light_client`, `merkle_proof`, `networking`, `sync` are out of
-# scope (they exercise primitives a dependency owns).
+# scope (they exercise primitives a dependency owns). `fast_confirmation` (the
+# confirmation-rule fork-choice format, minimal-only) is a runner we have not
+# implemented yet: deliberately uncollected, a named future work item rather
+# than a silent omission.
 IN_SCOPE_RUNNERS = {
     "sanity", "finality", "random", "epoch_processing", "operations",
     "rewards", "genesis", "fork", "transition", "fork_choice", "ssz_static",
+}
+
+# The `checks` keys `_build_fork_choice_request` models (its emitter chain) and,
+# for nested check objects, the subkeys each emitter reads. Keep both in lockstep
+# with the emitter chain: a key handled there but missing here emits a spurious
+# `unsupported <key>` line and silently demotes a fully-checked case to the
+# todo/xfail bucket.
+KNOWN_CHECK_KEYS = {
+    "get_proposer_head", "should_override_forkchoice_update", "head",
+    "payload_timeliness_vote", "payload_data_availability_vote",
+    "justified_checkpoint", "finalized_checkpoint", "proposer_boost_root",
+    "time", "genesis_time",
+}
+KNOWN_CHECK_SUBKEYS = {
+    "head": {"root", "slot", "payload_status"},
+    "payload_timeliness_vote": {"block_root", "votes"},
+    "payload_data_availability_vote": {"block_root", "votes"},
+    "justified_checkpoint": {"epoch", "root"},
+    "finalized_checkpoint": {"epoch", "root"},
 }
 
 
@@ -100,7 +122,8 @@ def walk_cases(extract_root: Path, preset: str, fork: str,
         # Fulu `fork` (Electra->Fulu upgrade) and `transition` (Electra->Fulu
         # boundary) require a full Electra parent fork the library never builds, so
         # they are permanently out of scope: not collected, not counted, not even as
-        # xfail. (The Gloas `fork` / `transition` are Fulu->Gloas, fully in scope.)
+        # xfail. (The Gloas `fork` / `transition` are Fulu->Gloas and the Heze ones
+        # Gloas->Heze, both fully in scope.)
         if fork == "fulu" and runner in ("fork", "transition"):
             continue
         for handler_dir in sorted(p for p in runner_dir.iterdir() if p.is_dir()):
@@ -136,8 +159,12 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
     `inputs` pair `anchorBlockPath,scriptPath`. The script is one line per
     `steps.yaml` entry, with `block` / `attestation` / `attester_slashing` steps
     referencing decompressed SSZ files by path, and `checks` split into one line
-    per supported key (`get_proposer_head` / `should_override_forkchoice_update`
-    checks become a single `unsupported` line, so the case reports out-of-scope)."""
+    per key. `get_proposer_head` emits a dedicated `get_proposer_head <root>`
+    step; `should_override_forkchoice_update` emits `unsupported
+    should_override_forkchoice_update`, so that case reports `todo` (an xfail).
+    Sibling keys in the same checks entry still emit their own lines. Any key or
+    nested subkey we don't model becomes `unsupported <key>`, keeping the xfail
+    reason accurate instead of silently dropping the check."""
     anchor_state = _decompress_to(tmpdir, case.path / "anchor_state.ssz_snappy")
     anchor_block = _decompress_to(tmpdir, case.path / "anchor_block.ssz_snappy")
     steps = yaml.safe_load((case.path / "steps.yaml").read_text())
@@ -171,10 +198,8 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
             c = s["checks"]
             if "get_proposer_head" in c:
                 lines.append(f"get_proposer_head {c['get_proposer_head']}")
-                continue
             if "should_override_forkchoice_update" in c:
-                lines.append("unsupported")
-                continue
+                lines.append("unsupported should_override_forkchoice_update")
             if "head" in c:
                 lines.append(f"head {c['head']['root']} {int(c['head']['slot'])}")
                 if "payload_status" in c["head"]:
@@ -197,6 +222,28 @@ def _build_fork_choice_request(case: Case, tmpdir: Path) -> str:
                 lines.append(f"time {int(c['time'])}")
             if "genesis_time" in c:
                 lines.append(f"genesis_time {int(c['genesis_time'])}")
+            # A check key we don't model (e.g. a future inclusion_list_satisfied) reports as
+            # `unsupported <key>`, so the case lands in the `todo`/xfail bucket rather than
+            # passing with the check silently dropped. The same guard runs one level down: an
+            # unmodeled subkey of a nested check object (e.g. a new field on `head` past
+            # root/slot/payload_status) surfaces as `unsupported <key>.<subkey>`, so the
+            # unmodeled-key promise covers nested shapes as well as top-level keys. `str(k)`
+            # keeps the join total if YAML 1.1 ever parses an unquoted key as a non-string.
+            # No alpha.11 vector hits either path.
+            unknown = [str(k) for k in c if k not in KNOWN_CHECK_KEYS]
+            for parent, known_sub in KNOWN_CHECK_SUBKEYS.items():
+                sub = c.get(parent)
+                if isinstance(sub, dict):
+                    unknown += [f"{parent}.{k}" for k in sub if k not in known_sub]
+            if unknown:
+                lines.append(f"unsupported {'/'.join(sorted(unknown))}")
+        else:
+            # An unrecognized step key (e.g. a future on_inclusion_list fork-choice step) reports
+            # as `unsupported <key>`, so the case lands `todo`/xfail with an accurate reason rather
+            # than silently dropping the step. Drop the auxiliary flags (valid / columns) and sort,
+            # so the reason names the step rather than its flags. No alpha.11 vector hits this.
+            keys = sorted(str(k) for k in s if k not in ("valid", "columns"))
+            lines.append(f"unsupported {'/'.join(keys) or 'unknown-step'}")
     script_path = tmpdir / "fc_script.txt"
     script_path.write_text("\n".join(lines))
     return "\t".join(["fork_choice", case.handler, str(anchor_state), "-", "1", "0", "-",

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -44,11 +44,13 @@ IN_SCOPE_RUNNERS = {
     "rewards", "genesis", "fork", "transition", "fork_choice", "ssz_static",
 }
 
-# The `checks` keys `_build_fork_choice_request` models (its emitter chain) and,
-# for nested check objects, the subkeys each emitter reads. Keep both in lockstep
-# with the emitter chain: a key handled there but missing here emits a spurious
-# `unsupported <key>` line and silently demotes a fully-checked case to the
-# todo/xfail bucket.
+# The `checks` keys `_build_fork_choice_request` recognizes. Most are modeled by
+# its emitter chain; `should_override_forkchoice_update` is recognized but
+# deliberately emitted as `unsupported` (the case lands todo/xfail).
+# KNOWN_CHECK_SUBKEYS below lists, for the nested check objects, the subkeys
+# each emitter reads. Keep both sets in lockstep with the emitter chain: a key
+# the chain handles but this set omits emits a spurious `unsupported <key>`
+# line and silently demotes a fully-checked case to the todo/xfail bucket.
 KNOWN_CHECK_KEYS = {
     "get_proposer_head", "should_override_forkchoice_update", "head",
     "payload_timeliness_vote", "payload_data_availability_vote",

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -25,12 +25,14 @@ Three forks are in scope:
 - **Fulu** is the base, authored whole. It carries the accumulated
   beacon-chain spec from Phase 0 through Electra, plus Fulu's PeerDAS
   data-availability additions (EIP-7594).
-- **Gloas** is a diff over Fulu. It adds enshrined proposer-builder separation
-  (EIP-7732): a builder registry, execution payload bids, the
+- **Gloas** is a diff over Fulu. It adds ePBS (EIP-7732): a builder
+  registry, execution payload bids, the
   payload-timeliness committee, and a reordered block pipeline.
 - **Heze** is a thin diff over Gloas. It adds fork-choice inclusion lists
-  (EIP-7805 FOCIL): the `InclusionList` container family, the inclusion-list
-  committee helpers, and the fork-choice store and satisfaction gate.
+  (EIP-7805 FOCIL): the `InclusionList` container family, the
+  inclusion-list committee helpers, an inclusion-list store folded into the
+  fork-choice store, and the payload satisfaction gate
+  (`is_payload_inclusion_list_satisfied`).
 
 For each fork the library implements the SSZ containers, the state transition
 (slots, blocks, epochs, and every operation), the fork upgrade, and a second

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -1,11 +1,11 @@
 # EthCLSpecs
 
 > **Status: experimental, single-developer; personal project, not an EF
-> release. Validated against the pyspec test vectors for two
-> forks (Fulu, Gloas); machine-checked proofs are future work.**
+> release. Validated against the pyspec test vectors for three
+> forks (Fulu, Gloas, Heze); machine-checked proofs are future work.**
 
-A Lean 4 implementation of the Ethereum consensus specification for the Fulu
-and Gloas forks. It is executable. The SSZ container types, the full
+A Lean 4 implementation of the Ethereum consensus specification for the Fulu,
+Gloas, and Heze forks. It is executable. The SSZ container types, the full
 beacon-chain state transition, the fork upgrade, and fork choice all run, and
 they are checked against Ethereum's pyspec
 [`consensus-spec-tests`](https://github.com/ethereum/consensus-spec-tests)
@@ -20,7 +20,7 @@ packages, through `EthCLLib`, to `EthCLSpecs`.
 
 ## What it covers
 
-Two forks are in scope:
+Three forks are in scope:
 
 - **Fulu** is the base, authored whole. It carries the accumulated
   beacon-chain spec from Phase 0 through Electra, plus Fulu's PeerDAS
@@ -28,6 +28,9 @@ Two forks are in scope:
 - **Gloas** is a diff over Fulu. It adds enshrined proposer-builder separation
   (EIP-7732): a builder registry, execution payload bids, the
   payload-timeliness committee, and a reordered block pipeline.
+- **Heze** is a thin diff over Gloas. It adds fork-choice inclusion lists
+  (EIP-7805 FOCIL): the `InclusionList` container family, the inclusion-list
+  committee helpers, and the fork-choice store and satisfaction gate.
 
 For each fork the library implements the SSZ containers, the state transition
 (slots, blocks, epochs, and every operation), the fork upgrade, and a second
@@ -80,8 +83,8 @@ inherit processRandao     -- a transition step it leaves unchanged
 ```
 
 **Validated against the real vectors.** The full in-scope suite passes at both
-the `minimal` and `mainnet` presets, for both forks, pinned to release
-`v1.7.0-alpha.10`. The verdict model is honest. An out-of-range read or a crash
+the `minimal` and `mainnet` presets, for all three forks (Fulu, Gloas, Heze),
+pinned to release `v1.7.0-alpha.11`. The verdict model is honest. An out-of-range read or a crash
 is a hard failure, and an unimplemented branch is a visible `xfail`. Every
 passing vector reflects a real match or a faithful rejection.
 
@@ -92,9 +95,9 @@ lake build EthCLLib EthCLSpecs       # build the framework and the fork bodies
 just ethcl-test                       # build everything plus the Lean self-tests
 
 # Pyspec against upstream vectors (downloads and caches the archive):
-just ethcl-pyspec-smoke          # dev subset, both forks
+just ethcl-pyspec-smoke          # dev subset, all three forks
 just ethcl-pyspec "--subset=0 --fork=gloas"   # one fork, full in-scope suite
-just ethcl-pyspec-full                # the full sweep: both presets, both forks
+just ethcl-pyspec-full                # the full sweep: both presets, all three forks
 ```
 
 CI runs the dev-subset smoke gate. The full multi-preset sweep runs on demand.

--- a/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
+++ b/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
@@ -40,7 +40,7 @@ bounded walk to finish.
 | `getPtc`                         | `Gloas/Operations.lean:368-376`     | Under the caller's guarantee that `data.slot + 1 == state.slot`, its computed offset into `ptcWindow` stays in range                              |
 | `canBuilderCoverBid`             | `Gloas/Operations.lean:419-422`     | Primary builder-solvency predicate; the natural theorem is that accepting a bid never leaves the builder insolvent                                |
 | `applyWithdrawals`               | `Gloas/Withdrawals.lean:173-184`    | A builder-flagged withdrawal decreases the builder's balance by at most its own balance, so the balance never goes negative                       |
-| `getAncestor`                    | `Gloas/ForkChoice.lean:156-163`     | The fuel supplied to its `fuelIterate` DAG walk is sufficient for the walk to terminate before running out                                        |
+| `getAncestor`                    | `Gloas/ForkChoice.lean:156-163`     | The fuel supplied to its `fuelLoop` DAG walk is sufficient for the walk to terminate before running out                                            |
 | `getHead`                        | `Gloas/ForkChoice.lean:446-465`     | The fuel `2 * blocks.length + 2` supplied to its LMD-GHOST walk is sufficient for the walk to reach a decided head before running out             |
 
 ---

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -54,10 +54,11 @@ DSL re-elaborates the captured `forkdef` in the Gloas namespace), so the overflo
 above propagated to Gloas with no Gloas-side change. The fork-choice asserts and plain-`Dict`
 reads throw faithfully, including `get_forkchoice_store`'s anchor-root assert (shared with Fulu
 and Heze) and the PTC block-replay vote writes (`notify_ptc_messages` routes through the
-throwing `on_payload_attestation_message`). The one holdout is `compute_pulled_up_tip`: it
-still swallows a justification-update reject, unreachable only because
-`get_block_root_at_slot` drops the pyspec recency assert. All catalogued in
-`IMPLEMENTATION_NOTES.md`, "Fork choice" and "Heze diff".
+throwing `on_payload_attestation_message`). `compute_pulled_up_tip` now propagates its
+`process_justification_and_finalization` reject instead of swallowing it, and
+`get_block_root_at_slot` carries the pyspec recency assert (`slot < state.slot <= slot +
+SLOTS_PER_HISTORICAL_ROOT`) again, so that reject is reachable rather than dead. All
+catalogued in `IMPLEMENTATION_NOTES.md`, "Fork choice" and "Heze diff".
 
 ## Heze
 

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -10,12 +10,17 @@ and the divergence is **recorded here** rather than papered over by bending Lean
 to a wrong vector.
 
 Each entry carries the vector id, the spec-text citation, and the upstream issue
-link, so the audit trail is one grep away.
+link, so the audit trail is one grep away. Resolved Lean-versus-vector divergences
+stay logged here for the audit trail even when the fix landed in Lean.
+
+Deliberate implementation divergences that no vector observes live in
+`IMPLEMENTATION_NOTES.md`, catalogued per fork; the FOCIL set is under "Heze diff".
 
 Pin: `v1.7.0-alpha.11` (all forks).
 
-Spec-markdown line citations (`<file>.md:NN`) are valid at this pin; every re-pin
-re-checks them alongside the divergences they anchor.
+Spec-markdown line citations (`<file>.md:NN`) resolve under `specs/` in
+`ethereum/consensus-specs` at the pinned version (also a git tag there) and are valid
+at this pin; every re-pin re-checks them alongside the divergences they anchor.
 
 ## Fulu
 
@@ -24,99 +29,38 @@ by root or rejects faithfully (`epoch_processing`, `operations` incl. standalone
 `execution_payload`, `sanity/blocks`, `sanity/slots`, `finality`, `random`,
 `rewards`, `fork_choice` incl. the PeerDAS data-availability `on_block` cases and
 `get_proposer_head`), with zero `xfail`. The only Fulu vectors not run are the
-deselected out-of-scope ones (`IMPLEMENTATION_NOTES.md` §2.x): the Fulu `fork` /
+deselected out-of-scope ones (`IMPLEMENTATION_NOTES.md`, "Scope and conformance"): the Fulu `fork` /
 `transition` formats (the Electra→Fulu upgrade / boundary, needing an Electra parent
 fork) and the `ssz_static` / `light_client` / `networking` / `merkle_proof` / `sync`
 runners.
 
 | Vector id | Spec citation | Upstream issue | Resolution |
 |---|---|---|---|
-| — | — | — | — |
+| `epoch_processing/registry_updates/pyspec_tests/invalid_large_withdrawable_epoch` | `electra/beacon-chain.md`, `initiate_validator_exit` | none (Lean-side gap) | Fixed in Lean |
 
-**Resolved.** `epoch_processing/registry_updates/.../invalid_large_withdrawable_epoch`
-was an open Lean-side gap (Lean's `UInt64` wrapped where the pyspec raises a
-`ValueError` serializing the overflowed `withdrawable_epoch`). Closed by asserting
-the `exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY` bound in
-`initiateValidatorExit`, so the case now rejects faithfully.
+The one resolved entry was a Lean-side gap: Lean's `UInt64`
+wrapped where the pyspec raises a `ValueError` serializing the overflowed
+`withdrawable_epoch`. Closed by asserting the `exit_epoch +
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY` bound in `initiateValidatorExit`, so the case
+now rejects faithfully.
 
 ## Gloas
 
-_No open discrepancies._ Gloas is fully ported (the EIP-7732 ePBS spine, operations,
-fork choice, and the Fulu→Gloas transition); every in-scope minimal and mainnet
-vector passes by root or rejects faithfully, with no `xfail`. Gloas inherits the Fulu
-`registry_updates` substep (`forkdef` replay), so the overflow fix above propagated to
-Gloas with no Gloas-side change.
-
-| Vector id | Spec citation | Upstream issue | Resolution |
-|---|---|---|---|
-| — | — | — | — |
+_No open discrepancies._ Gloas is fully ported (the EIP-7732 ePBS spine, that is the
+state-transition pipeline, plus operations, fork choice, and the Fulu→Gloas
+transition); every in-scope minimal and mainnet vector passes by root or rejects
+faithfully, with no `xfail`. Gloas inherits the Fulu `registry_updates` substep (the
+DSL re-elaborates the captured `forkdef` in the Gloas namespace), so the overflow fix
+above propagated to Gloas with no Gloas-side change. Two spec asserts dropped as
+total-function shapes are catalogued in `IMPLEMENTATION_NOTES.md`, "Fork choice" and
+"Heze diff" (the anchor-root one is shared with Fulu; Heze inherits both).
 
 ## Heze
 
-_No open vector discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
-`v1.7.0-alpha.11` (the two new containers do get full `ssz_static` suites, which pass), so there
-is no Lean-versus-vector divergence to record: the inherited Gloas spine and fork choice pass
-every in-scope Heze vector by root or reject faithfully, with no `xfail`. The vectorless FOCIL
-layer does carry deliberate divergences from the spec *text*, each pinned by the `Heze/*.lean`
-`#guard`s rather than exercised by a runner, and each recorded here so the audit trail is one
-grep away.
-
-`is_inclusion_list_satisfied` (`heze/fork-choice.md:54-62`) defers its verdict to
-`ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external EL. This
-harness has no execution layer, so the call routes through the `[ExecutionEngine]` seam
-(`EthCLLib.Spec.Engine`), whose default instance answers the constant `true`, the same treatment
-Gloas gives `verify_and_notify_new_payload` and `is_data_available`. That default is the residual
-EL trust boundary of the FOCIL gate; no conformance vector reaches the discriminating `false`
-branch, which the `pinRecordRefuted` pin drives end-to-end under a local refuting instance instead.
-The sibling `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with `assert
-root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so the Lean
-reads a missing key as `false` through `lookupD`. That default sits off the spec path, since the
-`payloads` / `payload_inclusion_list_satisfaction` co-write in `on_execution_payload_envelope` keeps
-the key present whenever `root ∈ payloads`. The `timeliness` read in
-`get_inclusion_list_transactions` is the same shape one store over: a plain dict read in the spec,
-`lookupD false` in Lean, off-path through `process_inclusion_list`'s own co-write
-(`Heze/ForkChoice.lean`).
-
-The other two are representational. `cyclicSample` (`heze/beacon-chain.md:95-110`) resamples the
-committee as `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation;
-the Lean read is total (`i % 0 = i`, then the `getD` default), and a real beacon chain never reaches a
-zero-active-validator slot, so the branch is unreachable (`Heze/Committees.lean`). The
-`InclusionListStore` is folded into the fork-choice `Store` as a field: the spec keeps it as a
-process-lifetime singleton (`heze/inclusion-list.md:28-38`, reached through
-`get_inclusion_list_store()`), but this framework's pure `EStateM` fork choice has no ambient
-mutable singleton to hang it off, so it rides inside `Store` and threads like every other piece of
-state, behavior-complete at zero coverage cost (`Heze/ForkChoice.lean`).
-
-The rest are total-function elisions of a spec `assert`/raise, the same class as
-`is_payload_inclusion_list_satisfied` above: latent (no alpha.11 vector reaches the branch) and
-each guarded or bounded at its call site. `record_payload_inclusion_list_satisfaction`
-(`heze/fork-choice.md`) reads `Slot(state.slot - 1)`; on a slot-0 state the pyspec raises the
-uint64 underflow, invalidating the whole `on_execution_payload_envelope` call with the store
-unmodified, while the Lean guards the underflow, records the verdict over an empty required set,
-and proceeds (`Heze/ForkChoice.lean`, `recordPayloadInclusionListSatisfaction`). Only an envelope
-whose target block state sits at slot 0 (the genesis anchor) could tell the difference, and no
-vector produces one. `should_extend_payload` (`heze/fork-choice.md`) opens with `assert
-store.blocks[root].slot + 1 == get_current_slot(store)`; a pure `Bool` forkdef cannot throw, so
-the Lean elides the assert, and its one caller (`get_payload_status_tiebreaker`) is gated by
-`is_previous_slot_payload_decision`, which enforces the same slot equation. The Gloas
-`should_extend_payload` carries the identical elision, so this is inherited shape, recorded here
-with the Heze layer that restates the body. Inside the same function, the spec also reads
-`store.blocks[proposer_root]` unguarded (a `KeyError` on a boost root absent from `blocks`); the
-Lean's `| none => true` extends instead, a miss-default in the *accepting* direction, unreachable
-while the boost root is always a stored block (`on_block` sets it).
-`is_valid_inclusion_list_signature`
-(`heze/beacon-chain.md:76-87`) reads `state.validators[message.validator_index]`, which raises
-`IndexError` on an out-of-range wire index; the Lean bounds the index and returns `false` instead
-(`Heze/Signing.lean`). Same rejection, different mechanism, and no in-model caller by design.
-`get_forkchoice_store` (`heze/fork-choice.md:140-166`) opens with `assert anchor_block.state_root
-== hash_tree_root(anchor_state)`; the Lean restatement elides it (a pure constructor), so an
-inconsistent anchor pair would seed a store instead of raising. Every fork_choice vector runs
-through this constructor, but the harness always derives the anchor block and state from the same
-vector's files, so the branch is unreachable in conformance; the Gloas and Fulu constructors carry
-the identical elision. Below this threshold, one framework-wide note: the inherited time
-arithmetic (`timeIntoSlotMs`, the store-time seed) wraps `UInt64` where the pyspec saturates or
-raises, observable only at astronomically unreachable uptimes.
-
-| Vector id | Spec citation | Upstream issue | Resolution |
-|---|---|---|---|
-| — | — | — | — |
+_No open discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
+`v1.7.0-alpha.11`; the two new containers pass their full `ssz_static` suites, and the
+inherited Gloas spine and fork choice pass every in-scope Heze vector by root or reject
+faithfully, with no `xfail`. The vectorless FOCIL layer carries deliberate divergences
+from the spec text; those are implementation choices no vector observes, catalogued in
+`IMPLEMENTATION_NOTES.md`, "Heze diff". Where a build-enforced pin covers one, the
+entry names it.

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -12,7 +12,10 @@ to a wrong vector.
 Each entry carries the vector id, the spec-text citation, and the upstream issue
 link, so the audit trail is one grep away.
 
-Pin: `v1.7.0-alpha.10` (both forks).
+Pin: `v1.7.0-alpha.11` (all forks).
+
+Spec-markdown line citations (`<file>.md:NN`) are valid at this pin; every re-pin
+re-checks them alongside the divergences they anchor.
 
 ## Fulu
 
@@ -43,6 +46,76 @@ fork choice, and the Fulu→Gloas transition); every in-scope minimal and mainne
 vector passes by root or rejects faithfully, with no `xfail`. Gloas inherits the Fulu
 `registry_updates` substep (`forkdef` replay), so the overflow fix above propagated to
 Gloas with no Gloas-side change.
+
+| Vector id | Spec citation | Upstream issue | Resolution |
+|---|---|---|---|
+| — | — | — | — |
+
+## Heze
+
+_No open vector discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
+`v1.7.0-alpha.11` (the two new containers do get full `ssz_static` suites, which pass), so there
+is no Lean-versus-vector divergence to record: the inherited Gloas spine and fork choice pass
+every in-scope Heze vector by root or reject faithfully, with no `xfail`. The vectorless FOCIL
+layer does carry deliberate divergences from the spec *text*, each pinned by the `Heze/*.lean`
+`#guard`s rather than exercised by a runner, and each recorded here so the audit trail is one
+grep away.
+
+`is_inclusion_list_satisfied` (`heze/fork-choice.md:54-62`) defers its verdict to
+`ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external EL. This
+harness has no execution layer, so the call routes through the `[ExecutionEngine]` seam
+(`EthCLLib.Spec.Engine`), whose default instance answers the constant `true`, the same treatment
+Gloas gives `verify_and_notify_new_payload` and `is_data_available`. That default is the residual
+EL trust boundary of the FOCIL gate; no conformance vector reaches the discriminating `false`
+branch, which the `pinRecordRefuted` pin drives end-to-end under a local refuting instance instead.
+The sibling `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with `assert
+root in store.payload_inclusion_list_satisfaction`; a pure `Bool` predicate cannot throw, so the Lean
+reads a missing key as `false` through `lookupD`. That default sits off the spec path, since the
+`payloads` / `payload_inclusion_list_satisfaction` co-write in `on_execution_payload_envelope` keeps
+the key present whenever `root ∈ payloads`. The `timeliness` read in
+`get_inclusion_list_transactions` is the same shape one store over: a plain dict read in the spec,
+`lookupD false` in Lean, off-path through `process_inclusion_list`'s own co-write
+(`Heze/ForkChoice.lean`).
+
+The other two are representational. `cyclicSample` (`heze/beacon-chain.md:95-110`) resamples the
+committee as `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation;
+the Lean read is total (`i % 0 = i`, then the `getD` default), and a real beacon chain never reaches a
+zero-active-validator slot, so the branch is unreachable (`Heze/Committees.lean`). The
+`InclusionListStore` is folded into the fork-choice `Store` as a field: the spec keeps it as a
+process-lifetime singleton (`heze/inclusion-list.md:28-38`, reached through
+`get_inclusion_list_store()`), but this framework's pure `EStateM` fork choice has no ambient
+mutable singleton to hang it off, so it rides inside `Store` and threads like every other piece of
+state, behavior-complete at zero coverage cost (`Heze/ForkChoice.lean`).
+
+The rest are total-function elisions of a spec `assert`/raise, the same class as
+`is_payload_inclusion_list_satisfied` above: latent (no alpha.11 vector reaches the branch) and
+each guarded or bounded at its call site. `record_payload_inclusion_list_satisfaction`
+(`heze/fork-choice.md`) reads `Slot(state.slot - 1)`; on a slot-0 state the pyspec raises the
+uint64 underflow, invalidating the whole `on_execution_payload_envelope` call with the store
+unmodified, while the Lean guards the underflow, records the verdict over an empty required set,
+and proceeds (`Heze/ForkChoice.lean`, `recordPayloadInclusionListSatisfaction`). Only an envelope
+whose target block state sits at slot 0 (the genesis anchor) could tell the difference, and no
+vector produces one. `should_extend_payload` (`heze/fork-choice.md`) opens with `assert
+store.blocks[root].slot + 1 == get_current_slot(store)`; a pure `Bool` forkdef cannot throw, so
+the Lean elides the assert, and its one caller (`get_payload_status_tiebreaker`) is gated by
+`is_previous_slot_payload_decision`, which enforces the same slot equation. The Gloas
+`should_extend_payload` carries the identical elision, so this is inherited shape, recorded here
+with the Heze layer that restates the body. Inside the same function, the spec also reads
+`store.blocks[proposer_root]` unguarded (a `KeyError` on a boost root absent from `blocks`); the
+Lean's `| none => true` extends instead, a miss-default in the *accepting* direction, unreachable
+while the boost root is always a stored block (`on_block` sets it).
+`is_valid_inclusion_list_signature`
+(`heze/beacon-chain.md:76-87`) reads `state.validators[message.validator_index]`, which raises
+`IndexError` on an out-of-range wire index; the Lean bounds the index and returns `false` instead
+(`Heze/Signing.lean`). Same rejection, different mechanism, and no in-model caller by design.
+`get_forkchoice_store` (`heze/fork-choice.md:140-166`) opens with `assert anchor_block.state_root
+== hash_tree_root(anchor_state)`; the Lean restatement elides it (a pure constructor), so an
+inconsistent anchor pair would seed a store instead of raising. Every fork_choice vector runs
+through this constructor, but the harness always derives the anchor block and state from the same
+vector's files, so the branch is unreachable in conformance; the Gloas and Fulu constructors carry
+the identical elision. Below this threshold, one framework-wide note: the inherited time
+arithmetic (`timeIntoSlotMs`, the store-time seed) wraps `UInt64` where the pyspec saturates or
+raises, observable only at astronomically unreachable uptimes.
 
 | Vector id | Spec citation | Upstream issue | Resolution |
 |---|---|---|---|

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -51,9 +51,13 @@ state-transition pipeline, plus operations, fork choice, and the Fulu→Gloas
 transition); every in-scope minimal and mainnet vector passes by root or rejects
 faithfully, with no `xfail`. Gloas inherits the Fulu `registry_updates` substep (the
 DSL re-elaborates the captured `forkdef` in the Gloas namespace), so the overflow fix
-above propagated to Gloas with no Gloas-side change. Two spec asserts dropped as
-total-function shapes are catalogued in `IMPLEMENTATION_NOTES.md`, "Fork choice" and
-"Heze diff" (the anchor-root one is shared with Fulu; Heze inherits both).
+above propagated to Gloas with no Gloas-side change. The fork-choice asserts and plain-`Dict`
+reads throw faithfully, including `get_forkchoice_store`'s anchor-root assert (shared with Fulu
+and Heze) and the PTC block-replay vote writes (`notify_ptc_messages` routes through the
+throwing `on_payload_attestation_message`). The one holdout is `compute_pulled_up_tip`: it
+still swallows a justification-update reject, unreachable only because
+`get_block_root_at_slot` drops the pyspec recency assert. All catalogued in
+`IMPLEMENTATION_NOTES.md`, "Fork choice" and "Heze diff".
 
 ## Heze
 

--- a/packages/EthCLSpecs/docs/DISCREPANCIES.md
+++ b/packages/EthCLSpecs/docs/DISCREPANCIES.md
@@ -19,8 +19,8 @@ Deliberate implementation divergences that no vector observes live in
 Pin: `v1.7.0-alpha.11` (all forks).
 
 Spec-markdown line citations (`<file>.md:NN`) resolve under `specs/` in
-`ethereum/consensus-specs` at the pinned version (also a git tag there) and are valid
-at this pin; every re-pin re-checks them alongside the divergences they anchor.
+`ethereum/consensus-specs` at the pinned version; every re-pin re-checks them
+alongside the divergences they anchor.
 
 ## Fulu
 
@@ -31,8 +31,7 @@ by root or rejects faithfully (`epoch_processing`, `operations` incl. standalone
 `get_proposer_head`), with zero `xfail`. The only Fulu vectors not run are the
 deselected out-of-scope ones (`IMPLEMENTATION_NOTES.md`, "Scope and conformance"): the Fulu `fork` /
 `transition` formats (the Electra→Fulu upgrade / boundary, needing an Electra parent
-fork) and the `ssz_static` / `light_client` / `networking` / `merkle_proof` / `sync`
-runners.
+fork) and the `light_client` / `networking` / `merkle_proof` / `sync` runners.
 
 | Vector id | Spec citation | Upstream issue | Resolution |
 |---|---|---|---|
@@ -51,21 +50,12 @@ state-transition pipeline, plus operations, fork choice, and the Fulu→Gloas
 transition); every in-scope minimal and mainnet vector passes by root or rejects
 faithfully, with no `xfail`. Gloas inherits the Fulu `registry_updates` substep (the
 DSL re-elaborates the captured `forkdef` in the Gloas namespace), so the overflow fix
-above propagated to Gloas with no Gloas-side change. The fork-choice asserts and plain-`Dict`
-reads throw faithfully, including `get_forkchoice_store`'s anchor-root assert (shared with Fulu
-and Heze) and the PTC block-replay vote writes (`notify_ptc_messages` routes through the
-throwing `on_payload_attestation_message`). `compute_pulled_up_tip` now propagates its
-`process_justification_and_finalization` reject instead of swallowing it, and
-`get_block_root_at_slot` carries the pyspec recency assert (`slot < state.slot <= slot +
-SLOTS_PER_HISTORICAL_ROOT`) again, so that reject is reachable rather than dead. All
-catalogued in `IMPLEMENTATION_NOTES.md`, "Fork choice" and "Heze diff".
+above propagated to Gloas with no Gloas-side change. Deliberate divergences are
+catalogued in `IMPLEMENTATION_NOTES.md`, "Gloas diff" and "Fork choice".
 
 ## Heze
 
 _No open discrepancies._ EIP-7805 (FOCIL) ships no behavioral conformance vector at
-`v1.7.0-alpha.11`; the two new containers pass their full `ssz_static` suites, and the
-inherited Gloas spine and fork choice pass every in-scope Heze vector by root or reject
-faithfully, with no `xfail`. The vectorless FOCIL layer carries deliberate divergences
-from the spec text; those are implementation choices no vector observes, catalogued in
-`IMPLEMENTATION_NOTES.md`, "Heze diff". Where a build-enforced pin covers one, the
-entry names it.
+`v1.7.0-alpha.11`, so there is no Lean-versus-vector divergence to record for the FOCIL
+layer. Its deliberate divergences from the spec text are catalogued in
+`IMPLEMENTATION_NOTES.md`, "Heze diff".

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -43,7 +43,7 @@ instance-implicit class, and a consumer, the test runner, a proof, or a future
 production client, picks the concrete instance at the call boundary. The spec
 body commits to none of them.
 
-Six seams carry the design.
+These seams carry the design.
 
 | Seam | Class / variable | What it abstracts | Fast instance | Pure instance |
 |---|---|---|---|---|
@@ -51,11 +51,12 @@ Six seams carry the design.
 | Config values | `[Config]` | config-tier values (fork versions, genesis delay) | the test config | a fixed config |
 | Merkleization hasher | `[HasherTag]` | the SSZ hash backend, carried as `HasherTag.H` | `Sha256` (FFI, opaque) | `Sha256Spec` (pure-Lean) |
 | Crypto backend | `[CryptoBackend]` | BLS verify/aggregate, KZG | caching FFI | symbolic (abstract `verify`) |
+| Execution engine | `[ExecutionEngine Payload Tx]` | EL-answered predicates (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
 | Finite-map backing | `{map : MapKind} [FcMap map]` | the fork-choice store's maps | `hashMap` | `treeMap` |
 | Box flavour | smart constructor at the anchor | cache strategy of the boxed state | `FastBox` (cached, `= CachedBox Sha256`) | `UncachedBox Sha256Spec` (uncached) |
 | Effect monad | `{StateTransition : Type → Type}` | the state-threading effect | `EStateM` | `StateT ∘ Except` |
 
-Five of these hide completely behind instance resolution or a constructor choice
+Most of these hide completely behind instance resolution or a constructor choice
 at the anchor, so the author never names them. The fork-choice map is the one
 exception, and it cannot hide: `map` lands in the `Store` type itself, so
 `Store hashMap` and `Store treeMap` are genuinely distinct types. A fork-choice

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -797,7 +797,7 @@ The crypto primitives are instance-implicit (`[CryptoBackend]`), even though one
 real algorithm is used, because the seam buys two things.
 
 **Caching.** The pyspec suite calls BLS `verify` repeatedly on recurring
-inputs: shared validator sets, domains, and fixtures recur across the sweep, and the
+inputs: shared validator sets, domains, and fixtures recur across the suite, and the
 runner holds one long-lived server per worker so the memo stays warm. The runner
 injects a backend that memoizes `verify` over the real FFI, keyed on the full
 `(pubkey, message, signature)` wire bytes, a small fixed-size key whose hash costs far

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -43,7 +43,7 @@ instance-implicit class, and a consumer, the test runner, a proof, or a future
 production client, picks the concrete instance at the call boundary. The spec
 body commits to none of them.
 
-These seams carry the design.
+Eight seams carry the design.
 
 | Seam | Class / variable | What it abstracts | Fast instance | Pure instance |
 |---|---|---|---|---|
@@ -51,13 +51,16 @@ These seams carry the design.
 | Config values | `[Config]` | config-tier values (fork versions, genesis delay) | the test config | a fixed config |
 | Merkleization hasher | `[HasherTag]` | the SSZ hash backend, carried as `HasherTag.H` | `Sha256` (FFI, opaque) | `Sha256Spec` (pure-Lean) |
 | Crypto backend | `[CryptoBackend]` | BLS verify/aggregate, KZG | caching FFI | symbolic (abstract `verify`) |
-| Execution engine | `[ExecutionEngine Payload Tx]` | EL-answered predicates (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
+| Execution engine | `[ExecutionEngine Payload Tx]` | predicates answered by the execution layer (`is_inclusion_list_satisfied`) | optimistic global instance | a local refuting/real instance |
 | Finite-map backing | `{map : MapKind} [FcMap map]` | the fork-choice store's maps | `hashMap` | `treeMap` |
 | Box flavour | smart constructor at the anchor | cache strategy of the boxed state | `FastBox` (cached, `= CachedBox Sha256`) | `UncachedBox Sha256Spec` (uncached) |
 | Effect monad | `{StateTransition : Type → Type}` | the state-threading effect | `EStateM` | `StateT ∘ Except` |
 
-Most of these hide completely behind instance resolution or a constructor choice
-at the anchor, so the author never names them. The fork-choice map is the one
+Seven of the eight hide completely behind instance resolution or a constructor
+choice at the anchor, so the author never names them. (The execution-engine pair
+is a trust axis rather than a speed one: the optimistic default answers `true`
+everywhere, and a local instance replaces it where a test or proof needs a real
+or refuting verdict.) The fork-choice map is the one
 exception, and it cannot hide: `map` lands in the `Store` type itself, so
 `Store hashMap` and `Store treeMap` are genuinely distinct types. A fork-choice
 section takes `map` as an explicit type variable for that reason. The finite-map

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -43,7 +43,7 @@ instance-implicit class, and a consumer, the test runner, a proof, or a future
 production client, picks the concrete instance at the call boundary. The spec
 body commits to none of them.
 
-Eight seams carry the design.
+These seams carry the design.
 
 | Seam | Class / variable | What it abstracts | Fast instance | Pure instance |
 |---|---|---|---|---|
@@ -56,11 +56,9 @@ Eight seams carry the design.
 | Box flavour | smart constructor at the anchor | cache strategy of the boxed state | `FastBox` (cached, `= CachedBox Sha256`) | `UncachedBox Sha256Spec` (uncached) |
 | Effect monad | `{StateTransition : Type → Type}` | the state-threading effect | `EStateM` | `StateT ∘ Except` |
 
-Seven of the eight hide completely behind instance resolution or a constructor
-choice at the anchor, so the author never names them. (The execution-engine pair
-is a trust axis rather than a speed one: the optimistic default answers `true`
-everywhere, and a local instance replaces it where a test or proof needs a real
-or refuting verdict.) The fork-choice map is the one
+Most of these hide completely behind instance resolution or a constructor choice
+at the anchor, so the author never names them. The execution engine's two columns
+read as a trust axis instead of a speed one. The fork-choice map is the one
 exception, and it cannot hide: `map` lands in the `Store` type itself, so
 `Store hashMap` and `Store treeMap` are genuinely distinct types. A fork-choice
 section takes `map` as an explicit type variable for that reason. The finite-map
@@ -425,7 +423,8 @@ it in its classify mode:
 |---|---|
 | `assert` | an expected rejection; a vector marked invalid should hit one |
 | `todo` | an unimplemented branch; flagged out-of-scope, not counted as a rejection |
-| `outOfBounds` / `missingKey` | a smell; the spec should not hit these on well-formed input, so they surface as likely bugs |
+| `outOfBounds` / `decodeFailure` | a smell; the spec should not hit these on well-formed input, so they surface as likely bugs |
+| `missingKey` / `arithmetic` | a fault the reference propagates rather than catches, so it never counts as a rejection |
 
 ### 6.1 `todo` as the deferral work-queue
 
@@ -861,22 +860,25 @@ shapes result, and only the last needs machinery.
 
 For the hard-measure case, where the bound is a runtime value (store size) and a
 decreasing measure is less obvious up front, the framework provides a `Step` done/next
-type and two structural-recursion-on-`Nat` primitives over it, both total and
-kernel-reducible: `fuelLoop` (monadic, for a walk that reads the store through the
-effect monad) and `fuelIterate` (pure, for a walk that is a plain function of the store).
-The author writes the step body returning `.done` / `.next` and passes the bound (a store
-or block count, a safe over-estimate); no `Nat` counter and no exhaustion branch in the
-body. `fuelIterate` returns the accumulator itself when the fuel runs out, matching a
-hand-rolled `| 0, a => a` walk, so the bound must exceed the walk length (exhaustion is
-then unreachable and the result is always real).
+type and structural-recursion-on-`Nat` primitives over it, all total and
+kernel-reducible: `fuelLoop` for a walk that reads the store through the effect monad,
+and `fuelIterateM` / `fuelIterateM!` for a linear iteration. The author writes the step
+body returning `.done` / `.next` and passes the bound (a store or block count, a safe
+over-estimate); no `Nat` counter and no exhaustion branch in the body. `fuelLoop` and
+`fuelIterateM` take an `exhausted` value and return it when the fuel runs out, so the
+bound must exceed the walk length; `fuelIterateM!` throws there instead, for the bounds
+that rest on an arithmetic identity rather than a structural count.
 
 ```lean
-def getAncestor (store : Store map) (root : Root) (slot : Slot) : Root :=
-  fuelIterate ((FcMap.keys store.blocks).length + 1) root fun r =>
-    match FcMap.lookup store.blocks r with
-    | some block => if block.slot > slot then .next block.parentRoot else .done r
-    | none       => .done r
+forkdef getAncestor (store : Store map) (root : Root) (slot : Slot) : StoreTransition Root :=
+  fuelLoop ((FcMap.keys store.blocks).length + 1) root root fun r => do
+    let block ← FcMap.getOrThrow store.blocks r
+    if block.slot > slot then pure (.next block.parentRoot)
+    else pure (.done r)
 ```
+
+The map read is `getOrThrow`, not a `lookup` with a default: `store.blocks[r]` is a plain
+`Dict` subscript in the spec, so a missing root has to reject.
 
 These suit the *linear* fork-choice walks (a single `.next` continuation): `getAncestor`
 and the `getHead` descent. A *tree* walk like `filterBlockTree`, which recurses over every
@@ -986,8 +988,9 @@ and the pytest fixture managing the subprocess.
 
 The report distinguishes the classify buckets from the error model: a passing
 case, an expected rejection (`assert` against an invalid vector), an out-of-scope
-deferral (`todo`), and a likely bug (`outOfBounds` / `missingKey` on well-formed
-input). A `todo` that a vector actually reaches fails loudly rather than passing
+deferral (`todo`), a likely bug (`outOfBounds` / `decodeFailure` on well-formed
+input), and an uncaught fault (`missingKey` / `arithmetic`, which the reference
+propagates). A `todo` that a vector actually reaches fails loudly rather than passing
 silently, which is the deferral safety net at work.
 
 ---

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -6,20 +6,21 @@ the glossary). Those four are the design of record. This file records how
 `EthCLSpecs` / `EthCLLib` realize them: the current architecture, the places the code
 deviates from a doc (with the reason), and the spec-faithfulness decisions worth
 knowing. Everything here describes the tree as it stands against the
-`v1.7.0-alpha.10` pin.
+`v1.7.0-alpha.11` pin.
 
 ## Scope and conformance
 
-Two forks, **Fulu** and **Gloas**, against the `consensus-spec-tests` minimal and
-mainnet archives at `v1.7.0-alpha.10` (the latest release with cut vectors; it is
+Three forks, **Fulu**, **Gloas**, and **Heze**, against the `consensus-spec-tests` minimal and
+mainnet archives at `v1.7.0-alpha.11` (the latest release with cut vectors; it is
 flagged pre-release, so the harness pins the tag explicitly rather than reading `gh
-release latest`). The full in-scope suite is green at both presets for both forks,
-`--subset=0`, zero failures and zero `xfail`:
+release latest`). The full in-scope suite is green at both presets for all three
+forks, `--subset=0`, zero failures and zero `xfail`:
 
-|       | minimal        | mainnet        |
-| ----- | -------------- | -------------- |
-| Fulu  | **760 passed** | **667 passed** |
-| Gloas | **903 passed** | **792 passed** |
+| | minimal | mainnet |
+|---|---|---|
+| Fulu  | **5188 passed** | **847 passed** |
+| Gloas | **6573 passed** | **1034 passed** |
+| Heze  | **6770 passed** | **997 passed** |
 
 Fulu's collected formats: `epoch_processing`, `operations` (including the standalone
 `execution_payload`), `rewards`, `sanity/blocks`, `sanity/slots`, `finality`,
@@ -33,15 +34,16 @@ implemented formats reach matches by root or rejects faithfully.
 - **Fulu `fork` / `transition`** (Electra→Fulu): the upgrade and the pre-fork Electra
   blocks both need a complete Electra parent fork the library never builds. The
   **Gloas** `fork` / `transition` (Fulu→Gloas) are in scope and green.
-- **`ssz_static`**: covered by SizzLean's own tests and the build-time `deriving
-SSZRepr` gates.
+- **Fulu `ssz_static`**: reports `skip` (covered by SizzLean's own tests and the
+  build-time `deriving SSZRepr` gates). Gloas and Heze run their per-fork
+  container vectors for real.
 - **`light_client`, `networking`, `merkle_proof`, `sync`**: not state-transition or
   fork-choice formats; outside `IN_SCOPE_RUNNERS`.
 - **`genesis`**: no vectors at the pin (see Genesis below).
 
 **CI.** The `ethcl` job in `lean_action_ci.yml` runs `just ethcl-test` (builds all
 four libraries, firing the framework and spec self-tests) and `just
-ethcl-pyspec-smoke` (the `pytest-xdist` dev subset at minimal for both forks
+ethcl-pyspec-smoke` (the `pytest-xdist` dev subset at minimal for all three forks
 through the per-worker `pyspec_server`). It is green iff no in-scope vector hits a
 bug-smell or a real mismatch. Mainnet and the full sweep run on demand
 (`--preset=mainnet`, `--subset=0`).
@@ -602,7 +604,7 @@ desynced or dead server, so the parallel run is deterministic.
 
 `SPECS_ARCHITECTURE.md` §10.1 marks `genesis` in scope and §6.1 names
 `initializeBeaconStateFromEth1` / `isValidGenesisState`. The pytest corpus carries no
-`genesis` vectors for Fulu or Gloas at the `v1.7.0-alpha.10` pin, so there is nothing to
+`genesis` vectors for Fulu, Gloas, or Heze at the `v1.7.0-alpha.11` pin, so there is nothing to
 drive; both stay a `todo` stub in `Interface.lean`.
 
 ## Proofs

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -485,10 +485,10 @@ differs here, so Gloas overrides most handlers rather than inheriting them, and 
 The weight/head walk throws its plain-`Dict` reads and `should_extend_payload`'s slot
 assert faithfully, threading `StoreTransitionError` end to end (`get_weight`, `get_head`,
 `filter_block_tree`, the leaf reads, and `should_extend_payload`'s
-`store.blocks[root]` / `store.blocks[proposer_root]`). `get_forkchoice_store`'s anchor-root
-assert (`assert anchor_block.state_root == hash_tree_root(anchor_state)`) is still dropped, its
-constructor pure across all three forks. That is a known faithfulness gap pending conversion to a
-throw in this branch. Heze inherits these shapes; the Heze diff below carries the detailed entries.
+`store.blocks[root]` / `store.blocks[proposer_root]`). `get_forkchoice_store` throws its
+anchor-root assert (`assert anchor_block.state_root == hash_tree_root(anchor_state)`), its
+constructor threaded through `Except StoreTransitionError` across all three forks. Heze inherits
+these shapes; the Heze diff below carries the detailed entries.
 
 ## Fulu state transition
 
@@ -631,17 +631,20 @@ on unreachability arguments at their call sites.
 
 The entries below record each FOCIL read and assert and how it meets the spec. Most are
 faithful throws: the spec rejects (an `assert`, a plain-`Dict` `KeyError`, an `IndexError`, a
-`uint64` underflow) and the Lean throws to match, unreachable on any alpha.11 vector. Two are
-residual: the `[ExecutionEngine]` seam's optimistic default, and one dropped anchor-root assert
-held for the cross-fork audit. Spec citations resolve under `specs/` in `ethereum/consensus-specs`
+`uint64` underflow) and the Lean throws to match, unreachable on any alpha.11 vector. One case
+is a deliberate trust boundary rather than a throw: the `[ExecutionEngine]` seam's optimistic
+default, the same injection-seam shape as `[CryptoBackend]`. The external execution layer owns
+that verdict and the spec does not raise there; the reference harness stubs it `true` too. Spec
+citations resolve under `specs/` in `ethereum/consensus-specs`
 at the pinned version, which is also a git tag there.
 
 - **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
   `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
   execution client. This harness has no execution layer, so the call goes through the
   `[ExecutionEngine]` typeclass (the Engine seam above), whose default instance answers
-  the constant `true`. That default is the residual execution-layer trust boundary of
-  the FOCIL gate. No conformance vector reaches the discriminating `false` branch; the
+  the constant `true`. That default is the execution-layer trust boundary of the FOCIL
+  gate, an injection seam, not a dropped throw. No conformance vector reaches the
+  discriminating `false` branch; the
   `pinRecordRefuted` `native_decide` example drives it end-to-end under a locally
   substituted refuting engine instance.
 - **Two map reads throw on a missing key, matching the spec.**
@@ -675,13 +678,14 @@ at the pinned version, which is also a git tag there.
   (`EthCLSpecs/Heze/Signing.lean`), rather than masking the raise as a `false`. The predicate has
   no in-model caller by design.
 - **`get_forkchoice_store`** (`heze/fork-choice.md:140-166`) opens with
-  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean restatement is a pure
-  constructor and drops it, so an inconsistent anchor pair seeds a store instead of raising. Every
-  fork_choice vector runs through this constructor, and the harness always derives the anchor block
-  and state from the same vector's files, so no vector exercises the mismatch. The Gloas and Fulu
-  constructors drop the identical assert. This is a known faithfulness gap pending conversion in
-  this branch; a faithful throw needs the constructor threaded through the reject monad across all
-  three forks.
+  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean seeds the store
+  through `Except StoreTransitionError` and throws that assert to match, rather than seeding a
+  store from an inconsistent anchor pair. The Gloas and Fulu constructors throw the
+  textually-identical assert (`gloas/fork-choice.md:184`, `phase0/fork-choice.md:216`). Every
+  fork_choice vector runs through this constructor with the anchor block and state derived from
+  the same vector's files, so `state_root` always matches and no vector exercises the reject
+  branch; `pinAnchorRejects` (`EthCLSpecs/Heze/ForkChoice.lean`) locks the throw on a mismatched
+  default pair.
 
 `get_inclusion_list_committee` (`heze/beacon-chain.md:95-110`) resamples the committee as
 `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation. The

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -425,8 +425,11 @@ on* : StoreTransition Unit` over the typed `StoreTransitionError`. They write th
 `assert` / `todo` the state machine uses (resolved to `StoreTransitionError` through
 `SpecReject` from the section's monad), `missingKey` for `FcMap` misses, and the inner
 `state_transition` runs through `runStateTransition` (`Spec/Assert.lean`, wrapping an inner
-failure as `StoreTransitionError.transition`). Queries and transforms stay pure
-`forkdef`s of the store. `ForkInterface.runForkChoice` returns `Except (RunError
+failure as `StoreTransitionError.transition`). In Fulu, queries and transforms stay pure
+`forkdef`s of the store, with `lookupD` defaults standing in for the spec's raising reads
+(the throw sweep that converted Gloas/Heze is still owed to Fulu); in Gloas/Heze the queries
+run in the throwing store monad too, so a plain-`Dict` miss rejects (`missingKey`) instead
+of defaulting. `ForkInterface.runForkChoice` returns `Except (RunError
 StoreTransitionError) Unit`, and `Server` classifies the typed reject (`.spec (.todo _)
 → todo`, everything else, a `decode` or any other spec reject, `→ bug`), so no `"TODO:"`
 string convention is involved. The `FcStep` wire
@@ -456,10 +459,15 @@ boost only when the block is timely, no boost is already set, and the block shar
 head's dependent root (`get_dependent_root`, gated by `MIN_SEED_LOOKAHEAD`), the v1.7
 rule.
 
-The linear DAG walks (`getAncestor`, the `getHead` descent, `advanceStoreTime`) route
-through the framework's pure `fuelIterate` (§12). The one tree walk, `filterBlockTree`,
-recurses over every child inside a fold, which a linear combinator cannot express, so it
-keeps a local fuel-bounded `where` helper. The totality the doc wants is met either way.
+The linear DAG walks route through fuel-bounded combinators (§12). In Gloas/Heze,
+`getAncestor` and the `getHead` descent read `store.blocks` as they go, so they thread the
+store monad through the throwing `fuelLoop`, rejecting a missing root with `missingKey` to
+match the spec's plain-`Dict` read; Fulu's walks are still the pure `fuelIterate` over
+`lookupD` defaults, the deferred Fulu half of the sweep. `advanceStoreTime`, which touches
+no map, stays on the pure `fuelIterate` in every fork. The one tree walk,
+`filterBlockTree`, recurses over every child inside a fold, which a linear combinator
+cannot express, so it keeps a local fuel-bounded `where` helper (monadic, for the same block
+read). The totality the doc wants is met either way.
 
 One framework-wide caveat, shared by all three forks: the inherited time arithmetic
 (`timeIntoSlotMs`, the store-time seed in `get_forkchoice_store`) wraps on `UInt64`
@@ -474,10 +482,13 @@ ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children
 checks; the `FcStep` protocol grows the envelope / PTC-message steps. EIP-7732 genuinely
 differs here, so Gloas overrides most handlers rather than inheriting them, and the
 `forkstruct` / `inherit` reuse pays off less than it does for the state transition.
-Two spec asserts are dropped there as total-function shapes: `should_extend_payload`'s
-slot assert (its one caller enforces the same equation) and `get_forkchoice_store`'s
-anchor-root assert (Fulu's constructor drops it too). Heze inherits both shapes
-unchanged; the Heze diff below carries the detailed entries.
+The weight/head walk throws its plain-`Dict` reads and `should_extend_payload`'s slot
+assert faithfully, threading `StoreTransitionError` end to end (`get_weight`, `get_head`,
+`filter_block_tree`, the leaf reads, and `should_extend_payload`'s
+`store.blocks[root]` / `store.blocks[proposer_root]`). `get_forkchoice_store`'s anchor-root
+assert (`assert anchor_block.state_root == hash_tree_root(anchor_state)`) is still dropped, its
+constructor pure across all three forks. That is a known faithfulness gap pending conversion to a
+throw in this branch. Heze inherits these shapes; the Heze diff below carries the detailed entries.
 
 ## Fulu state transition
 
@@ -614,13 +625,16 @@ everything FOCIL-specific the pinned spec text is the oracle, backed by the
 build-enforced pins in `EthCLSpecs/Heze/ForkChoice.lean`: kernel `#guard`s (the
 kernel evaluates the check at build time) where the expected value needs no hashing,
 and `native_decide` examples (compiled evaluation, needed once a hash-tree-root calls
-the FFI hasher the kernel cannot reduce) where it does. Not every divergence below
+the FFI hasher the kernel cannot reduce) where it does. Not every entry below
 carries a discriminating pin; where one exists the entry names it, and the rest stand
 on unreachability arguments at their call sites.
 
-Deliberate divergences from the spec text follow. None is observable by any alpha.11
-vector. Spec citations resolve under `specs/` in `ethereum/consensus-specs` at the
-pinned version, which is also a git tag there.
+The entries below record each FOCIL read and assert and how it meets the spec. Most are
+faithful throws: the spec rejects (an `assert`, a plain-`Dict` `KeyError`, an `IndexError`, a
+`uint64` underflow) and the Lean throws to match, unreachable on any alpha.11 vector. Two are
+residual: the `[ExecutionEngine]` seam's optimistic default, and one dropped anchor-root assert
+held for the cross-fork audit. Spec citations resolve under `specs/` in `ethereum/consensus-specs`
+at the pinned version, which is also a git tag there.
 
 - **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
   `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
@@ -630,44 +644,44 @@ pinned version, which is also a git tag there.
   the FOCIL gate. No conformance vector reaches the discriminating `false` branch; the
   `pinRecordRefuted` `native_decide` example drives it end-to-end under a locally
   substituted refuting engine instance.
-- **Two map reads default to `false` where the spec assumes the key present.**
+- **Two map reads throw on a missing key, matching the spec.**
   `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with
-  `assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` function
-  cannot throw, so the Lean reads a missing key as `false` (`lookupD`). A missing key
-  is unreachable when the spec's own invariant holds: `on_execution_payload_envelope`
-  writes `payloads` and `payload_inclusion_list_satisfaction` together, so the key is
-  present whenever `root ∈ payloads`. The `timeliness` read in
-  `get_inclusion_list_transactions` (`heze/inclusion-list.md:105-114`) is the same
-  pattern, with `process_inclusion_list` writing the stored list and its timeliness
-  entry together.
+  `assert root in store.payload_inclusion_list_satisfaction`; the Lean throws that `assert`
+  (`StoreTransition Bool`). The `timeliness` read in `get_inclusion_list_transactions`
+  (`heze/inclusion-list.md:105-114`) is a plain `Dict` (`inclusion-list.md:34`), so the Lean
+  `getOrThrow`s it (`missingKey`) in place of the old `lookupD false`. Both throws are unreachable
+  when the spec's own invariants hold: `on_execution_payload_envelope` writes `payloads` and
+  `payload_inclusion_list_satisfaction` together, so the satisfaction key is present whenever
+  `root ∈ payloads`; and `process_inclusion_list` writes each stored list with its timeliness
+  entry, so every stored `il_root` has one.
 - **`record_payload_inclusion_list_satisfaction`** (`heze/fork-choice.md:180-193`)
-  reads `Slot(state.slot - 1)`. On a slot-0 state the pyspec raises the uint64
-  underflow, which invalidates the whole `on_execution_payload_envelope` call with the
-  store unmodified; the Lean guards the underflow, records the verdict over an empty
-  required set, and proceeds. Only an envelope whose target block state sits at slot 0
-  (the genesis anchor) could tell the difference, and no vector produces one.
+  reads `Slot(state.slot - 1)`. On a slot-0 state the pyspec raises the uint64 underflow,
+  invalidating the whole `on_execution_payload_envelope` call with the store unmodified. The Lean
+  asserts `state.slot != 0` and throws to match, rather than substituting an empty required set.
+  Only an envelope whose target block state sits at slot 0 (the genesis anchor) could reach it,
+  and no vector produces one.
 - **`should_extend_payload`** (`heze/fork-choice.md:221-236`) opens with
-  `assert store.blocks[root].slot + 1 == get_current_slot(store)`; the Lean is a total
-  `Bool` function, so the assert is dropped. Its one caller
-  (`get_payload_status_tiebreaker`) is gated by `is_previous_slot_payload_decision`,
-  which enforces the same slot equation. Gloas drops the identical assert (see the Fork
-  choice section); Heze restates the body for the inclusion-list gate. In the same
-  function, the spec reads `store.blocks[proposer_root]` unguarded (a `KeyError` on a
-  boost root absent from `blocks`); the Lean's `| none => true` arm extends instead, a
-  default in the accepting direction, unreachable while the boost root is always a
-  stored block (`on_block` sets it).
+  `assert store.blocks[root].slot + 1 == get_current_slot(store)`; the Lean `getOrThrow`s
+  `blocks[root]` and throws that `assert` (`StoreTransition Bool`). Its one caller
+  (`get_payload_status_tiebreaker`) is gated by `is_previous_slot_payload_decision`, which
+  enforces the same slot equation, so the assert is unreachable in practice. Gloas throws the
+  identical assert (see the Fork choice section); Heze restates the body for the inclusion-list
+  gate. In the same function, the spec reads `store.blocks[proposer_root]` unguarded (a `KeyError`
+  on a boost root absent from `blocks`); the Lean `getOrThrow`s it, throwing to match, unreachable
+  while the boost root is always a stored block (`on_block` sets it).
 - **`is_valid_inclusion_list_signature`** (`heze/beacon-chain.md:76-87`) reads
-  `state.validators[message.validator_index]`, which raises `IndexError` on an
-  out-of-range wire index; the Lean bounds the index and returns `false` instead
-  (`EthCLSpecs/Heze/Signing.lean`). Same rejection, different mechanism; the predicate
-  has no in-model caller by design.
+  `state.validators[message.validator_index]`, which raises `IndexError` on an out-of-range wire
+  index; the Lean `sszGetIdx`s the index and throws `outOfBounds` to match
+  (`EthCLSpecs/Heze/Signing.lean`), rather than masking the raise as a `false`. The predicate has
+  no in-model caller by design.
 - **`get_forkchoice_store`** (`heze/fork-choice.md:140-166`) opens with
-  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean
-  restatement is a pure constructor and drops it, so an inconsistent anchor pair would
-  seed a store instead of raising. Every fork_choice vector runs through this
-  constructor, but the harness always derives the anchor block and state from the same
-  vector's files, so the branch is unreachable in conformance. The Gloas and Fulu
-  constructors drop the identical assert.
+  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean restatement is a pure
+  constructor and drops it, so an inconsistent anchor pair seeds a store instead of raising. Every
+  fork_choice vector runs through this constructor, and the harness always derives the anchor block
+  and state from the same vector's files, so no vector exercises the mismatch. The Gloas and Fulu
+  constructors drop the identical assert. This is a known faithfulness gap pending conversion in
+  this branch; a faithful throw needs the constructor threaded through the reject monad across all
+  three forks.
 
 `get_inclusion_list_committee` (`heze/beacon-chain.md:95-110`) resamples the committee as
 `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation. The

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -26,8 +26,10 @@ Fulu's collected formats: `epoch_processing`, `operations` (including the standa
 `execution_payload`), `rewards`, `sanity/blocks`, `sanity/slots`, `finality`,
 `random`, `fork_choice` (including the PeerDAS data-availability `on_block` cases and
 `get_proposer_head`). Gloas adds `fork`, `transition`, and the full ePBS
-`fork_choice`. `DISCREPANCIES.md` is empty of open discrepancies: every vector the
-implemented formats reach matches by root or rejects faithfully.
+`fork_choice`. `DISCREPANCIES.md` records no open vector discrepancy: every vector the
+implemented formats reach matches by root or rejects faithfully. Deliberate divergences
+from the spec *text* that no vector observes are catalogued per fork in this file (see
+the Heze diff), not there.
 
 **Out of scope** (deselected in `walk_cases`, not collected):
 
@@ -164,6 +166,23 @@ pubkeys are passed to `ethFastAggregateVerify`, which aggregates whatever list i
 given. This matches the spec result for all three of its cases (all-participate,
 majority-subtract, full list) and keeps the seam to `ethFastAggregateVerify` alone,
 with no G1 add/neg and no precomputed-aggregate dependency.
+
+## Engine seam
+
+`EthCLLib.Spec.Engine` defines `[ExecutionEngine]`, the execution-layer sibling of the
+crypto seam: a spec function whose verdict belongs to an external execution client
+routes through the typeclass instead of hard-coding an answer. `CryptoBackend` ships
+no global instance; every call site injects one. `ExecutionEngine`, by contrast,
+ships a default: the optimistic global instance answering the constant `true` (the
+seam table in `FRAMEWORK_ARCHITECTURE.md` §1), which matches how the conformance
+harness treats engine verdicts. A local `letI` substitutes a different instance per
+proof or per pin; the `pinRecordRefuted` example in `EthCLSpecs/Heze/ForkChoice.lean`
+refutes Heze's inclusion-list gate end-to-end this way.
+
+Heze's `is_inclusion_list_satisfied` is the seam's first user. Gloas's engine
+predicates (`verify_and_notify_new_payload`, `is_data_available`) share the
+constant-`true` verdict but are still modeled as inline constants; their migration
+onto the seam is a named follow-up in `EthCLLib.Spec.Engine`'s module docstring.
 
 ## State, presets, and the header macro
 
@@ -442,6 +461,11 @@ through the framework's pure `fuelIterate` (§12). The one tree walk, `filterBlo
 recurses over every child inside a fold, which a linear combinator cannot express, so it
 keeps a local fuel-bounded `where` helper. The totality the doc wants is met either way.
 
+One framework-wide caveat, shared by all three forks: the inherited time arithmetic
+(`timeIntoSlotMs`, the store-time seed in `get_forkchoice_store`) wraps on `UInt64`
+where the pyspec saturates or raises. The difference is observable only at
+astronomically unreachable uptimes.
+
 The Gloas fork choice is the node-based (`ForkChoiceNode = (root, payload_status)`)
 ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children` /
 `get_head` thread the payload status, with the ePBS handlers
@@ -450,6 +474,10 @@ ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children
 checks; the `FcStep` protocol grows the envelope / PTC-message steps. EIP-7732 genuinely
 differs here, so Gloas overrides most handlers rather than inheriting them, and the
 `forkstruct` / `inherit` reuse pays off less than it does for the state transition.
+Two spec asserts are dropped there as total-function shapes: `should_extend_payload`'s
+slot assert (its one caller enforces the same equation) and `get_forkchoice_store`'s
+anchor-root assert (Fulu's constructor drops it too). Heze inherits both shapes
+unchanged; the Heze diff below carries the detailed entries.
 
 ## Fulu state transition
 
@@ -567,6 +595,96 @@ phases. `Gloas/Transition.lean` reshapes `process_block` (drop
 payload-availability bit), and `process_epoch` (builder-pending-payments and
 `process_ptc_window` last). The `transition` format folds pre-fork Fulu blocks, applies
 `upgradeToGloas` plus onboarding at the boundary, then folds post-fork Gloas blocks.
+
+## Heze diff
+
+`EthCLSpecs.Heze` is `fork Heze from Gloas` plus EIP-7805 (FOCIL). At alpha.11
+the fork is a thin diff. EIP-7805 changes no state-transition substep, so the whole
+spine is the Gloas spine re-elaborated over Heze types, and the additions are two
+containers (`InclusionList`, `SignedInclusionList`), one committee accessor
+(`get_inclusion_list_committee`), one signature predicate
+(`is_valid_inclusion_list_signature`), and the fork-choice inclusion-list layer (the
+`InclusionListStore`, the satisfaction gate, and the `on_inclusion_list` handler).
+
+**Vector coverage.** FOCIL ships no behavioral conformance vector at the alpha.11 pin.
+The two new containers pass their full `ssz_static` suites, and the
+`on_execution_payload_envelope` fork_choice vectors do drive the Heze overrides, but
+only on the empty-inclusion-list, always-satisfied path they share with Gloas. For
+everything FOCIL-specific the pinned spec text is the oracle, backed by the
+build-enforced pins in `EthCLSpecs/Heze/ForkChoice.lean`: kernel `#guard`s (the
+kernel evaluates the check at build time) where the expected value needs no hashing,
+and `native_decide` examples (compiled evaluation, needed once a hash-tree-root calls
+the FFI hasher the kernel cannot reduce) where it does. Not every divergence below
+carries a discriminating pin; where one exists the entry names it, and the rest stand
+on unreachability arguments at their call sites.
+
+Deliberate divergences from the spec text follow. None is observable by any alpha.11
+vector. Spec citations resolve under `specs/` in `ethereum/consensus-specs` at the
+pinned version, which is also a git tag there.
+
+- **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
+  `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
+  execution client. This harness has no execution layer, so the call goes through the
+  `[ExecutionEngine]` typeclass (the Engine seam above), whose default instance answers
+  the constant `true`. That default is the residual execution-layer trust boundary of
+  the FOCIL gate. No conformance vector reaches the discriminating `false` branch; the
+  `pinRecordRefuted` `native_decide` example drives it end-to-end under a locally
+  substituted refuting engine instance.
+- **Two map reads default to `false` where the spec assumes the key present.**
+  `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with
+  `assert root in store.payload_inclusion_list_satisfaction`; a pure `Bool` function
+  cannot throw, so the Lean reads a missing key as `false` (`lookupD`). A missing key
+  is unreachable when the spec's own invariant holds: `on_execution_payload_envelope`
+  writes `payloads` and `payload_inclusion_list_satisfaction` together, so the key is
+  present whenever `root ∈ payloads`. The `timeliness` read in
+  `get_inclusion_list_transactions` (`heze/inclusion-list.md:105-114`) is the same
+  pattern, with `process_inclusion_list` writing the stored list and its timeliness
+  entry together.
+- **`record_payload_inclusion_list_satisfaction`** (`heze/fork-choice.md:180-193`)
+  reads `Slot(state.slot - 1)`. On a slot-0 state the pyspec raises the uint64
+  underflow, which invalidates the whole `on_execution_payload_envelope` call with the
+  store unmodified; the Lean guards the underflow, records the verdict over an empty
+  required set, and proceeds. Only an envelope whose target block state sits at slot 0
+  (the genesis anchor) could tell the difference, and no vector produces one.
+- **`should_extend_payload`** (`heze/fork-choice.md:221-236`) opens with
+  `assert store.blocks[root].slot + 1 == get_current_slot(store)`; the Lean is a total
+  `Bool` function, so the assert is dropped. Its one caller
+  (`get_payload_status_tiebreaker`) is gated by `is_previous_slot_payload_decision`,
+  which enforces the same slot equation. Gloas drops the identical assert (see the Fork
+  choice section); Heze restates the body for the inclusion-list gate. In the same
+  function, the spec reads `store.blocks[proposer_root]` unguarded (a `KeyError` on a
+  boost root absent from `blocks`); the Lean's `| none => true` arm extends instead, a
+  default in the accepting direction, unreachable while the boost root is always a
+  stored block (`on_block` sets it).
+- **`is_valid_inclusion_list_signature`** (`heze/beacon-chain.md:76-87`) reads
+  `state.validators[message.validator_index]`, which raises `IndexError` on an
+  out-of-range wire index; the Lean bounds the index and returns `false` instead
+  (`EthCLSpecs/Heze/Signing.lean`). Same rejection, different mechanism; the predicate
+  has no in-model caller by design.
+- **`get_forkchoice_store`** (`heze/fork-choice.md:140-166`) opens with
+  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean
+  restatement is a pure constructor and drops it, so an inconsistent anchor pair would
+  seed a store instead of raising. Every fork_choice vector runs through this
+  constructor, but the harness always derives the anchor block and state from the same
+  vector's files, so the branch is unreachable in conformance. The Gloas and Fulu
+  constructors drop the identical assert.
+
+Two model-structure choices carry no behavioral difference on any reachable input:
+
+- **`cyclicSample`** (`heze/beacon-chain.md:95-110`) resamples the committee as
+  `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty
+  concatenation. The Lean read is total (`i % 0 = i`, then the `getD` default), and a
+  real beacon chain never reaches a zero-active-validator slot, so the branch is
+  unreachable (`EthCLSpecs/Heze/Committees.lean`).
+- **The `InclusionListStore` rides inside the fork-choice `Store` as a field.** The
+  spec keeps it as a process-lifetime singleton reached through
+  `get_inclusion_list_store()` (`heze/inclusion-list.md:28-38`); this framework's fork
+  choice threads one `Store` value through the generic `StoreTransition` monad
+  (`SPEC_AUTHORING_MODEL.md` §4), with no ambient singleton to hang the spec's store
+  off, so it rides as a field and moves with the rest of the state. Behavior is
+  identical.
+  The full rationale lives on the `InclusionListStore` declaration
+  (`EthCLSpecs/Heze/ForkChoice.lean`).
 
 ## Config-tier values that bite
 

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -669,13 +669,18 @@ pinned version, which is also a git tag there.
   vector's files, so the branch is unreachable in conformance. The Gloas and Fulu
   constructors drop the identical assert.
 
-Two model-structure choices carry no behavioral difference on any reachable input:
+`get_inclusion_list_committee` (`heze/beacon-chain.md:95-110`) resamples the committee as
+`indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation. The
+accessor asserts the concatenation is non-empty and throws the fork-choice reject to match, so the
+read is faithful rather than the earlier total `getD` default. `pinCommitteeThrows`
+(`EthCLSpecs/Heze/ForkChoice.lean`) locks the throw, and the record pins run over a populated
+committee so their coverage stays live. A real beacon chain never reaches a zero-active-validator
+slot, so the throw is unreachable on every conformance vector. `cyclicSample`
+(`EthCLSpecs/Heze/Committees.lean`) keeps the wrap-around arithmetic, now with a caller that
+guarantees a non-empty source.
 
-- **`cyclicSample`** (`heze/beacon-chain.md:95-110`) resamples the committee as
-  `indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty
-  concatenation. The Lean read is total (`i % 0 = i`, then the `getD` default), and a
-  real beacon chain never reaches a zero-active-validator slot, so the branch is
-  unreachable (`EthCLSpecs/Heze/Committees.lean`).
+One model-structure choice carries no behavioral difference on any reachable input:
+
 - **The `InclusionListStore` rides inside the fork-choice `Store` as a field.** The
   spec keeps it as a process-lifetime singleton reached through
   `get_inclusion_list_store()` (`heze/inclusion-list.md:28-38`); this framework's fork

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -425,11 +425,11 @@ on* : StoreTransition Unit` over the typed `StoreTransitionError`. They write th
 `assert` / `todo` the state machine uses (resolved to `StoreTransitionError` through
 `SpecReject` from the section's monad), `missingKey` for `FcMap` misses, and the inner
 `state_transition` runs through `runStateTransition` (`Spec/Assert.lean`, wrapping an inner
-failure as `StoreTransitionError.transition`). In Fulu, queries and transforms stay pure
-`forkdef`s of the store, with `lookupD` defaults standing in for the spec's raising reads
-(the throw sweep that converted Gloas/Heze is still owed to Fulu); in Gloas/Heze the queries
-run in the throwing store monad too, so a plain-`Dict` miss rejects (`missingKey`) instead
-of defaulting. `ForkInterface.runForkChoice` returns `Except (RunError
+failure as `StoreTransitionError.transition`). Across Fulu, Gloas, and Heze the fork-choice
+queries and transforms run in the throwing store monad, so a plain-`Dict` miss rejects
+(`missingKey`) rather than standing in a `lookupD` default. The `DefaultDict`-backed reads
+(`equivocators`, `inclusion_lists`, the payload-timeliness votes) keep their defaults,
+matching the spec's `defaultdict`. `ForkInterface.runForkChoice` returns `Except (RunError
 StoreTransitionError) Unit`, and `Server` classifies the typed reject (`.spec (.todo _)
 → todo`, everything else, a `decode` or any other spec reject, `→ bug`), so no `"TODO:"`
 string convention is involved. The `FcStep` wire
@@ -459,20 +459,39 @@ boost only when the block is timely, no boost is already set, and the block shar
 head's dependent root (`get_dependent_root`, gated by `MIN_SEED_LOOKAHEAD`), the v1.7
 rule.
 
-The linear DAG walks route through fuel-bounded combinators (§12). In Gloas/Heze,
+The linear DAG walks route through fuel-bounded combinators (§12). In all three forks,
 `getAncestor` and the `getHead` descent read `store.blocks` as they go, so they thread the
 store monad through the throwing `fuelLoop`, rejecting a missing root with `missingKey` to
-match the spec's plain-`Dict` read; Fulu's walks are still the pure `fuelIterate` over
-`lookupD` defaults, the deferred Fulu half of the sweep. `advanceStoreTime`, which touches
+match the spec's plain-`Dict` read. `advanceStoreTime`, which touches
 no map, stays on the pure `fuelIterate` in every fork. The one tree walk,
 `filterBlockTree`, recurses over every child inside a fold, which a linear combinator
 cannot express, so it keeps a local fuel-bounded `where` helper (monadic, for the same block
 read). The totality the doc wants is met either way.
 
-One framework-wide caveat, shared by all three forks: the inherited time arithmetic
-(`timeIntoSlotMs`, the store-time seed in `get_forkchoice_store`) wraps on `UInt64`
-where the pyspec saturates or raises. The difference is observable only at
-astronomically unreachable uptimes.
+One framework-wide caveat, shared by all three forks: the store-time seed in
+`get_forkchoice_store` still uses raw `UInt64` time arithmetic that wraps where the pyspec
+saturates or raises. `timeIntoSlotMs` itself now routes through the clamping
+`secondsToMilliseconds`, so it saturates to match the spec. The difference is observable
+only at astronomically unreachable uptimes.
+
+The three `block_states` membership asserts (`on_block`'s parent read,
+`on_execution_payload_envelope`, `on_payload_attestation_message`, each an
+`assert ... in store.block_states` in the spec) read through `getOrAssert`, so a miss is the
+spec's `.assert` (`AssertionError`), matching the reference runner. This aligns them with the
+payload-timeliness and inclusion-list-satisfaction membership asserts, which already used
+`getOrAssert`. `checkStepValidity` now admits `.assert` and `.transition (.outOfBounds …)`
+(the store machine's only index-miss shape, since `StoreTransitionError` has no bare
+`.outOfBounds`), bare and wrapped, as expected rejections on a `valid: false` step, the
+reference runner's `AssertionError` / `IndexError` set; a stray `.missingKey` propagates as a
+failure.
+
+The execution-payload-envelope signature check (`verifyExecutionPayloadEnvelopeSignature`)
+reads `state.validators[proposer_index]` / `state.builders[builder_index]` through `sszGetIdx`,
+so an out-of-range index (the `builder_index` comes straight from the untrusted envelope) is
+the spec's `IndexError` as `.transition (.outOfBounds idx bound)`, caught by the reference
+runner and by `checkStepValidity`. The function is `Except StoreTransitionError Bool`; its
+caller binds the result before the `assert`, so the reject propagates in place of the former
+panicking `[i]!`.
 
 The Gloas fork choice is the node-based (`ForkChoiceNode = (root, payload_status)`)
 ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children` /

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -28,17 +28,14 @@ Fulu's collected formats: `epoch_processing`, `operations` (including the standa
 `get_proposer_head`). Gloas adds `fork`, `transition`, and the full ePBS
 `fork_choice`. `DISCREPANCIES.md` records no open vector discrepancy: every vector the
 implemented formats reach matches by root or rejects faithfully. Deliberate divergences
-from the spec *text* that no vector observes are catalogued per fork in this file (see
-the Heze diff), not there.
+from the spec *text* that no vector observes are catalogued per fork in this file.
 
 **Out of scope** (deselected in `walk_cases`, not collected):
 
 - **Fulu `fork` / `transition`** (Electra→Fulu): the upgrade and the pre-fork Electra
   blocks both need a complete Electra parent fork the library never builds. The
-  **Gloas** `fork` / `transition` (Fulu→Gloas) are in scope and green.
-- **Fulu `ssz_static`**: reports `skip` (covered by SizzLean's own tests and the
-  build-time `deriving SSZRepr` gates). Gloas and Heze run their per-fork
-  container vectors for real.
+  **Gloas** `fork` / `transition` (Fulu→Gloas) and the **Heze** ones (Gloas→Heze)
+  are in scope and green.
 - **`light_client`, `networking`, `merkle_proof`, `sync`**: not state-transition or
   fork-choice formats; outside `IN_SCOPE_RUNNERS`.
 - **`genesis`**: no vectors at the pin (see Genesis below).
@@ -171,18 +168,15 @@ with no G1 add/neg and no precomputed-aggregate dependency.
 
 `EthCLLib.Spec.Engine` defines `[ExecutionEngine]`, the execution-layer sibling of the
 crypto seam: a spec function whose verdict belongs to an external execution client
-routes through the typeclass instead of hard-coding an answer. `CryptoBackend` ships
-no global instance; every call site injects one. `ExecutionEngine`, by contrast,
-ships a default: the optimistic global instance answering the constant `true` (the
-seam table in `FRAMEWORK_ARCHITECTURE.md` §1), which matches how the conformance
-harness treats engine verdicts. A local `letI` substitutes a different instance per
-proof or per pin; the `pinRecordRefuted` example in `EthCLSpecs/Heze/ForkChoice.lean`
-refutes Heze's inclusion-list gate end-to-end this way.
+routes through the typeclass. Unlike `CryptoBackend` it ships a global default, the
+optimistic instance answering the constant `true` (the seam table in
+`FRAMEWORK_ARCHITECTURE.md` §1). A local `letI` overrides it; `pinRecordRefuted`
+(`EthCLSpecs/Heze/ForkChoice.lean`) refutes the inclusion-list gate that way.
 
 Heze's `is_inclusion_list_satisfied` is the seam's first user. Gloas's engine
-predicates (`verify_and_notify_new_payload`, `is_data_available`) share the
-constant-`true` verdict but are still modeled as inline constants; their migration
-onto the seam is a named follow-up in `EthCLLib.Spec.Engine`'s module docstring.
+predicates (`verify_and_notify_new_payload`, `is_data_available`) reach the same
+constant-`true` verdict as inline constants; `EthCLLib.Spec.Engine`'s module
+docstring tracks their migration onto the seam.
 
 ## State, presets, and the header macro
 
@@ -364,7 +358,7 @@ carries `getStateRoot` / `stateRoot` / `stateRoot!` and `runToRoot` (run a boxed
 action to its post-root, the `EStateM` twin of `runOn`). `Spec.SigningRoot` carries
 `htr`, `computeForkDataRoot`, `computeDomain`, `computeSigningRoot`, `isValidMerkleBranch`,
 and the signing-root verify combinator `blsVerifySigned`, over `[HasherTag]`. `Spec.Loop`
-carries `Step` / `fuelLoop` (monadic) / `fuelIterate` (pure walk). `Spec.FiniteMap` carries
+carries `Step` / `fuelLoop` / `fuelIterateM` / `fuelIterateM!`. `Spec.FiniteMap` carries
 `MapKind`, `FcMap` (with `lookupD` / `getOrThrow` / `getOrThrowKey` / `values` /
 `filterKeys`), `treeMap`, `hashMap`, and `Hashable (Vector …)`.
 
@@ -425,11 +419,7 @@ on* : StoreTransition Unit` over the typed `StoreTransitionError`. They write th
 `assert` / `todo` the state machine uses (resolved to `StoreTransitionError` through
 `SpecReject` from the section's monad), `missingKey` for `FcMap` misses, and the inner
 `state_transition` runs through `runStateTransition` (`Spec/Assert.lean`, wrapping an inner
-failure as `StoreTransitionError.transition`). Across Fulu, Gloas, and Heze the fork-choice
-queries and transforms run in the throwing store monad, so a plain-`Dict` miss rejects
-(`missingKey`) rather than standing in a `lookupD` default. The `DefaultDict`-backed reads
-(`equivocators`, `inclusion_lists`, the payload-timeliness votes) keep their defaults,
-matching the spec's `defaultdict`. `ForkInterface.runForkChoice` returns `Except (RunError
+failure as `StoreTransitionError.transition`). `ForkInterface.runForkChoice` returns `Except (RunError
 StoreTransitionError) Unit`, and `Server` classifies the typed reject (`.spec (.todo _)
 → todo`, everything else, a `decode` or any other spec reject, `→ bug`), so no `"TODO:"`
 string convention is involved. The `FcStep` wire
@@ -459,39 +449,25 @@ boost only when the block is timely, no boost is already set, and the block shar
 head's dependent root (`get_dependent_root`, gated by `MIN_SEED_LOOKAHEAD`), the v1.7
 rule.
 
-The linear DAG walks route through fuel-bounded combinators (§12). In all three forks,
-`getAncestor` and the `getHead` descent read `store.blocks` as they go, so they thread the
-store monad through the throwing `fuelLoop`, rejecting a missing root with `missingKey` to
-match the spec's plain-`Dict` read. `advanceStoreTime`, which touches
-no map, stays on the pure `fuelIterate` in every fork. The one tree walk,
-`filterBlockTree`, recurses over every child inside a fold, which a linear combinator
-cannot express, so it keeps a local fuel-bounded `where` helper (monadic, for the same block
-read). The totality the doc wants is met either way.
+The linear DAG walks route through fuel-bounded combinators (§12). `getAncestor` and the
+`getHead` descent read `store.blocks` as they go, so they thread the store monad through
+`fuelLoop`. The one tree walk, `filterBlockTree`, recurses over every child inside a fold,
+which a linear combinator cannot express, so it keeps a local fuel-bounded `where` helper.
+The totality the doc wants is met either way.
 
-One framework-wide caveat, shared by all three forks: the store-time seed in
-`get_forkchoice_store` still uses raw `UInt64` time arithmetic that wraps where the pyspec
-saturates or raises. `timeIntoSlotMs` itself now routes through the clamping
-`secondsToMilliseconds`, so it saturates to match the spec. The difference is observable
-only at astronomically unreachable uptimes.
+The fork-choice weight path still runs on raw `UInt64`, where the pyspec's unbounded ints
+cannot wrap: `getAttestationScore`'s balance fold, `getWeight`'s proposer-boost add, and
+the products in `committeeWeight`, `calculateCommitteeFraction`, and `getProposerScore`.
+`bpsDeadlineMs`'s `bps * SLOT_DURATION_MS` shares the shape. `checkedAdd` / `checkedMul`
+(`Spec/Errors.lean`) are the fix; deferred. Reaching any of them takes a total active
+balance within a factor of the `uint64` bound, which no preset's validator set approaches.
 
-The three `block_states` membership asserts (`on_block`'s parent read,
-`on_execution_payload_envelope`, `on_payload_attestation_message`, each an
-`assert ... in store.block_states` in the spec) read through `getOrAssert`, so a miss is the
-spec's `.assert` (`AssertionError`), matching the reference runner. This aligns them with the
-payload-timeliness and inclusion-list-satisfaction membership asserts, which already used
-`getOrAssert`. `checkStepValidity` now admits `.assert` and `.transition (.outOfBounds …)`
-(the store machine's only index-miss shape, since `StoreTransitionError` has no bare
-`.outOfBounds`), bare and wrapped, as expected rejections on a `valid: false` step, the
-reference runner's `AssertionError` / `IndexError` set; a stray `.missingKey` propagates as a
-failure.
-
-The execution-payload-envelope signature check (`verifyExecutionPayloadEnvelopeSignature`)
-reads `state.validators[proposer_index]` / `state.builders[builder_index]` through `sszGetIdx`,
-so an out-of-range index (the `builder_index` comes straight from the untrusted envelope) is
-the spec's `IndexError` as `.transition (.outOfBounds idx bound)`, caught by the reference
-runner and by `checkStepValidity`. The function is `Except StoreTransitionError Bool`; its
-caller binds the result before the `assert`, so the reject propagates in place of the former
-panicking `[i]!`.
+The reference catches different exceptions per step kind, so what satisfies a
+`valid: false` step varies too. `expect_assertion_error` (`context.py:424-435`) catches
+`IndexError` for the attestation, attester-slashing, envelope, and PTC-message steps.
+`add_block` catches `AssertionError` and `BlockNotFoundException` alone
+(`fork_choice.py:389`). `FcStepKind` carries that table, and `checkStepValidity`
+(`PySpecTests/Interface.lean`) reads it.
 
 The Gloas fork choice is the node-based (`ForkChoiceNode = (root, payload_status)`)
 ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children` /
@@ -501,13 +477,6 @@ ePBS rewrite: `get_ancestor` / `is_ancestor` / `get_weight` / `get_node_children
 checks; the `FcStep` protocol grows the envelope / PTC-message steps. EIP-7732 genuinely
 differs here, so Gloas overrides most handlers rather than inheriting them, and the
 `forkstruct` / `inherit` reuse pays off less than it does for the state transition.
-The weight/head walk throws its plain-`Dict` reads and `should_extend_payload`'s slot
-assert faithfully, threading `StoreTransitionError` end to end (`get_weight`, `get_head`,
-`filter_block_tree`, the leaf reads, and `should_extend_payload`'s
-`store.blocks[root]` / `store.blocks[proposer_root]`). `get_forkchoice_store` throws its
-anchor-root assert (`assert anchor_block.state_root == hash_tree_root(anchor_state)`), its
-constructor threaded through `Except StoreTransitionError` across all three forks. Heze inherits
-these shapes; the Heze diff below carries the detailed entries.
 
 ## Fulu state transition
 
@@ -540,6 +509,13 @@ MIN_VALIDATOR_WITHDRAWABILITY_DELAY < 2^64` before the write, so an over-range c
   rejects faithfully (matching the pyspec's `uint64` serialization `ValueError`) instead
   of wrapping silently on Lean's `UInt64`. Valid exits never approach the bound. Gloas
   inherits the substep with no Gloas-side change.
+- **`get_balance_after_withdrawals` accumulates on a wrapping `UInt64`.** Pyspec's
+  `sum(...)` adds unbounded ints, so its underflow `ValueError` fires against the true
+  sum; this fold wraps, so a true sum ≥ 2^64 passes the `withdrawn > bal` guard and
+  returns a wrong balance where pyspec raises. Unreachable while a validator's queued
+  withdrawals stay under its balance, which no vector violates. `checkedAdd`
+  (`Spec/Errors.lean`) is the fix; deferred. Gloas and Heze each restate the function and
+  carry the same divergence.
 - **`process_execution_payload` takes the execution engine as valid.** It checks
   parent-hash / prev-randao / timestamp consistency and caches the header;
   `verify_and_notify_new_payload` is the consumer's responsibility, which is valid for
@@ -628,105 +604,23 @@ payload-availability bit), and `process_epoch` (builder-pending-payments and
 
 ## Heze diff
 
-`EthCLSpecs.Heze` is `fork Heze from Gloas` plus EIP-7805 (FOCIL). At alpha.11
-the fork is a thin diff. EIP-7805 changes no state-transition substep, so the whole
-spine is the Gloas spine re-elaborated over Heze types, and the additions are two
-containers (`InclusionList`, `SignedInclusionList`), one committee accessor
-(`get_inclusion_list_committee`), one signature predicate
-(`is_valid_inclusion_list_signature`), and the fork-choice inclusion-list layer (the
-`InclusionListStore`, the satisfaction gate, and the `on_inclusion_list` handler).
-
-**Vector coverage.** FOCIL ships no behavioral conformance vector at the alpha.11 pin.
-The two new containers pass their full `ssz_static` suites, and the
-`on_execution_payload_envelope` fork_choice vectors do drive the Heze overrides, but
-only on the empty-inclusion-list, always-satisfied path they share with Gloas. For
-everything FOCIL-specific the pinned spec text is the oracle, backed by the
-build-enforced pins in `EthCLSpecs/Heze/ForkChoice.lean`: kernel `#guard`s (the
-kernel evaluates the check at build time) where the expected value needs no hashing,
-and `native_decide` examples (compiled evaluation, needed once a hash-tree-root calls
-the FFI hasher the kernel cannot reduce) where it does. Not every entry below
-carries a discriminating pin; where one exists the entry names it, and the rest stand
-on unreachability arguments at their call sites.
-
-The entries below record each FOCIL read and assert and how it meets the spec. Most are
-faithful throws: the spec rejects (an `assert`, a plain-`Dict` `KeyError`, an `IndexError`, a
-`uint64` underflow) and the Lean throws to match, unreachable on any alpha.11 vector. One case
-is a deliberate trust boundary rather than a throw: the `[ExecutionEngine]` seam's optimistic
-default, the same injection-seam shape as `[CryptoBackend]`. The external execution layer owns
-that verdict and the spec does not raise there; the reference harness stubs it `true` too. Spec
-citations resolve under `specs/` in `ethereum/consensus-specs`
-at the pinned version, which is also a git tag there.
+EIP-7805 changes no state-transition substep, so Heze inherits the Gloas spine whole
+and the diff is confined to the fork-choice inclusion-list layer. FOCIL ships no
+behavioral conformance vector at the alpha.11 pin, so the divergences below are anchored
+to the pinned spec text and the `EthCLSpecs/Heze/ForkChoice.lean` pins.
 
 - **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
   `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
   execution client. This harness has no execution layer, so the call goes through the
   `[ExecutionEngine]` typeclass (the Engine seam above), whose default instance answers
   the constant `true`. That default is the execution-layer trust boundary of the FOCIL
-  gate, an injection seam, not a dropped throw. No conformance vector reaches the
-  discriminating `false` branch; the
-  `pinRecordRefuted` `native_decide` example drives it end-to-end under a locally
-  substituted refuting engine instance.
-- **Two map reads throw on a missing key, matching the spec.**
-  `is_payload_inclusion_list_satisfied` (`heze/fork-choice.md:199-212`) opens with
-  `assert root in store.payload_inclusion_list_satisfaction`; the Lean throws that `assert`
-  (`StoreTransition Bool`). The `timeliness` read in `get_inclusion_list_transactions`
-  (`heze/inclusion-list.md:105-114`) is a plain `Dict` (`inclusion-list.md:34`), so the Lean
-  `getOrThrow`s it (`missingKey`) in place of the old `lookupD false`. Both throws are unreachable
-  when the spec's own invariants hold: `on_execution_payload_envelope` writes `payloads` and
-  `payload_inclusion_list_satisfaction` together, so the satisfaction key is present whenever
-  `root ∈ payloads`; and `process_inclusion_list` writes each stored list with its timeliness
-  entry, so every stored `il_root` has one.
-- **`record_payload_inclusion_list_satisfaction`** (`heze/fork-choice.md:180-193`)
-  reads `Slot(state.slot - 1)`. On a slot-0 state the pyspec raises the uint64 underflow,
-  invalidating the whole `on_execution_payload_envelope` call with the store unmodified. The Lean
-  asserts `state.slot != 0` and throws to match, rather than substituting an empty required set.
-  Only an envelope whose target block state sits at slot 0 (the genesis anchor) could reach it,
-  and no vector produces one.
-- **`should_extend_payload`** (`heze/fork-choice.md:221-236`) opens with
-  `assert store.blocks[root].slot + 1 == get_current_slot(store)`; the Lean `getOrThrow`s
-  `blocks[root]` and throws that `assert` (`StoreTransition Bool`). Its one caller
-  (`get_payload_status_tiebreaker`) is gated by `is_previous_slot_payload_decision`, which
-  enforces the same slot equation, so the assert is unreachable in practice. Gloas throws the
-  identical assert (see the Fork choice section); Heze restates the body for the inclusion-list
-  gate. In the same function, the spec reads `store.blocks[proposer_root]` unguarded (a `KeyError`
-  on a boost root absent from `blocks`); the Lean `getOrThrow`s it, throwing to match, unreachable
-  while the boost root is always a stored block (`on_block` sets it).
-- **`is_valid_inclusion_list_signature`** (`heze/beacon-chain.md:76-87`) reads
-  `state.validators[message.validator_index]`, which raises `IndexError` on an out-of-range wire
-  index; the Lean `sszGetIdx`s the index and throws `outOfBounds` to match
-  (`EthCLSpecs/Heze/Signing.lean`), rather than masking the raise as a `false`. The predicate has
-  no in-model caller by design.
-- **`get_forkchoice_store`** (`heze/fork-choice.md:140-166`) opens with
-  `assert anchor_block.state_root == hash_tree_root(anchor_state)`; the Lean seeds the store
-  through `Except StoreTransitionError` and throws that assert to match, rather than seeding a
-  store from an inconsistent anchor pair. The Gloas and Fulu constructors throw the
-  textually-identical assert (`gloas/fork-choice.md:184`, `phase0/fork-choice.md:216`). Every
-  fork_choice vector runs through this constructor with the anchor block and state derived from
-  the same vector's files, so `state_root` always matches and no vector exercises the reject
-  branch; `pinAnchorRejects` (`EthCLSpecs/Heze/ForkChoice.lean`) locks the throw on a mismatched
-  default pair.
-
-`get_inclusion_list_committee` (`heze/beacon-chain.md:95-110`) resamples the committee as
-`indices[i % len(indices)]`, which raises `ZeroDivisionError` on an empty concatenation. The
-accessor asserts the concatenation is non-empty and throws the fork-choice reject to match, so the
-read is faithful rather than the earlier total `getD` default. `pinCommitteeThrows`
-(`EthCLSpecs/Heze/ForkChoice.lean`) locks the throw, and the record pins run over a populated
-committee so their coverage stays live. A real beacon chain never reaches a zero-active-validator
-slot, so the throw is unreachable on every conformance vector. `cyclicSample`
-(`EthCLSpecs/Heze/Committees.lean`) keeps the wrap-around arithmetic, now with a caller that
-guarantees a non-empty source.
-
-One model-structure choice carries no behavioral difference on any reachable input:
+  gate. No conformance vector reaches the discriminating `false` branch.
 
 - **The `InclusionListStore` rides inside the fork-choice `Store` as a field.** The
   spec keeps it as a process-lifetime singleton reached through
-  `get_inclusion_list_store()` (`heze/inclusion-list.md:28-38`); this framework's fork
-  choice threads one `Store` value through the generic `StoreTransition` monad
-  (`SPEC_AUTHORING_MODEL.md` §4), with no ambient singleton to hang the spec's store
-  off, so it rides as a field and moves with the rest of the state. Behavior is
-  identical.
-  The full rationale lives on the `InclusionListStore` declaration
-  (`EthCLSpecs/Heze/ForkChoice.lean`).
+  `get_inclusion_list_store()` (`heze/inclusion-list.md:28-38`), and this framework has no
+  ambient singleton to hang it off. Behavior is identical. The rationale lives on the
+  `InclusionListStore` declaration (`EthCLSpecs/Heze/ForkChoice.lean`).
 
 ## Config-tier values that bite
 

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -455,9 +455,11 @@ The linear DAG walks route through fuel-bounded combinators (§12). `getAncestor
 which a linear combinator cannot express, so it keeps a local fuel-bounded `where` helper.
 The totality the doc wants is met either way.
 
-The fork-choice weight path still runs on raw `UInt64`, where the pyspec's unbounded ints
-cannot wrap: `getAttestationScore`'s balance fold, `getWeight`'s proposer-boost add, and
-the products in `committeeWeight`, `calculateCommitteeFraction`, and `getProposerScore`.
+The fork-choice weight path still runs on raw `UInt64`, where the pyspec's `uint64` ops
+raise: `getAttestationScore`'s balance fold (the spec's `sum(...)` accumulates in `Gwei`,
+so it raises during accumulation rather than widening, `phase0/fork-choice.md:326-336`),
+`getWeight`'s proposer-boost add, and the products in `committeeWeight`,
+`calculateCommitteeFraction`, and `getProposerScore`.
 `bpsDeadlineMs`'s `bps * SLOT_DURATION_MS` shares the shape. `checkedAdd` / `checkedMul`
 (`Spec/Errors.lean`) are the fix; deferred. Reaching any of them takes a total active
 balance within a factor of the `uint64` bound, which no preset's validator set approaches.
@@ -509,13 +511,6 @@ MIN_VALIDATOR_WITHDRAWABILITY_DELAY < 2^64` before the write, so an over-range c
   rejects faithfully (matching the pyspec's `uint64` serialization `ValueError`) instead
   of wrapping silently on Lean's `UInt64`. Valid exits never approach the bound. Gloas
   inherits the substep with no Gloas-side change.
-- **`get_balance_after_withdrawals` accumulates on a wrapping `UInt64`.** Pyspec's
-  `sum(...)` adds unbounded ints, so its underflow `ValueError` fires against the true
-  sum; this fold wraps, so a true sum ≥ 2^64 passes the `withdrawn > bal` guard and
-  returns a wrong balance where pyspec raises. Unreachable while a validator's queued
-  withdrawals stay under its balance, which no vector violates. `checkedAdd`
-  (`Spec/Errors.lean`) is the fix; deferred. Gloas and Heze each restate the function and
-  carry the same divergence.
 - **`process_execution_payload` takes the execution engine as valid.** It checks
   parent-hash / prev-randao / timestamp consistency and caches the header;
   `verify_and_notify_new_payload` is the consumer's responsibility, which is valid for

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -455,14 +455,23 @@ The linear DAG walks route through fuel-bounded combinators (§12). `getAncestor
 which a linear combinator cannot express, so it keeps a local fuel-bounded `where` helper.
 The totality the doc wants is met either way.
 
-The fork-choice weight path still runs on raw `UInt64`, where the pyspec's `uint64` ops
-raise: `getAttestationScore`'s balance fold (the spec's `sum(...)` accumulates in `Gwei`,
-so it raises during accumulation rather than widening, `phase0/fork-choice.md:326-336`),
-`getWeight`'s proposer-boost add, and the products in `committeeWeight`,
-`calculateCommitteeFraction`, and `getProposerScore`.
-`bpsDeadlineMs`'s `bps * SLOT_DURATION_MS` shares the shape. `checkedAdd` / `checkedMul`
-(`Spec/Errors.lean`) are the fix; deferred. Reaching any of them takes a total active
-balance within a factor of the `uint64` bound, which no preset's validator set approaches.
+The fork-choice weight path still runs on raw `UInt64` where the pyspec's `uint64` ops
+raise, and it is deferred as one piece because it rests on one root: `getTotalBalance`
+(`phase0/beacon-chain.md:1130-1140`), whose `sum(...)` accumulates in `Gwei` and raises,
+while this fold wraps. `committeeWeight` is `getTotalActiveBalance / SLOTS_PER_EPOCH`,
+`calculateCommitteeFraction` and `getProposerScore` are its products, and `getWeight`'s
+proposer-boost add takes one operand from them, so checking any of those while the total
+underneath still wraps would only move the wrong number around.
+
+The conversion is larger than the fork-choice layer. `getTotalBalance` and
+`getTotalActiveBalance` are pure `forkdef`s with 15 call sites across epoch processing,
+rewards, registry updates, the transition spine, and fork choice; making them throwing
+propagates upward through every pure caller (§7.1's rule, one layer over). The remaining
+independent site is `getAttestationScore`'s own balance fold, which sums
+`state.validators[i].effective_balance` directly and could be checked on its own; it stays
+with the rest so the weight path converts in one go rather than half-guarded. Reaching any
+of them takes a total active balance within a factor of the `uint64` bound, which no
+preset's validator set approaches.
 
 The reference catches different exceptions per step kind, so what satisfies a
 `valid: false` step varies too. `expect_assertion_error` (`context.py:424-435`) catches

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -77,7 +77,7 @@ wraps both behind the `[CryptoBackend]` seam.
 **The vectors and the spec source.** Conformance runs against the upstream
 `consensus-spec-tests`, downloaded per `pyspecPinnedVersion`. The
 `PINNED_VERSION` in `packages/EthCLSpecs/PySpecTests/harness.py` pins
-`v1.7.0-alpha.10`; the implementation bumps
+`v1.7.0-alpha.11`; the implementation bumps
 to the current latest release at start and confirms the tag carries Gloas vectors.
 The archive layout is `tests/<preset>/<fork>/<runner>/<handler>/<suite>/<case>/`; the
 preset and fork live in the path, and each case carries a `meta.yaml`

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -78,7 +78,8 @@ wraps both behind the `[CryptoBackend]` seam.
 `consensus-spec-tests`, downloaded per `pyspecPinnedVersion`. The
 `PINNED_VERSION` in `packages/EthCLSpecs/PySpecTests/harness.py` pins
 `v1.7.0-alpha.11`; the implementation bumps
-to the current latest release at start and confirms the tag carries Gloas vectors.
+to the current latest release at start and confirms the tag carries vectors for the
+newest ported fork (Heze at this writing).
 The archive layout is `tests/<preset>/<fork>/<runner>/<handler>/<suite>/<case>/`; the
 preset and fork live in the path, and each case carries a `meta.yaml`
 (`bls_setting`, `blocks_count`, the `transition` format's `fork_epoch`). The spec

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -329,7 +329,8 @@ disk to a green result.
   case-tree walk, `meta.yaml` parsing, and a `pytest-xdist` runner where each worker
   holds one server through a `session`-scoped fixture.
 - The classify-bucket reporting: passing, expected rejection, out-of-scope `todo`,
-  likely-bug (`outOfBounds` / `missingKey`).
+  likely-bug (`outOfBounds` / `decodeFailure`), uncaught fault (`missingKey` /
+  `arithmetic`).
 
 **Acceptance.** One format, the single-operation handler the slice implements, is
 green end-to-end at the minimal preset, driven through a per-worker Lean server.
@@ -375,8 +376,8 @@ has every primitive it calls.
   `[CryptoBackend]` class with the caching FFI backend (keyed by the full serialized
   input per primitive), the symbolic backend, the `bls_setting: 2` verify-off mode,
   and the batch KZG cell verifier.
-- The control-flow combinators: the `Step` done/next type with `fuelLoop` (monadic) and
-  `fuelIterate` (the pure walk for linear DAG descents), with the per-loop decision rule
+- The control-flow combinators: the `Step` done/next type with `fuelLoop`, and
+  `fuelIterateM` / `fuelIterateM!` for linear walks, with the per-loop decision rule
   documented.
 - The finite-map and fork-choice store: `MapKind`, the `FcMap` operation class
   (`insert`, `lookup`, `contains`, `fold`, `keys`), the `treeMap` and `hashMap`

--- a/packages/EthCLSpecs/docs/README.md
+++ b/packages/EthCLSpecs/docs/README.md
@@ -1,7 +1,7 @@
 # EthCLSpecs, architecture documents
 
 EthCLSpecs is a Lean 4 library for Ethereum consensus-spec types, SSZ, the
-state-transition function, and fork choice, covering the Fulu and Gloas forks.
+state-transition function, and fork choice, covering the Fulu, Gloas, and Heze forks.
 
 Three documents define the design. Read them in order.
 
@@ -10,8 +10,8 @@ Three documents define the design. Read them in order.
    canonical glossary. Start here.
 2. [FRAMEWORK_ARCHITECTURE.md](FRAMEWORK_ARCHITECTURE.md), the framework and DSL that
    implement the contract.
-3. [SPECS_ARCHITECTURE.md](SPECS_ARCHITECTURE.md), how the Fulu and Gloas specs are
-   organized, ported, and tested.
+3. [SPECS_ARCHITECTURE.md](SPECS_ARCHITECTURE.md), how the fork specs (Fulu, Gloas,
+   Heze) are organized, ported, and tested.
 
 The glossary in the first document is the single source of truth for shared
 vocabulary; the other two quote it.
@@ -21,6 +21,12 @@ vocabulary; the other two quote it.
 implementor needs. During implementation, deviations and notable findings go in
 `IMPLEMENTATION_NOTES.md` (created then), not into these four documents, which stay
 the design of record.
+
+[DISCREPANCIES.md](DISCREPANCIES.md) is the narrow spec-vs-vector ledger: it records
+only cases where a released vector contradicts the spec text (upstream pyspec bugs)
+and resolved vector-level gaps, keyed by vector id. Deliberate implementation
+divergences that no vector observes belong in `IMPLEMENTATION_NOTES.md` instead,
+catalogued per fork.
 
 [FUTURE_WORK.md](FUTURE_WORK.md) records deferred changes: what is left, why it waits,
 and the shape it will take, so a later pass picks each one up whole. The current entry is

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -922,20 +922,20 @@ The pinned version per fork is the `pyspecPinnedVersion` constant of the contrac
 spec-revision-pin section: the latest upstream tag carrying that fork's vectors,
 stable or pre-release. Fulu pins a stable release. Gloas tracks the consensus-specs
 main branch, so it pins a pre-release or alpha tag, or a dev commit, while it is
-unreleased. The two forks sit at different pins at the same time.
+unreleased. Forks can sit at different pins at the same time.
 
 The values below are illustrative and are bumped to the current latest release at
-implementation time (the pytest harnesses pin `v1.7.0-alpha.10` at this writing);
+implementation time (the pytest harnesses pin `v1.7.0-alpha.11` at this writing);
 the implementation also confirms the chosen tag
 actually carries Gloas vectors, falling back to a dev commit if not.
 
 ```lean
 namespace EthCLSpecs.Fulu
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"   -- latest release at writing
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"   -- latest release at writing
 end EthCLSpecs.Fulu
 
 namespace EthCLSpecs.Gloas
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"   -- same tag while Gloas is unreleased
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"   -- same tag while Gloas is unreleased
 end EthCLSpecs.Gloas
 ```
 

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -6,7 +6,7 @@ it, for the Lean 4 consensus-spec library. It sits above its two siblings.
 author writes and what the framework supplies, carries the canonical glossary,
 and states the author/framework boundary table. `FRAMEWORK_ARCHITECTURE.md`
 builds each "framework generates" cell of that table from below. This document
-uses both from the author's side: it shows how the Fulu and Gloas specs are
+uses both from the author's side: it shows how the Fulu, Gloas, and Heze specs are
 organized, ported, tested, and eventually proved, written against the contract
 and on top of the machinery. Read `SPEC_AUTHORING_MODEL.md` first. This document
 quotes its glossary rather than re-coining terms, and cross-references both
@@ -64,7 +64,7 @@ Both `minimal` and `mainnet` presets are supported from the start, through the
 preset tier system that `FRAMEWORK_ARCHITECTURE.md` builds in its
 preset-constant-config-tier-system section. Minimal comes first for fast
 iteration: its smaller vector widths and shorter epochs make a failing vector
-quick to reproduce. Mainnet vectors exist for both forks and run on demand rather
+quick to reproduce. Mainnet vectors exist for all three forks and run on demand rather
 than on every push, since they are slower. The preset machinery carries both from
 day one, so mainnet is a CI-schedule choice, never a missing capability.
 
@@ -833,15 +833,15 @@ interface and `PySpecTests`, written once and fork-agnostic, runs every format.
 | `rewards/*` | a single delta function | yes |
 | `fork_choice` | the `on_*` handlers | yes |
 | `genesis` | `initializeBeaconStateFromEth1` | yes |
-| `fork` | `upgradeToGloas` | yes (Fulu to Gloas only) |
-| `transition` | `stateTransition` with `upgradeToGloas` mid-fold | yes (Fulu to Gloas only) |
-| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Fulu + Gloas) |
+| `fork` | `upgradeToGloas` / `upgradeToHeze` | yes (Fulu→Gloas, Gloas→Heze) |
+| `transition` | `stateTransition` with the upgrade mid-fold | yes (Fulu→Gloas, Gloas→Heze) |
+| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Gloas + Heze; Fulu via SizzLean) |
 | `bls`, `kzg` | n/a | no (crypto-backend concern) |
 
 The `rewards/*` format is in scope and drives a single delta function in isolation,
 the reward and penalty deltas of the `Rewards` concern file (row 29). `fork` and
-`transition` run only the Fulu-to-Gloas upgrade, since Electra is not built. Both
-presets run; mainnet runs on demand rather than on every CI pass.
+`transition` run the Fulu-to-Gloas and Gloas-to-Heze upgrades only, since Electra is
+not built. Both presets run; mainnet runs on demand rather than on every CI pass.
 
 ### 10.2 The reject-faithfulness audit
 
@@ -927,7 +927,7 @@ unreleased. Forks can sit at different pins at the same time.
 The values below are illustrative and are bumped to the current latest release at
 implementation time (the pytest harnesses pin `v1.7.0-alpha.11` at this writing);
 the implementation also confirms the chosen tag
-actually carries Gloas vectors, falling back to a dev commit if not.
+actually carries the newest ported fork's vectors, falling back to a dev commit if not.
 
 ```lean
 namespace EthCLSpecs.Fulu

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -650,16 +650,15 @@ effect-monad section runs the full state transition inside the `onBlock` handler
 and surfaces any inner failure through `StoreTransitionError.transition`. The
 step-and-check harness shape comes from the conformance framework.
 
-### 7.1 The read layer is pure, the handlers are monadic
+### 7.1 The read layer is monadic, like the handlers
 
-The fork-choice read layer is pure functions over the `Store`. `getHead`,
-`getWeight`, `filterBlockTree`, and their helpers take a `Store` and return a value.
-The `on_*` handlers are the monadic `StoreTransition` actions that mutate the store
-and call the read layer on `(← get)`.
+The fork-choice read layer runs in `StoreTransition`. `getHead`, `getWeight`,
+`filterBlockTree`, and their helpers take a `Store` and return a monadic action; the
+`on_*` handlers mutate the store and call the read layer on `(← get)`.
 
 ```lean
--- read layer: pure, recursive, takes the Store as an argument
-def getWeight (store : Store map) (root : Root) : Gwei := ...
+-- read layer: monadic, recursive, takes the Store as an argument
+forkdef getWeight (store : Store map) (root : Root) : StoreTransition Gwei := ...
 
 -- handler: monadic, mutates the store, calls the read layer on the current store
 forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
@@ -669,20 +668,17 @@ forkdef onBlock (signedBlock : SignedBeaconBlock) : StoreTransition Unit := do
   ...
 ```
 
-This diverges from the monadic state-transition accessors of Section 5, and the
-divergence is deliberate. The fork-choice reads are genuinely recursive: `getHead`
-walks the block tree, `getWeight` sums a subtree, `filterBlockTree` prunes
-recursively. A pure recursive function takes a clean `termination_by` measure on its
-argument and reasons cleanly in a later proof. Monadic recursion would drag the
-termination proof and the equation lemmas through the monad for read-only walks that
-never mutate, which is friction for no gain. Purity is infectious upward: a pure walk
-cannot call a monadic accessor, so the whole read layer is pure together.
+The reads have to be able to reject, which settles the choice. `store.blocks[root]` is a
+plain `Dict` subscript in the spec, so a missing root raises `KeyError`, and the weight
+path's `uint64` arithmetic raises on overflow. A `Gwei`-valued pure function has nowhere
+to put that: it has to supply a default, and a vector that should reject then passes.
+Rejection is infectious upward, so once a leaf read can raise, every walk above it is
+monadic too. That is why the layer moved as a unit, and why a monadic walk calling either
+a pure or a monadic helper is the invariant that holds here.
 
-The same principle drives both machines: be monadic only where it helps and does not
-hurt. It lands on monadic in the state transition because the accessors read the
-threaded state and do not recurse, and it lands on pure here because the recursion
-makes monadic hurt. The state-transition accessors of Section 5 and the fork-choice
-reads here are two applications of one rule, not a contradiction.
+This matches the monadic state-transition accessors of Section 5 for the same reason: in
+both machines a spec-faithful read is one that can fail. Termination is independent of
+the choice, and §7.2 covers it.
 
 ### 7.2 Per-loop termination
 
@@ -695,11 +691,18 @@ invariant proof at definition time. The framework's `fuelLoop` defers that proof
 the cost of a defined-but-unreachable default branch.
 
 The per-loop rule is explicit. Default to well-founded recursion when the measure is
-clean. `getHead`, for instance, has a clean measure when child slots strictly
-increase, so `maxSlot - currentSlot` strictly decreases and `termination_by` closes
-it. Reach for `fuelLoop` only when the up-front invariant proof would block the
+clean, and reach for `fuelLoop` when the up-front invariant proof would block the
 definition from existing before proofs are in scope. Record the choice and its reason
 at each such loop, so a later reader knows whether a bound is honest or deferred.
+
+Every fork-choice walk currently takes the second option: `getAncestor`, `getHead`,
+and `filterBlockTree` are all `fuelLoop`-bounded, with the block count as the bound.
+The read layer being monadic (§7.1) is what tips it. `getHead` has a clean measure on
+paper, since `maxSlot - currentSlot` strictly decreases when child slots increase, but
+discharging it through `StoreTransition` means carrying the measure past a step that
+can reject, which is the up-front proof this rule defers. The bounds are therefore
+deferred rather than honest. The `DAG walks` section header in each fork's
+`ForkChoice.lean` records that choice for the walks it heads.
 
 ---
 
@@ -835,7 +838,7 @@ interface and `PySpecTests`, written once and fork-agnostic, runs every format.
 | `genesis` | `initializeBeaconStateFromEth1` | yes |
 | `fork` | `upgradeToGloas` / `upgradeToHeze` | yes (Fulu→Gloas, Gloas→Heze) |
 | `transition` | `stateTransition` with the upgrade mid-fold | yes (Fulu→Gloas, Gloas→Heze) |
-| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Gloas + Heze; Fulu via SizzLean) |
+| `ssz_static` | each container's `SSZRepr` (decode, hash-tree-root, round-trip) | yes (Fulu + Gloas + Heze) |
 | `bls`, `kzg` | n/a | no (crypto-backend concern) |
 
 The `rewards/*` format is in scope and drives a single delta function in isolation,

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -629,7 +629,8 @@ fork must provide, with fixed signatures, expressed as a typeclass the fork
 instantiates. The entry points are `stateTransition`, `processSlots`, the
 individual `process_*` steps and operation handlers, the reward and penalty
 delta functions, the `on_*` fork-choice handlers,
-`initializeBeaconStateFromEth1`, and `upgradeToGloas`. Each entry point is
+`initializeBeaconStateFromEth1`, and the fork upgrade (`upgradeToGloas`,
+`upgradeToHeze`). Each entry point is
 independently invocable, so a single-operation vector can drive a single handler
 without running a whole block.
 

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -598,7 +598,7 @@ implementation passes the full pyspec suite. It is recorded as a constant in
 the fork:
 
 ```lean
-def pyspecPinnedVersion : String := "v1.7.0-alpha.10"
+def pyspecPinnedVersion : String := "v1.7.0-alpha.11"
 ```
 
 The name is lowerCamelCase, per the Lean convention; the value is the release

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -327,7 +327,7 @@ order, so they map one to one.
 | **Lifecycle functions** (`initializeBeaconStateFromEth1`, `isValidGenesisState`, `upgradeToGloas`) over the container constructors | the container constructors and the `genesis` / `fork` harness drivers | the container front-end, the conformance framework |
 | **Arithmetic** as faithful `UInt64` transcription | the `UInt64` operations, the `Nat`-correspondence lemmas, `umax` / `umin` / `isqrt`, the type-directed `uintToBytes` width | the arithmetic layer |
 | **Crypto calls** through the framework's signing-root and verify helpers | `computeSigningRoot` and friends, `isValidMerkleBranch`, the vector-typed BLS wrappers (`blsVerify` / `blsVerifySigned` / `blsFastAggregateVerify` / `blsEthFastAggregateVerify` / `blsAggregatePubkeys`) over the BLS and KZG primitives behind `[CryptoBackend]` | the crypto layer |
-| **Bounded loops** as fold / `forM` / well-founded recursion, or `fuelLoop` / `fuelIterate` where the measure resists | the `Step` type, `fuelLoop` (monadic) and `fuelIterate` (pure walk) | the control-flow combinators |
+| **Bounded loops** as fold / `forM` / well-founded recursion, or `fuelLoop` / `fuelIterateM` where the measure resists | the `Step` type, `fuelLoop`, `fuelIterateM` and `fuelIterateM!` | the control-flow combinators |
 | **Constants** as `Const.*` references, grouped by tier | the three-tier `Preset` / universal / `Config` system under one `Const` namespace | the preset / constant / config tier system |
 | **The fork interface implementation** (the fixed entry points) | every test driver and the format-to-entry-point dispatch in `PySpecTests` | the conformance framework |
 

--- a/packages/SizzLean/PySpecTests/harness.py
+++ b/packages/SizzLean/PySpecTests/harness.py
@@ -29,7 +29,7 @@ import yaml
 
 # The pinned release (matches EthCLSpecs.Fulu.Interface.pyspecPinnedVersion and
 # the EthCLSpecs harness). `ssz_generic` ships in the `general` archive.
-PINNED_VERSION = "v1.7.0-alpha.10"
+PINNED_VERSION = "v1.7.0-alpha.11"
 CACHE_DIR = Path.home() / ".cache" / "sizzlean"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 


### PR DESCRIPTION
The pure total functions that pyspec throws on (via `assert`, a plain-`Dict` `KeyError`, an `IndexError`, or a `uint64` over/underflow), which were modeled as silent totals, now throw faithfully through the effect monad across the Fulu, Gloas, and Heze fork choices. Answers the fork-choice faithfulness review on etheorem/etheorem#6, which is closed in favour of this branch: the Heze layer is stacked underneath here commit for commit, so merging this merges that.

## What changed

- Gloas fork-choice runs through the throwing `StoreTransition` monad. That covers the weight/head/reorg walk, the leaf plain-`Dict` reads, `should_extend_payload`'s slot assert, and `getHead` via `fuelLoop`.
- Heze FOCIL fork-choice reads throw where pyspec does. `is_payload_inclusion_list_satisfied`, the timeliness plain-`Dict` read, `record_payload_inclusion_list_satisfaction`'s slot underflow, the inclusion-list-signature `IndexError`, and the empty inclusion-list-committee `ZeroDivisionError`.
- `get_forkchoice_store` throws its opening anchor assert (`anchor_block.state_root == hash_tree_root(anchor_state)`) in all three forks, seeding through `Except StoreTransitionError`.
- A new reject class, `StateTransitionError.arithmetic`, for a `uint64` over/underflow. pyspec raises `ValueError` there, which the reference runner leaves uncaught (unlike the `AssertionError` / `IndexError` it does catch), so it is a distinct uncaught class rather than a caught `.assert`. The withdrawal validator/builder reads go through `sszGetIdx` (the faithful `IndexError`) in place of a guarding `assert`, and the `block_timeliness[root][INDEX]` list reads throw through a new `arrGetIdx`.
- The runner's `.block` step scores `on_block` alone against the step's `valid` flag, then replays the block's own attestations / attester-slashings only on the valid path, matching pyspec's `add_block`.

### Checked `uint64` arithmetic

`checkedAdd` / `checkedSub` / `checkedMul` reject on overflow where the bare operators wrap. Converted: the `get_forkchoice_store` time seed, `get_slots_since_genesis`, `compute_time_at_slot`, `time_into_slot`, `on_tick`'s per-slot catch-up, `is_finalization_ok`'s epoch gap, `get_proposer_head`'s slot comparisons, `process_attestation`'s inclusion delay, `process_execution_payload`'s timestamp product and sum, `get_ptc`'s window index, `get_balance_after_withdrawals`' accumulator, and the Gloas slot/epoch adds in `filter_block_tree`, `is_previous_slot_payload_decision` and `is_proposer_equivocation`.

`on_tick`'s catch-up runs on a new `fuelIterateM!`, which throws on fuel exhaustion rather than returning the accumulator.

All three operators raise through one helper, `throwArithmetic`, which also serves the spec's single non-operator arithmetic fault (`get_inclusion_list_committee`'s `indices[i % len(indices)]` on an empty committee, a `ZeroDivisionError`). No call site names the per-machine wrapper; the `[ErrorConv StateTransitionError E]` bound rides the fault in as `.arithmetic` on the state machine and `.transition (.arithmetic …)` on the store machine.

### Per-step-kind reject scoring

The reference's caught set differs by step kind: `expect_assertion_error` (`context.py:424-435`) catches `IndexError` for the attestation, attester-slashing, envelope and PTC-message steps, while `add_block` (`fork_choice.py:389`) catches `AssertionError` and `BlockNotFoundException` alone. `FcStepKind` carries that table and `checkStepValidity` reads it.

A store-side `missingKey` classifies as an uncaught fault rather than a likely bug: it is a bare-`Dict` `KeyError`, which the reference propagates, so it can never be an invalid vector's expected rejection. A decode failure scores as a failure rather than a rejection.

### Fixes found while reviewing

- **A decode failure no longer clean-passes an invalid step.** A fork-choice SSZ decode failure was thrown as `.assert`, an expected rejection, so a decoder or wrong-container bug on a `valid:false` step passed green. `StoreTransitionError.decodeFailure` stays out of `isExpectedRejection`.
- **A nested `todo` / `outOfScope` reports correctly**, routed through `RunError.classify`.
- **`getWeight` reads `store.blocks` inside the generator's short-circuit branches**, matching pyspec. Hoisting it made an empty-`latest_messages` store, exactly what `get_forkchoice_store` returns, raise `.missingKey` where the reference returns `Gwei(0)`.
- **A column sidecar the decoder cannot read rejects** rather than being dropped, which would let a `valid:false` step pass on a broken decoder.

### Review follow-ups

Five commits on top of the original stack, from Leo's review pass.

- **Fuel exhaustion rejects as `todo`, not `assert`** (`b69aa01`). `fuelIterateM!`'s bound belongs to this model rather than to spec text, so exhausting it is a work-queue item. As `assert` it sat in the caught set, which would have passed a `valid: false` step green on a bound we already know is wrong. Both call sites are `on_tick`, whose steps always run `expectedValid := true`, so no verdict moves. The class keeps it that way for the next caller.
- **One canonical raise for the arithmetic fault** (`fc68ce6`). Five sites built `.arithmetic` by hand, two of them naming the `.transition` wrapper themselves. The three `balanceAfterWithdrawals` copies and `record_payload_inclusion_list_satisfaction` were open-coding `checkedSub` and now call it; `throwArithmetic` covers the one genuine non-operator fault. Behavior-preserving, and `pinBalanceUnderflowThrows` still holds.
- **Three documentation corrections** (`258a7e9`, `c98cb4c`, `e24e79c`). The `cyclicSample` note still said the caller "asserts", naming the caught class where the guard is an uncaught `.arithmetic` throw. `betterOf` now records why its `foldlM` surfaces the same reject as the spec's `max`: an accumulator reached its position by surviving an earlier step, so its key already succeeded and cannot throw on the re-run. `getWeight` names its two deliberate non-conversions (the unchecked index is in range by construction, the `Gwei` sums defer with the weight path) where they previously lived only in this description.

## Faithfulness pins

Each throw whose reject branch no conformance vector reaches carries a build-enforced pin: `pinCommitteeThrows`, `pinRecordRefuted`, `pinAnchorRejects`, `pinBalanceUnderflowThrows`, and the collect/timeliness pins. The class-sensitive ones match on the reject constructor, so a regression from `.assert` to `.missingKey` breaks the build. `native_decide` where a hash is involved, kernel `#guard` otherwise.

`fuelIterateM!`'s fuel-out is pinned the same way in `Tests/FrameworkUtils.lean`, on both the constructor and `isExpectedRejection`, so a regression back to `.assert` breaks the build rather than turning a wrong loop bound into a green step.

## Conformance

All six sweeps pass-to-pass against baseline, zero failures:

| fork | minimal | mainnet |
|------|---------|---------|
| fulu | 5188 | 847 |
| gloas | 6573 | 1034 |
| heze | 6770 | 997 |

21409 total. Every converted throw is unreachable on a current conformance vector, so no verdict moves; the pins carry the regression guard.

The five review follow-up commits were verified on `just ethcl-test` (439 jobs green, the `native_decide` and `#guard` pins included) and `just ethcl-pyspec-smoke` (fulu 152, gloas 200, heze 201 passed, zero failures). The full sweep above has not been re-run since; only one of the five touches a live code path, and it is behavior-preserving.

Note for anyone reproducing the build: bare `lake build` at the repo root builds nothing and still exits 0, because the umbrella package declares no `lean_lib`. Use `just ethcl-test`.

<details>
<summary>Deferred findings (all filed as issues)</summary>

Real, but unreachable on any current conformance vector, or cleanup. Every one is now an issue, so none of it depends on this branch surviving the squash. The detail lives in the issues; this is the index.

| Issue | Site | What |
|---|---|---|
| etheorem/etheorem#43 | `Spec/Balances.lean`, the weight path | `getTotalBalance`'s fold wraps where the spec's `sum(...)` raises. The whole weight path rests on it and converts as one piece. |
| etheorem/etheorem#44 | state-transition `uint64` arithmetic | Bare `+` / `-` / `*` remains across epoch processing and the registry. Partly blocked on #41. |
| etheorem/etheorem#45 | `Fulu/Transition.lean` | `process_execution_payload`'s timestamp assert keeps the seconds form where the spec uses milliseconds. Value-equivalent at both presets. |
| etheorem/etheorem#46 | `Gloas/ForkChoice.lean` | `is_data_available` / `verify_and_notify_new_payload` are inline `true`. Migrate onto the `[ExecutionEngine]` seam. |
| etheorem/etheorem#47 | `PySpecTests/harness.py` | The `flagged` bug-smell marker is computed, sent as `bug!`, and discarded before any human sees it. |
| etheorem/etheorem#48 | `Gloas/Interface.lean` | `get_proposer_head` routes to `.todo` for Gloas. Fulu implements it. |
| etheorem/etheorem#49 | `Spec/Engine.lean` | FOCIL `is_inclusion_list_satisfied` is the optimistic default; only `pinRecordRefuted` reaches the `false` branch. |
| etheorem/etheorem#50 | `Heze/Signing.lean` | `isValidInclusionListSignature` carries no pin and no vector, so the EIP-7805 signature and domain path is unexercised. |
| etheorem/etheorem#41 | `Spec/Errors.lean` | The caught set is per step kind but still one policy per runner. Blocks `initiate_validator_exit`'s conversion to `checkedAdd`. |
| etheorem/etheorem#51 | `PySpecTests/harness.py` | `ServerClient` mutes Lean panics, cannot time out a wedged server, and does not reap the previous `Popen`. |
| etheorem/etheorem#52 | `EthCLSpecs` / `EthCLLib` | ~650 lines of `native_decide` pins ship in the precompiled libraries rather than the `*Tests` libraries the lakefiles designate. |
| etheorem/etheorem#53 | the three `Interface.lean` | The fork-choice step interpreter is triplicated across forks and kept in lockstep by hand. |
| etheorem/etheorem#54 | the three `Interface.lean` | The block-replay sub-action is labelled `.attestation` though it replays attester slashings too. Sub-issue of #53. |
| etheorem/etheorem#55 | `Gloas/ForkChoice.lean` | `betterOf` recomputes `getWeight` for both sides of each comparison. Performance only; `c98cb4c` records why it is otherwise unobservable. |
| etheorem/etheorem#56 | `SPECS_ARCHITECTURE.md` §7.2 | The fuel-versus-measure justification is recorded per section rather than per loop site. |

</details>
