### PR TITLE
docs: add Fulu and Heze proof candidates to the ledger

### DIFF
--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -67,6 +67,15 @@ included, so a proof about `EthCLSpecs.Gloas.f` says nothing about
 kind of theorem they ask for within a fork, since the kind is what tells an
 author how to state it. `EthCLSpecs/Proofs/` splits per fork the same way.
 
+## Dependencies between rows
+
+Three claims rest on another row:
+
+- The committee partition rests on the shuffle bijection.
+- Plausible liveness rests on accountable safety.
+- Both `processDeposit` rows rest on the Merkle branch check that
+  [`../../SizzLean/docs/PLAN.md`](../../SizzLean/docs/PLAN.md) Phase 5 tracks.
+
 ---
 
 ## Gloas
@@ -170,6 +179,15 @@ Functions where the useful theorem hasn't been identified yet, either because th
 
 ## Fulu
 
+### Round-trip and conversion properties
+
+Functions whose natural theorem is an inverse relationship with another Fulu function, applying one after the other returns the original value, at least under a stated precondition.
+
+| Function | Location | Property | Status | Tracking |
+| --- | --- | --- | --- | --- |
+| `computeEpochAtSlot` | `Fulu/Time.lean:29` | `computeEpochAtSlot (computeStartSlotAtEpoch e) = e`, for `e < 2^59`. The raw `UInt64` multiply wraps above `2^59`, so the identity needs that bound | proposed |  |
+| `computeStartSlotAtEpoch` | `Fulu/Time.lean:32` | The same identity, seen from this side. The round trip is the row above | proposed |  |
+
 ### Bounds and termination properties
 
 Functions where the theorem is a numeric bound, no overflow, no underflow, never exceeding a spec constant, or a termination bound, a fuel parameter large enough for a bounded walk to finish.
@@ -177,6 +195,43 @@ Functions where the theorem is a numeric bound, no overflow, no underflow, never
 | Function | Location | Property | Status | Tracking |
 | --- | --- | --- | --- | --- |
 | `reserveChurn` | `Fulu/RegistryUpdates.lean:69-74` | Arithmetic never underflows | proposed |  |
+| `increaseBalance` | `Fulu/Balances.lean:29` | The balance addition never wraps | proposed |  |
+| `processDeposit` | `Fulu/Operations.lean:223` | Neither the incremented deposit index nor the running total balance exceeds `2^64`. Dafny stated both bounds and assumed them through `{:axiom}` lemmas, so Dafny's statements are reusable as a template. Its proofs are not. A sharper bound is open as well. The branch check needs `eth1DepositIndex < 2^32`, which follows from `eth1DepositIndex <= eth1Data.depositCount` together with a bound on `depositCount`. The consensus spec does not bound `depositCount`, since that count arrives from the execution layer. Any statement here is therefore conditional on the deposit contract's depth-32 capacity | proposed |  |
+| `processRegistryUpdates` | `Fulu/EpochProcessing.lean:174` | The registry never exceeds `VALIDATOR_REGISTRY_LIMIT` | proposed |  |
+| `getBeaconCommittee` | `Fulu/Committees.lean:83` | An active-validator count in `[32, 2^22]` implies every committee size is in `(0, MAX_VALIDATORS_PER_COMMITTEE]`. Dafny proves the same bound in `ActiveValidatorBounds` | proposed |  |
+| `computeBalanceWeightedSelection` | `Fulu/Committees.lean:118` | Its `cbwsAux` sampler loop takes `10000000` fuel, which always suffices for the walk to finish | proposed |  |
+
+### Safety and invariant preservation
+
+Functions with a specific invariant, precondition bundle, or side-effect guarantee that should hold whenever the function runs: exactly-once behavior, mutual exclusion between cases, or a value staying untouched under some condition.
+
+| Function | Location | Property | Status | Tracking |
+| --- | --- | --- | --- | --- |
+| `computeShuffledPermutation` | `Fulu/Committees.lean:32` | A bijection on `[0, indexCount)`. No prior art: Dafny stubbed shuffling to the identity, and Runtime Verification did not prove it either | proposed |  |
+| `getBeaconCommittee` | `Fulu/Committees.lean:83` | The committees for a slot partition the active set: their union is the active validator set and they are pairwise disjoint. This follows from the shuffle bijection. The committee-size bound is the separate row under Bounds and termination properties | proposed |  |
+| `processDeposit` | `Fulu/Operations.lean:223` | `validators.size = balances.size` holds at the append site, and then holds across the transition. The two overflow bounds are the separate row under Bounds and termination properties | proposed |  |
+| `isSlashableAttestationData` | `Fulu/Operations.lean:38` | Agrees with the spec's slashability condition, a double vote or a surround vote, given the `strictlySorted` well-formedness the caller establishes | proposed |  |
+| `processRegistryUpdates` | `Fulu/EpochProcessing.lean:174` | One third of a joint claim with `initiateValidatorExit` and `computeExitEpochAndUpdateChurn`: a validator flows from active to exited at most once, and the churn consumed in an epoch never exceeds the churn limit | proposed |  |
+| `initiateValidatorExit` | `Fulu/RegistryUpdates.lean:112` | One third of a joint claim with `processRegistryUpdates` and `computeExitEpochAndUpdateChurn`: a validator flows from active to exited at most once, and the churn consumed in an epoch never exceeds the churn limit | proposed |  |
+| `computeExitEpochAndUpdateChurn` | `Fulu/RegistryUpdates.lean:78` | One third of a joint claim with `processRegistryUpdates` and `initiateValidatorExit`: a validator flows from active to exited at most once, and the churn consumed in an epoch never exceeds the churn limit | proposed |  |
+
+### State-transition correctness
+
+The block/slot/epoch-processing spine itself: the composition of the individual processing steps into the top-level state transition, and the properties that hold as a direct consequence of running through it.
+
+| Function | Location | Property | Status | Tracking |
+| --- | --- | --- | --- | --- |
+| `processJustificationAndFinalization` | `Fulu/EpochProcessing.lean:78` | Casper FFG accountable safety: conflicting finalized and justified checkpoints imply that at least `1/3` of the stake is slashable. Needs an abstract FFG layer over the epoch-processing functions and a refinement back to them. Plausible liveness, that finalization stays possible with `>= 2/3` honest, comes after accountable safety and reuses that model. Apalache bounded-model-checked the 3SF form of the property (Konnov et al. 2025), so the result is checked up to a bound and remains unproved | proposed |  |
+
+### Fork-choice correctness
+
+Properties specific to the fork-choice store and the LMD-GHOST tree: agreement between two ways of computing the same relation, preconditions gating block/attestation acceptance, and correctness of the store's own bookkeeping.
+
+| Function | Location | Property | Status | Tracking |
+| --- | --- | --- | --- | --- |
+| `getAncestor` | `Fulu/ForkChoice.lean:136` | One third of a joint claim with `getHead` and `onBlock`: a valid store is a chain, ancestry is slot-monotone, and an accepted block stays accepted. Dafny proves the chain and slot-monotone parts as `aValidStoreIsAChain` | proposed |  |
+| `getHead` | `Fulu/ForkChoice.lean:261` | One third of a joint claim with `getAncestor` and `onBlock`: a valid store is a chain, ancestry is slot-monotone, and an accepted block stays accepted. Dafny proves the chain and slot-monotone parts as `aValidStoreIsAChain` | proposed |  |
+| `onBlock` | `Fulu/ForkChoice.lean:526` | One third of a joint claim with `getAncestor` and `getHead`: a valid store is a chain, ancestry is slot-monotone, and an accepted block stays accepted. Dafny proves the chain and slot-monotone parts as `aValidStoreIsAChain` | proposed |  |
 
 
 ---
@@ -197,6 +252,8 @@ Properties specific to the fork-choice store and the LMD-GHOST tree: agreement b
 | `shouldExtendPayload` | `Heze/ForkChoice.lean:320-342` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | in progress | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
 | `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-418` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
 | `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-448` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
+| `isPayloadInclusionListSatisfied` | `Heze/ForkChoice.lean:305` | EIP-7805 FOCIL: a payload is accepted only when it carries every transaction that a timely inclusion list requires | proposed |  |
+| `processInclusionList` | `Heze/ForkChoice.lean:170` | At most one stored list per validator per committee, asserted in its docstring and not proved. A conflicting second list leaves the stored list untouched and records the sender as an equivocator for that committee. The handler then ignores later lists from that validator on entry | proposed |  |
 
 ---
 
@@ -207,3 +264,21 @@ Properties specific to the fork-choice store and the LMD-GHOST tree: agreement b
 - [`SPECS_ARCHITECTURE.md`](SPECS_ARCHITECTURE.md) §11 — candidate theorems from the
   framework's own design docs, and the inheritance-replay proof-transfer question the
   `inherit`-adjacent entries above assume.
+- [`../../SizzLean/docs/PLAN.md`](../../SizzLean/docs/PLAN.md) Phase 5 — the SSZ-side
+  targets, which include the merkleization agreement. Any Merkle-proof consumer here
+  needs that agreement before a theorem about the cached tree says anything about a
+  spec root.
+- ConsenSys `eth2.0-dafny` (Phase 0, archived) — proved the state transition as
+  refinement, plus committee-size bounds and fork-choice store invariants. It stubbed
+  shuffling to the identity. It assumed the overflow bounds through `{:axiom}` lemmas
+  instead of proving them. Its Casper FFG accountable-safety result reached only an
+  unmerged branch, under a fixed validator set.
+- Runtime Verification — an executable K model of the Phase 0 transition,
+  conformance-tested rather than proved. A separate Coq development closed Gasper
+  accountable safety and plausible liveness, over an abstract model with dynamic
+  validator sets. It also proved the deposit contract's incremental Merkle root equal
+  to the naive full-tree root. It refined the KEVM bytecode against an untrusted
+  compiler, which found bugs. That incremental-tree result is the closest prior art to
+  the deposit branch check the `processDeposit` rows name.
+- Nyx Foundation `formal-leanSpec` — a parallel Lean 4 formalization of the
+  post-quantum leanSpec, with its own SSZ layer.

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1489,6 +1489,69 @@ corollary without rework. The README's
 [Proof coverage](../README.md#proof-coverage) section carries
 the per-constructor table users see.
 
+### Beyond the three central theorems
+
+Stage 18 covers serialization. Merkleization has no proved
+result yet.
+
+**Merkleization agreement.** Prove `Node.merkleRootWithCache`
+(`Cache/MerkleTree/Merkle.lean`) equal to `hashTreeRoot`
+(`Spec/HashTreeRoot.lean`). Stage 12 checks that the two agree on
+three fixtures by `native_decide`. There is no proof. Without
+one, a theorem about the cached tree's root says nothing about
+the root the spec computes.
+
+The spec merkleizer folds breadth-first with
+level-indexed zero padding while the cached builder splits
+depth-first, so the induction carries a level offset. It needs no
+depth bound beyond that. `zeroHashAt` memoises the first 100
+depths and runs the same `zeroHashRec` recurrence past them. The
+two towers therefore agree at every depth, including the
+cap-derived depths (`list`, `bitlist`) that reach furthest.
+
+Dafny left `hash()` uninterpreted and could only
+differential-test this property. `LeanSha256` and the named
+FFI-equivalence axioms under `Hasher/` make a proof against a
+concrete hash possible.
+
+**Zero tower, padding and chunking.** `zeroHashes`
+(`Cache/MerkleTree/Zero.lean`), `padToChunk`, `chunkDepth` and
+`mixInLength` (`Spec/HashTreeRoot.lean`). Padding and chunking
+are the structural difference between the two merkleizers, so
+these are steps inside the agreement proof. Dafny proved the equivalent
+chunk-count and length bookkeeping, which is the one part of
+merkleization it did reach.
+
+**Generalized-index library.** Decompose `getGeneralizedIndex`
+and `getSubtreeIndex` (`Spec/GeneralizedIndex.lean`) into the
+`(depth, index)` pair the merkleization theorems take. Every
+Merkle-proof consumer needs it. Light-client header branches
+address leaves by generalized index rather than raw tree
+position. The blob and data-column sidecar inclusion proofs do
+the same.
+`kzgCommitmentsInclusionProof`
+(`EthCLSpecs/Fulu/Blocks.lean:63`) is the sidecar case, not
+modeled yet. Deposits are the exception. Their index is a plain
+tree position.
+
+**Branch completeness.** Prove that `isValidMerkleBranch`
+(`EthCLLib/Spec/SigningRoot.lean:68`) accepts the honest opening
+of a SizzLean tree. Dafny never implemented the function, so
+there is no prior statement to reuse. `processDeposit` needs a
+mix-in-length variant. Stated general over depth, that variant
+also serves the sidecar proofs above.
+
+Two gaps separate that from the shipped call sites. Each call site
+checks a branch taken off the wire.
+`EthCLSpecs/Fulu/Operations.lean:225` checks it against the
+deposit contract's incremental tree, which is not an `ofShape`
+tree. The wire value therefore needs its own connection to the
+tree the theorem describes. The light-client sites call
+`is_valid_normalized_merkle_branch`, which pads a short branch
+with a zero prefix. `isValidMerkleBranch` rejects any branch
+whose length differs from the depth, so those openings need the
+normalized form modeled first.
+
 ---
 
 ## Cross-cutting concerns (apply to every stage)


### PR DESCRIPTION
## Summary

This PR adds proof targets to the two docs that carry them. #74 replaced
`CONSENSUS_PROOF_CANDIDATES.md` with `PROOF_LEDGER.md`, so the candidate rows
now use the ledger's five-column form. They sit in its per-fork sections.

## What changed

- `EthCLSpecs/docs/PROOF_LEDGER.md`: the Fulu section gains 15 rows across five
  subsections. The Heze section gains 2 rows for the EIP-7805 FOCIL surface.
  Every new row reads `proposed`. A new section, "Dependencies between rows",
  names the three claims that rest on another row. Related work gains four
  entries: ConsenSys `eth2.0-dafny`, Runtime Verification, Nyx
  `formal-leanSpec`, and SizzLean Phase 5.
- `SizzLean/docs/PLAN.md`: Phase 5 gains a "Beyond the three central theorems"
  section.

Two rows named several functions at once. Two more cited several line spans in
one cell. This PR splits both forms, one row per function and one span per row.
`check_citations.py` matches a single span per citation. The comma form
(`Fulu/Time.lean:25,28`) therefore matches nothing, and the checker skips it.

This PR drops the `EthCLSpecs/docs/README.md` change. Its only edit described
the deleted file. Main's replacement paragraphs already cover the ledger.

## Test plan

- [x] `just check-citations` resolves 66 citations in 5 files. Five spans had
      drifted since August 12. `--fix` rewrote them.
- [x] `just lint` is clean.

This PR changes docs only. No Lean source changed, so the build and suite rows
do not apply.

## Risk / trust footprint

None. This PR changes docs only.

## Notes for reviewers

The ledger names `is_valid_normalized_merkle_branch` and
`kzgCommitmentsInclusionProof` as unmodeled. Neither has a Lean declaration yet.

Every ported row reads `proposed`, the two Fulu time functions included. The
baseline does list `Fulu.computeStartSlotAtEpoch` at the touched tier. That mark
comes from `Proofs/Gloas/InitializePtcWindow.lean`, which opens the name. No
theorem yet states the round trip this row asks for.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
