### PR TITLE
feat(gloas-update-checkpoints-proof): prove updateCheckpoints checkpoint monotonicity

### DIFF
--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -7,8 +7,9 @@ import EthCLSpecs.Proofs.UpdateCheckpoints
 
 Mathlib-free proofs about `EthCLSpecs` declarations, colocated with the specs
 the way `SizzLean.Proofs` is colocated with `SizzLean`: same package, same
-build, `bv_decide` / `decide` / `native_decide` over the spec's own types, no
-mathlib. A theorem that turns out to need mathlib moves to the standalone
+build, closed by whichever of `bv_decide`, `decide`, `native_decide`, or plain
+case analysis the goal needs, over the spec's own types, no mathlib. A
+theorem that turns out to need mathlib moves to the standalone
 `EthCLProofs` package instead (`docs/SPECS_ARCHITECTURE.md` §11), the
 `LeanPoseidonProofs` containment pattern, so mathlib never reaches this
 library, the framework, the runner, or the conformance path.

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -1,5 +1,6 @@
 import EthCLSpecs.Proofs.BuilderIndex
 import EthCLSpecs.Proofs.InitializePtcWindow
+import EthCLSpecs.Proofs.UpdateCheckpoints
 
 /-!
 # `EthCLSpecs.Proofs`: consensus-spec theorems (index)
@@ -18,4 +19,6 @@ Re-exports:
   (`isBuilderIndex`, `toBuilderIndex`, `convertBuilderIndexToValidatorIndex`).
 * `EthCLSpecs.Proofs.InitializePtcWindow`: the seeded `ptcWindow`'s two
   regions (`initializePtcWindow`).
+* `EthCLSpecs.Proofs.UpdateCheckpoints`: `Gloas.updateCheckpoints` checkpoint
+  monotonicity, the justified/finalized epoch never decreases.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -7,12 +7,12 @@ import EthCLSpecs.Proofs.UpdateCheckpoints
 
 Mathlib-free proofs about `EthCLSpecs` declarations, colocated with the specs
 the way `SizzLean.Proofs` is colocated with `SizzLean`: same package, same
-build, closed by whichever of `bv_decide`, `decide`, `native_decide`, or plain
-case analysis the goal needs, over the spec's own types, no mathlib. A
-theorem that turns out to need mathlib moves to the standalone
-`EthCLProofs` package instead (`docs/SPECS_ARCHITECTURE.md` §11), the
-`LeanPoseidonProofs` containment pattern, so mathlib never reaches this
-library, the framework, the runner, or the conformance path.
+build. Each theorem is closed by whichever tactic its goal needs, `bv_decide`,
+`decide`, `native_decide`, or plain case analysis. Always over the spec's own
+types, never mathlib. A theorem that turns out to need mathlib moves to the standalone
+`EthCLProofs` package instead (`docs/SPECS_ARCHITECTURE.md` §11), following the
+`LeanPoseidonProofs` containment pattern. Mathlib never reaches this library,
+the framework, the runner, or the conformance path.
 
 Re-exports:
 

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -21,5 +21,6 @@ Re-exports:
 * `EthCLSpecs.Proofs.InitializePtcWindow`: the seeded `ptcWindow`'s two
   regions (`initializePtcWindow`).
 * `EthCLSpecs.Proofs.UpdateCheckpoints`: `Gloas.updateCheckpoints` checkpoint
-  monotonicity, the justified/finalized epoch never decreases.
+  monotonicity, the justified/finalized epoch never decreases. Its theorems sit
+  in `EthCLSpecs.Proofs.Gloas`, since `updateCheckpoints` exists in both forks.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -23,12 +23,10 @@ open EthCLSpecs.Gloas (Store updateCheckpoints Checkpoint)
 open EthCLSpecs.Fulu (Preset)
 open EthCLLib.Spec (MapKind HasherTag)
 
-variable {map : MapKind} [Preset] [HasherTag]
-  (store : Store map) (j f : Checkpoint)
-
 /-- The resulting justified checkpoint is either unchanged because `j` is not newer,
 or exactly `j` because its epoch is strictly greater. -/
-theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
+theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances
+    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
     ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
@@ -44,7 +42,8 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
 
 /-- The resulting finalized checkpoint is either unchanged because `f` is not newer,
 or exactly `f` because its epoch is strictly greater. -/
-theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
+theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances
+    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
     ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
@@ -59,14 +58,16 @@ theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
   · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
 
 /-- `updateCheckpoints` never lowers the Store's justified epoch. -/
-theorem updateCheckpoints_justifiedEpoch_le :
+theorem updateCheckpoints_justifiedEpoch_le
+    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
     store.justifiedCheckpoint.epoch ≤ (updateCheckpoints store j f).justifiedCheckpoint.epoch := by
   rcases updateCheckpoints_justifiedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
   · rw [h]; exact UInt64.le_refl _
   · rw [h]; exact UInt64.le_of_lt hlt
 
 /-- `updateCheckpoints` never lowers the Store's finalized epoch. -/
-theorem updateCheckpoints_finalizedEpoch_le :
+theorem updateCheckpoints_finalizedEpoch_le
+    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
     store.finalizedCheckpoint.epoch ≤ (updateCheckpoints store j f).finalizedCheckpoint.epoch := by
   rcases updateCheckpoints_finalizedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
   · rw [h]; exact UInt64.le_refl _

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -31,7 +31,7 @@ or exactly `j` because its epoch is strictly greater. -/
 theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
-      ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
+    ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
         store.justifiedCheckpoint.epoch < j.epoch) := by
   -- Decide both guards so `simp` can reduce the nested record updates
   -- and project the checkpoint field unaffected by the other update.
@@ -47,7 +47,7 @@ or exactly `f` because its epoch is strictly greater. -/
 theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
-      ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
+    ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
         store.finalizedCheckpoint.epoch < f.epoch) := by
   -- Decide both guards so `simp` can reduce the nested record updates
   -- and project the checkpoint field unaffected by the other update.

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -23,9 +23,8 @@ store.justifiedCheckpoint.epoch` on the unchanged side, `store.justifiedCheckpoi
 < j.epoch` on the advancing side, so the disjunction is the `if`'s condition and its
 negation, not just its two possible outputs. The monotonicity theorems (`_epoch_le`) are
 the corollary a reader actually wants, "epochs never go backwards." Scoped to
-`EthCLSpecs.Gloas.updateCheckpoints` only; the Fulu declaration of the same name has an
-identical body but is a separate, unrelated `forkdef` in a different namespace, not
-covered here.
+`EthCLSpecs.Gloas.updateCheckpoints` only. (The Fulu declaration of the same name is a
+separate `forkdef` in a different namespace, not covered here.)
 
 See `EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md`, "Monotonicity properties".
 -/
@@ -41,55 +40,19 @@ open EthCLLib.Spec (MapKind HasherTag)
 variable {map : MapKind} [Preset] [HasherTag]
   (store : Store map) (j f : Checkpoint)
 
-/-! ### Field independence
-
-`updateCheckpoints`' two `if`s each write one field of the `Store`; the "each checkpoint
-either remains unchanged or advances" reading of the function depends on those two
-writes not interfering, on the finalized `if` never touching `justifiedCheckpoint` and
-the justified `if` never touching `finalizedCheckpoint`. That's not an assumption about
-`updateCheckpoints`, it's a property of the `{ s with field := v }` update notation both
-`if`s use: the notation elaborates to a `Store.mk` application that substitutes the named
-field and copies every other field straight from `s`, so for two distinct field names
-the write and the read never alias. Recorded here as its own pair of `rfl` lemmas, true
-by that elaboration alone, no unfolding of `updateCheckpoints` and no guard decision
-needed, so the independence is confirmed as a standalone, citable fact rather than left
-implicit in whatever `simp` happens to do inside the two theorems below. (`simp`'s own
-default reduction of a record update performs the identical step when closing those
-theorems' goals, which is *why* passing these lemmas to `simp` there is flagged
-"unused": the fact is already load-bearing in the kernel check, just not under this
-name.) -/
-
-/-- Setting `justifiedCheckpoint` leaves `finalizedCheckpoint` untouched. Not consumed by
-name anywhere (the two theorems below get the identical reduction for free from `simp`'s
-own record-projection handling once both guards are decided), `private` because its role
-is this file's own documentation, not public API. -/
-private theorem finalizedCheckpoint_of_justifiedCheckpoint_update :
-    ({ store with justifiedCheckpoint := j } : Store map).finalizedCheckpoint =
-      store.finalizedCheckpoint := rfl
-
-/-- The mirror: setting `finalizedCheckpoint` leaves `justifiedCheckpoint` untouched. -/
-private theorem justifiedCheckpoint_of_finalizedCheckpoint_update :
-    ({ store with finalizedCheckpoint := f } : Store map).justifiedCheckpoint =
-      store.justifiedCheckpoint := rfl
-
 /-- The justified half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
 disjunction over the guard `j.epoch > store.justifiedCheckpoint.epoch` and its negation,
 not just over the two outputs: the unchanged arm additionally proves the guard *failed*
 (`j.epoch ≤ store.justifiedCheckpoint.epoch`), the advancing arm additionally proves it
 *fired* (`store.justifiedCheckpoint.epoch < j.epoch`). `UInt64.not_lt` turns the negated
-guard into that `≤`. The `by_cases` on `h2` is there only because `simp` can't push a
-projection through an *undecided* `ite` (no generic `apply_ite`-style lemma is in scope
-here), once `h2` pins down which of the `f`-arm's two branches fired, closing the
-resulting concrete projection is exactly
-`justifiedCheckpoint_of_finalizedCheckpoint_update`, `simp`'s own default reduction of a
-record update already performs that same step, which is why the lemma is redundant to
-name explicitly in the `simp` set below, its content, not its citation, is what the
-`by_cases` is discharging. -/
+guard into that `≤`. -/
 theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
       ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
         store.justifiedCheckpoint.epoch < j.epoch) := by
+  -- Decide both guards so `simp` can reduce the nested record updates
+  -- and project the checkpoint field unaffected by the other update.
   by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;>
     by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch
   · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h1⟩
@@ -99,16 +62,14 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
 
 /-- The finalized half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
 disjunction over the guard `f.epoch > store.finalizedCheckpoint.epoch` and its negation,
-the mirror of `updateCheckpoints_justifiedCheckpoint_eq_or_advances`. Symmetrically, the
-`by_cases` on `h1` decides which of the `j`-arm's two branches fired before the
-`finalizedCheckpoint` projection is taken; once decided, closing it is exactly
-`finalizedCheckpoint_of_justifiedCheckpoint_update`, again already covered by `simp`'s
-default record-projection reduction. -/
+the mirror of `updateCheckpoints_justifiedCheckpoint_eq_or_advances`. -/
 theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
       ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
         store.finalizedCheckpoint.epoch < f.epoch) := by
+  -- Decide both guards so `simp` can reduce the nested record updates
+  -- and project the checkpoint field unaffected by the other update.
   by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;>
     by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch
   · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h2⟩

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -1,30 +1,16 @@
 import EthCLSpecs.Gloas.ForkChoice
 
 /-!
-# `EthCLSpecs.Proofs.UpdateCheckpoints`: `updateCheckpoints` checkpoint monotonicity
+# `EthCLSpecs.Proofs.UpdateCheckpoints`: checkpoint monotonicity
 
-`EthCLSpecs.Gloas.updateCheckpoints` (`Gloas/ForkChoice.lean:470-472`) is the Store's
-checkpoint-advancement primitive: given a justified candidate `j` and a finalized
-candidate `f`, each of `store.justifiedCheckpoint` / `store.finalizedCheckpoint` is
-overwritten with its candidate exactly when the candidate's epoch is strictly greater,
-and left untouched otherwise. The current call sites, `on_block`'s post-state
-checkpoints, `compute_pulled_up_tip`'s pulled-up-state checkpoints, and
-`on_tick_per_slot`'s unrealized-checkpoint promotion, funnel through this one gate; the
-genesis/anchor Store construction (`get_forkchoice_store`) writes both fields directly
-instead, that's initialization, not an update, so it sits outside this claim, and
-outside anything this file proves. Therefore, each invocation of `updateCheckpoints`
+`EthCLSpecs.Gloas.updateCheckpoints` replaces the Store's justified and finalized
+checkpoints only when the corresponding candidate has a strictly greater epoch.
+This file characterizes both branches exactly and proves that each invocation
 preserves or advances both recorded epochs.
 
-The two guard conditions are read directly off the function body, so each result below
-is a direct consequence of the `if`, not an inherited precondition: the "exact
-characterization" theorems below (`_eq_or_advances`) restate the two-armed `if` as a
-disjunction with *both* arms carrying the guard that produced them, `j.epoch ≤
-store.justifiedCheckpoint.epoch` on the unchanged side, `store.justifiedCheckpoint.epoch
-< j.epoch` on the advancing side, so the disjunction is the `if`'s condition and its
-negation, not just its two possible outputs. The monotonicity theorems (`_epoch_le`) are
-the corollary a reader actually wants, "epochs never go backwards." Scoped to
-`EthCLSpecs.Gloas.updateCheckpoints` only. (The Fulu declaration of the same name is a
-separate `forkdef` in a different namespace, not covered here.)
+All current updates to these fields use this function; `getForkchoiceStore` initializes
+the fields directly and is outside this claim. The separate Fulu declaration is also
+out of scope.
 
 See `EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md`, "Monotonicity properties".
 -/
@@ -40,12 +26,8 @@ open EthCLLib.Spec (MapKind HasherTag)
 variable {map : MapKind} [Preset] [HasherTag]
   (store : Store map) (j f : Checkpoint)
 
-/-- The justified half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
-disjunction over the guard `j.epoch > store.justifiedCheckpoint.epoch` and its negation,
-not just over the two outputs: the unchanged arm additionally proves the guard *failed*
-(`j.epoch ≤ store.justifiedCheckpoint.epoch`), the advancing arm additionally proves it
-*fired* (`store.justifiedCheckpoint.epoch < j.epoch`). `UInt64.not_lt` turns the negated
-guard into that `≤`. -/
+/-- The resulting justified checkpoint is either unchanged because `j` is not newer,
+or exactly `j` because its epoch is strictly greater. -/
 theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
@@ -60,9 +42,8 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
   · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
   · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
 
-/-- The finalized half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
-disjunction over the guard `f.epoch > store.finalizedCheckpoint.epoch` and its negation,
-the mirror of `updateCheckpoints_justifiedCheckpoint_eq_or_advances`. -/
+/-- The resulting finalized checkpoint is either unchanged because `f` is not newer,
+or exactly `f` because its epoch is strictly greater. -/
 theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
@@ -77,19 +58,14 @@ theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
   · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
   · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
 
-/-- Monotonicity, the property the proof candidates doc names: `updateCheckpoints`
-never lowers the Store's justified epoch. Either arm of
-`updateCheckpoints_justifiedCheckpoint_eq_or_advances` gives it, the unchanged arm by
-`UInt64.le_refl`, the advancing arm by `UInt64.le_of_lt` since its strict `<` is in
-particular a `≤`. -/
+/-- `updateCheckpoints` never lowers the Store's justified epoch. -/
 theorem updateCheckpoints_justifiedEpoch_le :
     store.justifiedCheckpoint.epoch ≤ (updateCheckpoints store j f).justifiedCheckpoint.epoch := by
   rcases updateCheckpoints_justifiedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
   · rw [h]; exact UInt64.le_refl _
   · rw [h]; exact UInt64.le_of_lt hlt
 
-/-- Monotonicity for the finalized epoch, the mirror of
-`updateCheckpoints_justifiedEpoch_le`. -/
+/-- `updateCheckpoints` never lowers the Store's finalized epoch. -/
 theorem updateCheckpoints_finalizedEpoch_le :
     store.finalizedCheckpoint.epoch ≤ (updateCheckpoints store j f).finalizedCheckpoint.epoch := by
   rcases updateCheckpoints_finalizedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -1,0 +1,138 @@
+import EthCLSpecs.Gloas.ForkChoice
+
+/-!
+# `EthCLSpecs.Proofs.UpdateCheckpoints`: `updateCheckpoints` checkpoint monotonicity
+
+`EthCLSpecs.Gloas.updateCheckpoints` (`Gloas/ForkChoice.lean:470-472`) is the Store's
+checkpoint-advancement primitive: given a justified candidate `j` and a finalized
+candidate `f`, each of `store.justifiedCheckpoint` / `store.finalizedCheckpoint` is
+overwritten with its candidate exactly when the candidate's epoch is strictly greater,
+and left untouched otherwise. The current call sites, `on_block`'s post-state
+checkpoints, `compute_pulled_up_tip`'s pulled-up-state checkpoints, and
+`on_tick_per_slot`'s unrealized-checkpoint promotion, funnel through this one gate; the
+genesis/anchor Store construction (`get_forkchoice_store`) writes both fields directly
+instead, that's initialization, not an update, so it sits outside this claim, and
+outside anything this file proves. Therefore, each invocation of `updateCheckpoints`
+preserves or advances both recorded epochs.
+
+The two guard conditions are read directly off the function body, so each result below
+is a direct consequence of the `if`, not an inherited precondition: the "exact
+characterization" theorems below (`_eq_or_advances`) restate the two-armed `if` as a
+disjunction with *both* arms carrying the guard that produced them, `j.epoch ≤
+store.justifiedCheckpoint.epoch` on the unchanged side, `store.justifiedCheckpoint.epoch
+< j.epoch` on the advancing side, so the disjunction is the `if`'s condition and its
+negation, not just its two possible outputs. The monotonicity theorems (`_epoch_le`) are
+the corollary a reader actually wants, "epochs never go backwards." Scoped to
+`EthCLSpecs.Gloas.updateCheckpoints` only; the Fulu declaration of the same name has an
+identical body but is a separate, unrelated `forkdef` in a different namespace, not
+covered here.
+
+See `EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md`, "Monotonicity properties".
+-/
+
+set_option autoImplicit false
+
+namespace EthCLSpecs.Proofs
+
+open EthCLSpecs.Gloas (Store updateCheckpoints Checkpoint)
+open EthCLSpecs.Fulu (Preset)
+open EthCLLib.Spec (MapKind HasherTag)
+
+variable {map : MapKind} [Preset] [HasherTag]
+  (store : Store map) (j f : Checkpoint)
+
+/-! ### Field independence
+
+`updateCheckpoints`' two `if`s each write one field of the `Store`; the "each checkpoint
+either remains unchanged or advances" reading of the function depends on those two
+writes not interfering, on the finalized `if` never touching `justifiedCheckpoint` and
+the justified `if` never touching `finalizedCheckpoint`. That's not an assumption about
+`updateCheckpoints`, it's a property of the `{ s with field := v }` update notation both
+`if`s use: the notation elaborates to a `Store.mk` application that substitutes the named
+field and copies every other field straight from `s`, so for two distinct field names
+the write and the read never alias. Recorded here as its own pair of `rfl` lemmas, true
+by that elaboration alone, no unfolding of `updateCheckpoints` and no guard decision
+needed, so the independence is confirmed as a standalone, citable fact rather than left
+implicit in whatever `simp` happens to do inside the two theorems below. (`simp`'s own
+default reduction of a record update performs the identical step when closing those
+theorems' goals, which is *why* passing these lemmas to `simp` there is flagged
+"unused": the fact is already load-bearing in the kernel check, just not under this
+name.) -/
+
+/-- Setting `justifiedCheckpoint` leaves `finalizedCheckpoint` untouched. Not consumed by
+name anywhere (the two theorems below get the identical reduction for free from `simp`'s
+own record-projection handling once both guards are decided), `private` because its role
+is this file's own documentation, not public API. -/
+private theorem finalizedCheckpoint_of_justifiedCheckpoint_update :
+    ({ store with justifiedCheckpoint := j } : Store map).finalizedCheckpoint =
+      store.finalizedCheckpoint := rfl
+
+/-- The mirror: setting `finalizedCheckpoint` leaves `justifiedCheckpoint` untouched. -/
+private theorem justifiedCheckpoint_of_finalizedCheckpoint_update :
+    ({ store with finalizedCheckpoint := f } : Store map).justifiedCheckpoint =
+      store.justifiedCheckpoint := rfl
+
+/-- The justified half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
+disjunction over the guard `j.epoch > store.justifiedCheckpoint.epoch` and its negation,
+not just over the two outputs: the unchanged arm additionally proves the guard *failed*
+(`j.epoch ≤ store.justifiedCheckpoint.epoch`), the advancing arm additionally proves it
+*fired* (`store.justifiedCheckpoint.epoch < j.epoch`). `UInt64.not_lt` turns the negated
+guard into that `≤`. The `by_cases` on `h2` is there only because `simp` can't push a
+projection through an *undecided* `ite` (no generic `apply_ite`-style lemma is in scope
+here), once `h2` pins down which of the `f`-arm's two branches fired, closing the
+resulting concrete projection is exactly
+`justifiedCheckpoint_of_finalizedCheckpoint_update`, `simp`'s own default reduction of a
+record update already performs that same step, which is why the lemma is redundant to
+name explicitly in the `simp` set below, its content, not its citation, is what the
+`by_cases` is discharging. -/
+theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
+    ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
+        j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
+      ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
+        store.justifiedCheckpoint.epoch < j.epoch) := by
+  by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;>
+    by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch
+  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h1⟩
+  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h1⟩
+  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
+  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
+
+/-- The finalized half of `updateCheckpoints`' two-armed `if`, restated as an exhaustive
+disjunction over the guard `f.epoch > store.finalizedCheckpoint.epoch` and its negation,
+the mirror of `updateCheckpoints_justifiedCheckpoint_eq_or_advances`. Symmetrically, the
+`by_cases` on `h1` decides which of the `j`-arm's two branches fired before the
+`finalizedCheckpoint` projection is taken; once decided, closing it is exactly
+`finalizedCheckpoint_of_justifiedCheckpoint_update`, again already covered by `simp`'s
+default record-projection reduction. -/
+theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
+    ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
+        f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
+      ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
+        store.finalizedCheckpoint.epoch < f.epoch) := by
+  by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;>
+    by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch
+  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h2⟩
+  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h2⟩
+  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
+  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
+
+/-- Monotonicity, the property the proof candidates doc names: `updateCheckpoints`
+never lowers the Store's justified epoch. Either arm of
+`updateCheckpoints_justifiedCheckpoint_eq_or_advances` gives it, the unchanged arm by
+`UInt64.le_refl`, the advancing arm by `UInt64.le_of_lt` since its strict `<` is in
+particular a `≤`. -/
+theorem updateCheckpoints_justifiedEpoch_le :
+    store.justifiedCheckpoint.epoch ≤ (updateCheckpoints store j f).justifiedCheckpoint.epoch := by
+  rcases updateCheckpoints_justifiedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
+  · rw [h]; exact UInt64.le_refl _
+  · rw [h]; exact UInt64.le_of_lt hlt
+
+/-- Monotonicity for the finalized epoch, the mirror of
+`updateCheckpoints_justifiedEpoch_le`. -/
+theorem updateCheckpoints_finalizedEpoch_le :
+    store.finalizedCheckpoint.epoch ≤ (updateCheckpoints store j f).finalizedCheckpoint.epoch := by
+  rcases updateCheckpoints_finalizedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
+  · rw [h]; exact UInt64.le_refl _
+  · rw [h]; exact UInt64.le_of_lt hlt
+
+end EthCLSpecs.Proofs

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -33,12 +33,11 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances
         store.justifiedCheckpoint.epoch < j.epoch) := by
   -- Decide both guards so `simp` can reduce the nested record updates
   -- and project the checkpoint field unaffected by the other update.
-  by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;>
-    by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch
-  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h1⟩
-  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h1⟩
-  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
-  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h1⟩
+  by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch
+  · refine .inr ⟨?_, h1⟩
+    by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
+  · refine .inl ⟨?_, UInt64.not_lt.mp h1⟩
+    by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
 
 /-- The resulting finalized checkpoint is either unchanged because `f` is not newer,
 or exactly `f` because its epoch is strictly greater. -/
@@ -50,12 +49,11 @@ theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances
         store.finalizedCheckpoint.epoch < f.epoch) := by
   -- Decide both guards so `simp` can reduce the nested record updates
   -- and project the checkpoint field unaffected by the other update.
-  by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;>
-    by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch
-  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h2⟩
-  · exact .inr ⟨by simp [updateCheckpoints, h1, h2], h2⟩
-  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
-  · exact .inl ⟨by simp [updateCheckpoints, h1, h2], UInt64.not_lt.mp h2⟩
+  by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch
+  · refine .inr ⟨?_, h2⟩
+    by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
+  · refine .inl ⟨?_, UInt64.not_lt.mp h2⟩
+    by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
 
 /-- `updateCheckpoints` never lowers the Store's justified epoch. -/
 theorem updateCheckpoints_justifiedEpoch_le

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -18,6 +18,19 @@ subjects of the sibling proof modules these theorem names would collide with a F
 companion. They live in `EthCLSpecs.Proofs.Gloas`, mirroring the `EthCLSpecs.Gloas`
 namespace the subject itself sits in, leaving `EthCLSpecs.Proofs.Fulu` free.
 
+## The shared proof shape
+
+Every proof here decides both of the definition's guards with `by_cases`, then lets
+`simp` reduce the resulting nested record updates. The second guard is load-bearing
+even where the statement never mentions it: the definition's outer `if` tests the
+finalized epoch of the store the *inner* `if` already produced, so `simp` cannot
+project either checkpoint field until both branches are settled. Dropping either
+`by_cases` leaves unsolved goals.
+
+`split` looks like the shorter route and is not available. `forkdef` elaborates
+the definition's `let` into `have store := ...`, which `split` refuses to see
+through ("Could not split an `if` or `match` expression in the goal").
+
 See `EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md`, "Monotonicity properties".
 -/
 
@@ -61,8 +74,6 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
         store.justifiedCheckpoint.epoch < j.epoch) := by
-  -- Decide both guards so `simp` can reduce the nested record updates
-  -- and project the checkpoint field unaffected by the other update.
   by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch
   · refine .inr ⟨?_, h1⟩
     by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
@@ -76,8 +87,6 @@ theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
         store.finalizedCheckpoint.epoch < f.epoch) := by
-  -- Decide both guards so `simp` can reduce the nested record updates
-  -- and project the checkpoint field unaffected by the other update.
   by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch
   · refine .inr ⟨?_, h2⟩
     by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -12,12 +12,17 @@ All current updates to these fields use this function; `getForkchoiceStore` init
 the fields directly and is outside this claim. The separate Fulu declaration is also
 out of scope.
 
+`updateCheckpoints` is declared identically in both forks, so unlike the Gloas-only
+subjects of the sibling proof modules these theorem names would collide with a Fulu
+companion. They live in `EthCLSpecs.Proofs.Gloas`, mirroring the `EthCLSpecs.Gloas`
+namespace the subject itself sits in, leaving `EthCLSpecs.Proofs.Fulu` free.
+
 See `EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md`, "Monotonicity properties".
 -/
 
 set_option autoImplicit false
 
-namespace EthCLSpecs.Proofs
+namespace EthCLSpecs.Proofs.Gloas
 
 open EthCLSpecs.Gloas (Store updateCheckpoints Checkpoint)
 open EthCLSpecs.Fulu (Preset)
@@ -71,4 +76,4 @@ theorem updateCheckpoints_finalizedEpoch_le
   · rw [h]; exact UInt64.le_refl _
   · rw [h]; exact UInt64.le_of_lt hlt
 
-end EthCLSpecs.Proofs
+end EthCLSpecs.Proofs.Gloas

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -29,6 +29,12 @@ open EthCLSpecs.Gloas (Store updateCheckpoints Checkpoint)
 open EthCLSpecs.Fulu (Preset)
 open EthCLLib.Spec (MapKind HasherTag)
 
+/-! Every theorem below is stated about one arbitrary Store and one arbitrary pair of
+candidate checkpoints, under the `[Preset]` / `[HasherTag]` the `Store` forkstruct binds.
+Lean includes each of these in a signature only when the statement mentions it, and all
+five statements mention all five. -/
+variable {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint)
+
 /-- `updateCheckpoints` rewritten as a single record update: each checkpoint field
 takes its candidate exactly when that candidate's epoch is strictly greater, and
 every other field of the Store is carried through untouched.
@@ -37,8 +43,7 @@ This is the frame condition the two branch characterizations below do not carry.
 They project one field each, so on their own they leave open whether the function
 also disturbs `time`, `equivocatingIndices`, or any of the maps. A caller
 threading a Store through a fork-choice transition needs to know it does not. -/
-theorem updateCheckpoints_eq
-    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+theorem updateCheckpoints_eq :
     updateCheckpoints store j f =
       { store with
         justifiedCheckpoint :=
@@ -51,8 +56,7 @@ theorem updateCheckpoints_eq
 
 /-- The resulting justified checkpoint is either unchanged because `j` is not newer,
 or exactly `j` because its epoch is strictly greater. -/
-theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances
-    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).justifiedCheckpoint = store.justifiedCheckpoint ∧
         j.epoch ≤ store.justifiedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).justifiedCheckpoint = j ∧
@@ -67,8 +71,7 @@ theorem updateCheckpoints_justifiedCheckpoint_eq_or_advances
 
 /-- The resulting finalized checkpoint is either unchanged because `f` is not newer,
 or exactly `f` because its epoch is strictly greater. -/
-theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances
-    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances :
     ((updateCheckpoints store j f).finalizedCheckpoint = store.finalizedCheckpoint ∧
         f.epoch ≤ store.finalizedCheckpoint.epoch) ∨
     ((updateCheckpoints store j f).finalizedCheckpoint = f ∧
@@ -82,16 +85,14 @@ theorem updateCheckpoints_finalizedCheckpoint_eq_or_advances
     by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;> simp [updateCheckpoints, h1, h2]
 
 /-- `updateCheckpoints` never lowers the Store's justified epoch. -/
-theorem updateCheckpoints_justifiedEpoch_le
-    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+theorem updateCheckpoints_justifiedEpoch_le :
     store.justifiedCheckpoint.epoch ≤ (updateCheckpoints store j f).justifiedCheckpoint.epoch := by
   rcases updateCheckpoints_justifiedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
   · rw [h]; exact UInt64.le_refl _
   · rw [h]; exact UInt64.le_of_lt hlt
 
 /-- `updateCheckpoints` never lowers the Store's finalized epoch. -/
-theorem updateCheckpoints_finalizedEpoch_le
-    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+theorem updateCheckpoints_finalizedEpoch_le :
     store.finalizedCheckpoint.epoch ≤ (updateCheckpoints store j f).finalizedCheckpoint.epoch := by
   rcases updateCheckpoints_finalizedCheckpoint_eq_or_advances store j f with ⟨h, _⟩ | ⟨h, hlt⟩
   · rw [h]; exact UInt64.le_refl _

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -5,8 +5,9 @@ import EthCLSpecs.Gloas.ForkChoice
 
 `EthCLSpecs.Gloas.updateCheckpoints` replaces the Store's justified and finalized
 checkpoints only when the corresponding candidate has a strictly greater epoch.
-This file characterizes both branches exactly and proves that each invocation
-preserves or advances both recorded epochs.
+This file pins the whole result down as one record update, characterizes each
+checkpoint's two branches, and proves that every invocation preserves or advances
+both recorded epochs.
 
 All current updates to these fields use this function; `getForkchoiceStore` initializes
 the fields directly and is outside this claim. The separate Fulu declaration is also
@@ -27,6 +28,26 @@ namespace EthCLSpecs.Proofs.Gloas
 open EthCLSpecs.Gloas (Store updateCheckpoints Checkpoint)
 open EthCLSpecs.Fulu (Preset)
 open EthCLLib.Spec (MapKind HasherTag)
+
+/-- `updateCheckpoints` rewritten as a single record update: each checkpoint field
+takes its candidate exactly when that candidate's epoch is strictly greater, and
+every other field of the Store is carried through untouched.
+
+This is the frame condition the two branch characterizations below do not carry.
+They project one field each, so on their own they leave open whether the function
+also disturbs `time`, `equivocatingIndices`, or any of the maps. A caller
+threading a Store through a fork-choice transition needs to know it does not. -/
+theorem updateCheckpoints_eq
+    {map : MapKind} [Preset] [HasherTag] (store : Store map) (j f : Checkpoint) :
+    updateCheckpoints store j f =
+      { store with
+        justifiedCheckpoint :=
+          if j.epoch > store.justifiedCheckpoint.epoch then j else store.justifiedCheckpoint,
+        finalizedCheckpoint :=
+          if f.epoch > store.finalizedCheckpoint.epoch then f else store.finalizedCheckpoint } := by
+  by_cases h1 : j.epoch > store.justifiedCheckpoint.epoch <;>
+    by_cases h2 : f.epoch > store.finalizedCheckpoint.epoch <;>
+      simp [updateCheckpoints, h1, h2]
 
 /-- The resulting justified checkpoint is either unchanged because `j` is not newer,
 or exactly `j` because its epoch is strictly greater. -/

--- a/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
+++ b/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
@@ -72,7 +72,7 @@ never decreasing, never shrinking, never losing a previously-added element.
 | -------------------- | ------------------------------- | ------------------------------------------------------------ |
 | `getWeight`          | `Gloas/ForkChoice.lean:359-369` | Weight only grows as more attestations accumulate for a node |
 | `onAttesterSlashing` | `Gloas/ForkChoice.lean:791-801` | The set of equivocating indices only grows, never shrinks    |
-| `updateCheckpoints`  | `Gloas/ForkChoice.lean:470-472` | Justified/finalized epochs never decrease                    |
+| `updateCheckpoints`  | `Gloas/ForkChoice.lean:470-472` | **In review**, see `EthCLSpecs/Proofs/UpdateCheckpoints.lean`. Each justified/finalized checkpoint either remains unchanged or advances to its candidate, so its epoch never decreases. |
 
 ---
 

--- a/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
+++ b/packages/EthCLSpecs/docs/CONSENSUS_PROOF_CANDIDATES.md
@@ -10,6 +10,9 @@ the fork's surface area, just the functions with a clear invariant, safety prope
 Gloas introduces 62 new functions and overrides 46 inherited ones. The candidates below were identified by reading across the Gloas specification and supporting libraries, focusing on functions with clear correctness properties, safety invariants, algebraic laws, monotonicity properties, and other proof-worthy invariants. The list is not exhaustive.
 
 The sections below group candidates by the kind of theorem they naturally suggest.
+A candidate carries no marker until it is discharged, at which point its row reads
+**Proved** and names the module holding the theorems. There is no intermediate state:
+a proof in flight is tracked by its pull request, and the row flips when that merges.
 
 ---
 
@@ -21,7 +24,7 @@ under a stated precondition.
 
 | Function                              | Location                    | Rationale                                                                                                                                                                                                                                                                                  |
 | ------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `convertBuilderIndexToValidatorIndex` | `Gloas/Operations.lean:415` | **In review**, see `EthCLSpecs/Proofs/BuilderIndex.lean`. Round-trips with `toBuilderIndex` on any `bi` that does not already carry the `BUILDER_INDEX_FLAG` bit, since `toBuilderIndex` always clears that bit, the round trip holds only under that precondition, not as a free identity |
+| `convertBuilderIndexToValidatorIndex` | `Gloas/Operations.lean:415` | **Proved**, see `EthCLSpecs/Proofs/BuilderIndex.lean`. Round-trips with `toBuilderIndex` on any `bi` that does not already carry the `BUILDER_INDEX_FLAG` bit, since `toBuilderIndex` always clears that bit, the round trip holds only under that precondition, not as a free identity. |
 
 ---
 
@@ -72,7 +75,7 @@ never decreasing, never shrinking, never losing a previously-added element.
 | -------------------- | ------------------------------- | ------------------------------------------------------------ |
 | `getWeight`          | `Gloas/ForkChoice.lean:359-369` | Weight only grows as more attestations accumulate for a node |
 | `onAttesterSlashing` | `Gloas/ForkChoice.lean:791-801` | The set of equivocating indices only grows, never shrinks    |
-| `updateCheckpoints`  | `Gloas/ForkChoice.lean:470-472` | **In review**, see `EthCLSpecs/Proofs/UpdateCheckpoints.lean`. Each justified/finalized checkpoint either remains unchanged or advances to its candidate, so its epoch never decreases. |
+| `updateCheckpoints`  | `Gloas/ForkChoice.lean:470-472` | **Proved**, see `EthCLSpecs/Proofs/UpdateCheckpoints.lean`. Each justified/finalized checkpoint either remains unchanged or advances to its candidate, so its epoch never decreases, and no other Store field moves. |
 
 ---
 
@@ -114,7 +117,7 @@ incidental, it's what the function does.
 | --------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `upgradeToGloas`      | `Gloas/Upgrade.lean:101-156` | Preserves inherited state while correctly initializing the new ePBS state                                                                                            |
 | `computePtcFromFulu`  | `Gloas/Upgrade.lean:35-43`   | Agrees with `Gloas.computePtc` once the state is upgraded                                                                                                            |
-| `initializePtcWindow` | `Gloas/Upgrade.lean:50-60`   | **In review**, see `EthCLSpecs/Proofs/InitializePtcWindow.lean`. The first `SLOTS_PER_EPOCH` entries are the empty committee, and every remaining entry equals `computePtcFromFulu` at the slot computed by `initializePtcWindow` |
+| `initializePtcWindow` | `Gloas/Upgrade.lean:50-60`   | **Proved**, see `EthCLSpecs/Proofs/InitializePtcWindow.lean`. The first `SLOTS_PER_EPOCH` entries are the empty committee, and every remaining entry equals `computePtcFromFulu` at the slot computed by `initializePtcWindow`. |
 
 ---
 

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -626,4 +626,9 @@ separation.
   placeholder and the remainder computed via `computePtcFromFulu`), plus a
   `default` corollary for the first region.
 
+- **`Proofs/UpdateCheckpoints.lean`** establishes exact unchanged-or-advances
+  characterizations for Gloas's justified and finalized checkpoints, with
+  monotonicity corollaries proving that neither recorded epoch decreases.
+  The proofs use ordinary case analysis and core `UInt64` ordering lemmas.
+
 - **`CONSENSUS_PROOF_CANDIDATES.md`** tracks candidate consensus proof targets.

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -626,9 +626,12 @@ separation.
   placeholder and the remainder computed via `computePtcFromFulu`), plus a
   `default` corollary for the first region.
 
-- **`Proofs/UpdateCheckpoints.lean`** establishes exact unchanged-or-advances
-  characterizations for Gloas's justified and finalized checkpoints, with
-  monotonicity corollaries proving that neither recorded epoch decreases.
-  The proofs use ordinary case analysis and core `UInt64` ordering lemmas.
+- **`Proofs/UpdateCheckpoints.lean`** rewrites Gloas's `updateCheckpoints` as a
+  single record update, which doubles as the frame condition that no other Store
+  field moves. On top of it sit unchanged-or-advances characterizations for the
+  justified and finalized checkpoints, plus monotonicity corollaries proving that
+  neither recorded epoch decreases. The proofs use ordinary case analysis and
+  core `UInt64` ordering lemmas. Their theorems live in `EthCLSpecs.Proofs.Gloas`
+  rather than the flat `EthCLSpecs.Proofs`, since Fulu declares the same function.
 
 - **`CONSENSUS_PROOF_CANDIDATES.md`** tracks candidate consensus proof targets.


### PR DESCRIPTION
## Summary

Adds `EthCLSpecs/Proofs/UpdateCheckpoints.lean`, proving monotonicity for
`EthCLSpecs.Gloas.updateCheckpoints`:

- Each justified/finalized checkpoint either remains unchanged when its
  candidate is not newer, or becomes exactly the candidate when its epoch is
  strictly greater. Both outcomes include the guard condition that selected them.
- Two corollaries prove that `updateCheckpoints` never lowers either recorded epoch.
- The proof is scoped to the Gloas declaration. Fulu's separate declaration is
  out of scope.

## Supporting Changes

- Marks `updateCheckpoints` **In review** in
  `CONSENSUS_PROOF_CANDIDATES.md`.
- Adds the proof module to `IMPLEMENTATION_NOTES.md`.
- Updates `Proofs.lean`'s module documentation to include ordinary case analysis.

## Notes for Reviewers

- This PR proves monotonicity for each invocation of `updateCheckpoints`; it
  does not establish a protocol-wide invariant over arbitrary fork-choice
  transition histories. Such a theorem would additionally need to cover Store
  initialization and every path that can write either checkpoint field.
- `getForkchoiceStore` writes both fields during genesis/anchor initialization
  and is outside this claim.
- The proofs use `by_cases`, `simp`, and core `UInt64` ordering lemmas. They
  introduce no mathlib dependency, decision procedure, `sorry`, or new axiom.
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound`.

## Test Plan

- [x] `lake build`
- [x] `lake build EthCLSpecs.Proofs.UpdateCheckpoints`
- [x] `just ethcl-test`
- [x] `just lint`