### PR TITLE
feat(gloas-initialize-ptc-window-proof): prove initializePtcWindow regions

### DIFF
--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -1,4 +1,5 @@
 import EthCLSpecs.Proofs.BuilderIndex
+import EthCLSpecs.Proofs.InitializePtcWindow
 
 /-!
 # `EthCLSpecs.Proofs`: consensus-spec theorems (index)
@@ -15,4 +16,6 @@ Re-exports:
 
 * `EthCLSpecs.Proofs.BuilderIndex`: the builder-index flag round-trip
   (`isBuilderIndex`, `toBuilderIndex`, `convertBuilderIndexToValidatorIndex`).
+* `EthCLSpecs.Proofs.InitializePtcWindow`: the seeded `ptcWindow`'s two
+  regions (`initializePtcWindow`).
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
@@ -1,0 +1,59 @@
+import EthCLSpecs.Gloas.Upgrade
+
+/-!
+# `EthCLSpecs.Proofs.InitializePtcWindow`: the seeded PTC window's two regions
+
+`EthCLSpecs.Gloas.initializePtcWindow` (`Gloas/Upgrade.lean`) builds the
+Fulu → Gloas fork transition's cached `ptcWindow` as one `Vector.ofFn` over
+`Fin (3 * SLOTS_PER_EPOCH)`, branching on whether the index falls in the empty
+first epoch or the two computed epochs after it. Both branches are proved by
+unfolding the definition and letting `simp` reduce the `Vector.ofFn` /
+`Fin.val` arithmetic and discharge the `if`, no induction, no `native_decide`,
+no mathlib.
+-/
+
+set_option autoImplicit false
+
+open EthCLLib.Spec
+open EthCLSpecs.Fulu
+
+namespace EthCLSpecs.Proofs
+
+open EthCLSpecs.Gloas (initializePtcWindow computePtcFromFulu)
+
+/-- The window's first `SLOTS_PER_EPOCH` entries (the placeholder "previous
+epoch", empty because the pre-fork Fulu state carries no PTC) are the all-zero
+committee, `initialize_ptc_window`'s `emptyCommittee`. -/
+theorem initializePtcWindow_lt [Preset] [HasherTag] (state : Fulu.State)
+    (i : Fin (3 * Const.slotsPerEpoch)) (h : i.val < Const.slotsPerEpoch) :
+    (initializePtcWindow state)[i] = Vector.replicate Const.ptcSize 0 := by
+  simp [initializePtcWindow, h]
+
+/-- The window's remaining `2 * SLOTS_PER_EPOCH` entries (the current epoch and
+the one after it) are `computePtcFromFulu` evaluated at the slot
+`initialize_ptc_window` computes for that offset: split the offset
+`k := i - SLOTS_PER_EPOCH` into an epoch delta (`k / SLOTS_PER_EPOCH`) and an
+intra-epoch slot offset (`k % SLOTS_PER_EPOCH`), exactly as the definition
+does, rather than the collapsed `startSlot(currentEpoch) + k` form (which
+would need a `UInt64` no-overflow side condition this statement doesn't
+carry). -/
+theorem initializePtcWindow_ge [Preset] [HasherTag] (state : Fulu.State)
+    (i : Fin (3 * Const.slotsPerEpoch)) (h : Const.slotsPerEpoch ≤ i.val) :
+    (initializePtcWindow state)[i] =
+      let k := i.val - Const.slotsPerEpoch
+      computePtcFromFulu state
+        (computeStartSlotAtEpoch (currentEpochOf state + UInt64.ofNat (k / Const.slotsPerEpoch)) +
+          UInt64.ofNat (k % Const.slotsPerEpoch)) := by
+  simp [initializePtcWindow, Nat.not_lt.mpr h]
+
+/-- The first region's committee is also the ambient `default` for
+`Vector ValidatorIndex Const.ptcSize` (`ValidatorIndex := UInt64`'s `default`
+is `0`, and `Vector`'s `Inhabited` instance is pointwise), so callers that
+already reason in terms of `default` don't need to unfold `initializePtcWindow`
+a second time to get there. -/
+theorem initializePtcWindow_lt_default [Preset] [HasherTag] (state : Fulu.State)
+    (i : Fin (3 * Const.slotsPerEpoch)) (h : i.val < Const.slotsPerEpoch) :
+    (initializePtcWindow state)[i] = default :=
+  initializePtcWindow_lt state i h
+
+end EthCLSpecs.Proofs

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
@@ -6,27 +6,28 @@ import EthCLSpecs.Gloas.Upgrade
 `EthCLSpecs.Gloas.initializePtcWindow` (`Gloas/Upgrade.lean`) builds the
 Fulu → Gloas fork transition's cached `ptcWindow` as one `Vector.ofFn` over
 `Fin (3 * SLOTS_PER_EPOCH)`, branching on whether the index falls in the empty
-first epoch or the two computed epochs after it. Both branches are proved by
-unfolding the definition and letting `simp` reduce the `Vector.ofFn` /
-`Fin.val` arithmetic and discharge the `if`, no induction, no `native_decide`,
+first epoch or the remaining two SLOTS_PER_EPOCH regions. Both branches are proved by
+unfolding the definition and letting `simp` reduce the `Vector.ofFn`
+application and discharge the `if`, no induction, no `native_decide`,
 no mathlib.
 -/
 
 set_option autoImplicit false
 
-open EthCLLib.Spec (HasherTag)
-open EthCLSpecs.Fulu (Preset computeStartSlotAtEpoch currentEpochOf)
-
 namespace EthCLSpecs.Proofs
 
+open EthCLLib.Spec (HasherTag)
+open EthCLSpecs.Fulu (Preset computeStartSlotAtEpoch currentEpochOf)
 open EthCLSpecs.Gloas (initializePtcWindow computePtcFromFulu)
 
 /-- The window's first `SLOTS_PER_EPOCH` entries (the placeholder "previous
 epoch", empty because the pre-fork Fulu state carries no PTC) are the all-zero
 committee, `initialize_ptc_window`'s `emptyCommittee`. -/
-theorem initializePtcWindow_lt [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : i.val < Fulu.Const.slotsPerEpoch) :
-    (initializePtcWindow state)[i] = Vector.replicate Fulu.Const.ptcSize 0 := by
+theorem initializePtcWindow_lt [Preset] [HasherTag] :
+    ∀ (state : Fulu.State) (i : Fin (3 * Fulu.Const.slotsPerEpoch)),
+      i.val < Fulu.Const.slotsPerEpoch →
+      (initializePtcWindow state)[i] = Vector.replicate Fulu.Const.ptcSize 0 := by
+  intro state i h
   simp [initializePtcWindow, h]
 
 /-- The window's remaining `2 * SLOTS_PER_EPOCH` entries (the current epoch and
@@ -37,13 +38,15 @@ intra-epoch slot offset (`k % SLOTS_PER_EPOCH`), exactly as the definition
 does, rather than the collapsed `startSlot(currentEpoch) + k` form (which
 would need a `UInt64` no-overflow side condition this statement doesn't
 carry). -/
-theorem initializePtcWindow_ge [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : Fulu.Const.slotsPerEpoch ≤ i.val) :
-    (initializePtcWindow state)[i] =
-      let k := i.val - Fulu.Const.slotsPerEpoch
-      computePtcFromFulu state
-        (computeStartSlotAtEpoch (currentEpochOf state + UInt64.ofNat (k / Fulu.Const.slotsPerEpoch)) +
-          UInt64.ofNat (k % Fulu.Const.slotsPerEpoch)) := by
+theorem initializePtcWindow_ge [Preset] [HasherTag] :
+    ∀ (state : Fulu.State) (i : Fin (3 * Fulu.Const.slotsPerEpoch)),
+      Fulu.Const.slotsPerEpoch ≤ i.val →
+      (initializePtcWindow state)[i] =
+        let k := i.val - Fulu.Const.slotsPerEpoch
+        computePtcFromFulu state
+          (computeStartSlotAtEpoch (currentEpochOf state + UInt64.ofNat (k / Fulu.Const.slotsPerEpoch)) +
+            UInt64.ofNat (k % Fulu.Const.slotsPerEpoch)) := by
+  intro state i h
   simp [initializePtcWindow, Nat.not_lt.mpr h]
 
 /-- The first region's committee is also the ambient `default` for
@@ -51,9 +54,11 @@ theorem initializePtcWindow_ge [Preset] [HasherTag] (state : Fulu.State)
 `default` is `0`, and `Vector`'s `Inhabited` instance is pointwise), so callers
 that already reason in terms of `default` don't need to unfold
 `initializePtcWindow` a second time to get there. -/
-theorem initializePtcWindow_lt_default [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : i.val < Fulu.Const.slotsPerEpoch) :
-    (initializePtcWindow state)[i] = default :=
-  initializePtcWindow_lt state i h
+theorem initializePtcWindow_lt_default [Preset] [HasherTag] :
+    ∀ (state : Fulu.State) (i : Fin (3 * Fulu.Const.slotsPerEpoch)),
+      i.val < Fulu.Const.slotsPerEpoch →
+      (initializePtcWindow state)[i] = default := by
+  intro state i h
+  exact initializePtcWindow_lt state i h
 
 end EthCLSpecs.Proofs

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/InitializePtcWindow.lean
@@ -14,8 +14,8 @@ no mathlib.
 
 set_option autoImplicit false
 
-open EthCLLib.Spec
-open EthCLSpecs.Fulu
+open EthCLLib.Spec (HasherTag)
+open EthCLSpecs.Fulu (Preset computeStartSlotAtEpoch currentEpochOf)
 
 namespace EthCLSpecs.Proofs
 
@@ -25,8 +25,8 @@ open EthCLSpecs.Gloas (initializePtcWindow computePtcFromFulu)
 epoch", empty because the pre-fork Fulu state carries no PTC) are the all-zero
 committee, `initialize_ptc_window`'s `emptyCommittee`. -/
 theorem initializePtcWindow_lt [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Const.slotsPerEpoch)) (h : i.val < Const.slotsPerEpoch) :
-    (initializePtcWindow state)[i] = Vector.replicate Const.ptcSize 0 := by
+    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : i.val < Fulu.Const.slotsPerEpoch) :
+    (initializePtcWindow state)[i] = Vector.replicate Fulu.Const.ptcSize 0 := by
   simp [initializePtcWindow, h]
 
 /-- The window's remaining `2 * SLOTS_PER_EPOCH` entries (the current epoch and
@@ -38,21 +38,21 @@ does, rather than the collapsed `startSlot(currentEpoch) + k` form (which
 would need a `UInt64` no-overflow side condition this statement doesn't
 carry). -/
 theorem initializePtcWindow_ge [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Const.slotsPerEpoch)) (h : Const.slotsPerEpoch ≤ i.val) :
+    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : Fulu.Const.slotsPerEpoch ≤ i.val) :
     (initializePtcWindow state)[i] =
-      let k := i.val - Const.slotsPerEpoch
+      let k := i.val - Fulu.Const.slotsPerEpoch
       computePtcFromFulu state
-        (computeStartSlotAtEpoch (currentEpochOf state + UInt64.ofNat (k / Const.slotsPerEpoch)) +
-          UInt64.ofNat (k % Const.slotsPerEpoch)) := by
+        (computeStartSlotAtEpoch (currentEpochOf state + UInt64.ofNat (k / Fulu.Const.slotsPerEpoch)) +
+          UInt64.ofNat (k % Fulu.Const.slotsPerEpoch)) := by
   simp [initializePtcWindow, Nat.not_lt.mpr h]
 
 /-- The first region's committee is also the ambient `default` for
-`Vector ValidatorIndex Const.ptcSize` (`ValidatorIndex := UInt64`'s `default`
-is `0`, and `Vector`'s `Inhabited` instance is pointwise), so callers that
-already reason in terms of `default` don't need to unfold `initializePtcWindow`
-a second time to get there. -/
+`Vector ValidatorIndex Fulu.Const.ptcSize` (`ValidatorIndex := UInt64`'s
+`default` is `0`, and `Vector`'s `Inhabited` instance is pointwise), so callers
+that already reason in terms of `default` don't need to unfold
+`initializePtcWindow` a second time to get there. -/
 theorem initializePtcWindow_lt_default [Preset] [HasherTag] (state : Fulu.State)
-    (i : Fin (3 * Const.slotsPerEpoch)) (h : i.val < Const.slotsPerEpoch) :
+    (i : Fin (3 * Fulu.Const.slotsPerEpoch)) (h : i.val < Fulu.Const.slotsPerEpoch) :
     (initializePtcWindow state)[i] = default :=
   initializePtcWindow_lt state i h
 

--- a/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
+++ b/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
@@ -114,7 +114,7 @@ incidental, it's what the function does.
 | --------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `upgradeToGloas`      | `Gloas/Upgrade.lean:101-156` | Preserves inherited state while correctly initializing the new ePBS state                                                                                            |
 | `computePtcFromFulu`  | `Gloas/Upgrade.lean:35-43`   | Agrees with `Gloas.computePtc` once the state is upgraded                                                                                                            |
-| `initializePtcWindow` | `Gloas/Upgrade.lean:50-60`   | Each entry of the window it builds is either the empty committee, for the first `SLOTS_PER_EPOCH` slots, or `computePtcFromFulu` evaluated at the corresponding slot |
+| `initializePtcWindow` | `Gloas/Upgrade.lean:50-60`   | **In review**, see `EthCLSpecs/Proofs/InitializePtcWindow.lean`. The first `SLOTS_PER_EPOCH` entries are the empty committee, and every remaining entry equals `computePtcFromFulu` at the slot computed by `initializePtcWindow` |
 
 ---
 

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -621,4 +621,9 @@ separation.
   `convertBuilderIndexToValidatorIndex`, proving the builder-index flag
   round-trip and tagging properties.
 
+- **`Proofs/InitializePtcWindow.lean`** establishes three `simp`-closed theorems
+  over `initializePtcWindow`: its two index regions (the empty first-epoch
+  placeholder and the remainder computed via `computePtcFromFulu`), plus a
+  `default` corollary for the first region.
+
 - **`CONSENSUS_PROOF_CANDIDATES.md`** tracks candidate consensus proof targets.


### PR DESCRIPTION
## Summary

Adds `EthCLSpecs/Proofs/InitializePtcWindow.lean`, proving the two index
regions of `initializePtcWindow`'s (Fulu → Gloas upgrade) cached `ptcWindow`:

- The first `SLOTS_PER_EPOCH` entries are the empty placeholder committee
  (`initializePtcWindow_lt`).
- Every remaining entry equals `computePtcFromFulu` evaluated at the slot
  `initializePtcWindow`'s else-branch computes, split into an epoch delta
  and an intra-epoch offset exactly as the implementation does
  (`initializePtcWindow_ge`).
- A `default` corollary for the first region (`initializePtcWindow_lt_default`),
  since the zero `ValidatorIndex` committee is definitionally `default`.

## Supporting Changes

- Marks `initializePtcWindow` **In review** in `CONSENSUS_PROOF_CANDIDATES.md`,
  pointing at the new proof file.
- Adds the `Proofs/InitializePtcWindow.lean` entry to `IMPLEMENTATION_NOTES.md`'s
  "## Proofs" section.
- Re-exports the new module from `EthCLSpecs/Proofs.lean`.

## Notes for Reviewers

- This is a structural characterization of `initializePtcWindow` itself, not
  a cross-fork correctness claim. It doesn't relate the window's contents back
  to Gloas's own `getPtc`. That bridge theorem is harder (it needs to reason
  about the upgrade boundary) and is left for a follow-up.
- `initializePtcWindow_ge`'s RHS states the exact `div`/`mod` slot formula the
  `if`'s else-branch computes, not the collapsed `startSlot(currentEpoch) + k`
  form, so no `UInt64` no-overflow hypothesis is needed or assumed.
- All three theorems index via `Fin (3 * SLOTS_PER_EPOCH)`
  (`(initializePtcWindow state)[i]`), so the upper bound is carried by the
  index type itself; no separate bounds lemma needed.
- Proofs close with `simp` unfolding `initializePtcWindow` directly, following
  `Proofs/BuilderIndex.lean`'s idiom (`∀ … := by intro …`, `open`s scoped
  inside the namespace). No induction, `native_decide`, `bv_decide`, `sorry`,
  or mathlib; `#print axioms` on all three shows only Lean's three core
  axioms (`propext`, `Classical.choice`, `Quot.sound`).

## Test Plan

- [x] `lake build`
- [x] `lake build EthCLSpecs`
- [x] `just ethcl-test`
- [x] `just lint`