### PR TITLE
feat(ethcllib): isValidMerkleBranch completeness over openable paths

### DIFF
--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -1,3 +1,4 @@
+import EthCLLib.Proofs.MerkleOpening
 import EthCLLib.Proofs.MerkleBranch
 
 /-!

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -1,4 +1,8 @@
 import EthCLLib.Spec.SigningRoot
+import EthCLLib.Proofs.MerkleOpening
+import SizzLean.Proofs.Perfect
+import SizzLean.Hasher.CombineWidth
+import SizzLean.Proofs.Util
 
 /-!
 # `EthCLLib.Proofs.MerkleBranch`: what `isValidMerkleBranch` accepts
@@ -9,9 +13,24 @@ import EthCLLib.Spec.SigningRoot
 Past the length guard, the check reduces to a plain fold of `branch` over `leaf`,
 compared to `root`.
 
+Open a tree at `index` with `honestLeaf` / `honestBranch`, and the check returns
+`true`. `IsOpenable` (`EthCLLib/Proofs/MerkleOpening.lean`) is the path-shaped
+hypothesis, and every `IsPerfect` tree satisfies it at every index
+(`isOpenable_of_isPerfect`).
+
+The theorems quantify over `Node.merkleRoot`, the tree's own root. The spec's
+callers pass a root from elsewhere: `process_deposit` reads
+`state.eth1_data.deposit_root`, and hands the check a wire-deserialised `Array`
+rather than a `Node`.
+
 Bit ordering: `branch` runs bottom-to-top and entry `i` is the level-`i` sibling.
 The routing convention lives in `EthCLLib.Spec.MerklePath`. The shipped check and
 this fold both call `routeRight`, so the two agree by definition.
+
+Under an abstract `[HasherTag]`, `isValidMerkleBranch_complete` and the two guard
+bridges apply as they stand. The results carrying `[CombineWidth32 HasherTag.H]`
+need `pureHasherTag` or `fastHasherTag`, since `HasherTag.H` is otherwise a stuck
+projection matching no instance.
 -/
 
 set_option autoImplicit false
@@ -19,6 +38,9 @@ set_option autoImplicit false
 namespace EthCLLib.Proofs
 
 open SizzLean
+open SizzLean.Hasher
+open SizzLean.Cache.MerkleTree
+open SizzLean.Proofs
 open EthCLLib.Spec
 
 /-! ### The proof-side fold
@@ -47,6 +69,19 @@ private theorem branchFold_succ [HasherTag] (leaf : ByteArray)
   unfold branchFold
   rw [List.range_succ, List.foldl_append]
   rfl
+
+/-- **Reads at or above `depth` cannot matter.** Two branches agreeing below
+`depth` drive the same walk. The induction step can therefore ignore the sibling
+`siblingPath` pushes on at the top. -/
+private theorem branchFold_congr [HasherTag] (leaf : ByteArray)
+    (b b' : Array (Vector UInt8 32)) (depth index : Nat)
+    (hagree : ∀ i, i < depth → b[i]! = b'[i]!) :
+    branchFold leaf b depth index = branchFold leaf b' depth index := by
+  induction depth with
+  | zero => rfl
+  | succ d ih =>
+      rw [branchFold_succ, branchFold_succ, ih (fun i hi => hagree i (by omega)),
+          hagree d (by omega)]
 
 /-- The checked fold itself, in range: every `branch[i]` read hits, so the
 `IndexError` arm never fires. The statement sits on the inner `foldlM`, since the
@@ -118,11 +153,150 @@ private theorem isValidMerkleBranch_iff [HasherTag] (leaf : Vector UInt8 32)
   rw [isValidMerkleBranch_eq_beq _ _ _ _ _ hsize]
   exact beq_iff_eq
 
+/-- **Core completeness.** Along an openable path into `n`, folding the extracted
+leaf and sibling path reconstructs the tree's root.
+
+The proof inducts on `IsOpenable`. Each pair case peels the top level with
+`branchFold_succ`. It then rewrites the lower `d` steps to ignore the pushed top
+sibling, through `branchFold_congr` against `getElem!_push_lt`, in range by
+`siblingPath_size`. It applies the sub-path IH, rewrites the cached sibling read
+back to `merkleRoot` (`rootOf_eq_merkleRoot`, which needs no hypothesis), and
+closes with `merkleRoot_pair`. Each constructor fixes its own bit, so neither
+case has to split.
+
+The base case is the `rootOf`/`merkleRoot` bridge: a zero-step fold returns the
+stop node's root unchanged.
+
+The siblings arrive root-typed, as `isValidMerkleBranch` takes them, and each
+`vecToBytes (bytesToRoot ·)` round-trips on the 32-byte widths `IsOpenable`
+carries. -/
+private theorem branchFold_eq_merkleRoot [HasherTag] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable HasherTag.H n depth index →
+      branchFold (leafAt HasherTag.H n depth index)
+          ((siblingPath HasherTag.H n depth index).map bytesToRoot) depth index
+        = Node.merkleRoot HasherTag.H n := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index =>
+      simpa [branchFold, leafAt_zero] using rootOf_eq_merkleRoot HasherTag.H m
+  | @left l r d index c hbit hl hr32 hc ihl =>
+      -- bit clear: our leaf sits in the LEFT subtree. The level-`d` sibling is
+      -- `r`'s root, mixed on the right (`combine acc sibling`).
+      -- The constructor and the fold both test `routeRight index d`, so `hbit`
+      -- discharges the openers and the fold together.
+      rw [branchFold_succ]
+      simp only [leafAt, siblingPath, hbit, Bool.false_eq_true, if_false]
+      have hsz : (siblingPath HasherTag.H l d index).size = d := siblingPath_size HasherTag.H hl
+      rw [branchFold_congr _ _ ((siblingPath HasherTag.H l d index).map bytesToRoot) d index
+            (fun i hi => by
+              rw [Array.map_push, getElem!_push_lt _ _ _
+                (by rw [Array.size_map, hsz]; exact hi)]),
+          ihl]
+      have htop := getElem!_push_size ((siblingPath HasherTag.H l d index).map bytesToRoot)
+        (bytesToRoot (Node.rootOf HasherTag.H r))
+      rw [Array.size_map, hsz] at htop
+      rw [Array.map_push, htop,
+        vecToBytes_bytesToRoot _ (by rw [rootOf_eq_merkleRoot]; exact hr32),
+        rootOf_eq_merkleRoot HasherTag.H r, merkleRoot_pair HasherTag.H hc]
+  | @right l r d index c hbit hr hl32 hc ihr =>
+      -- bit set: our leaf sits in the RIGHT subtree. The level-`d` sibling is
+      -- `l`'s root, mixed on the left (`combine sibling acc`).
+      rw [branchFold_succ]
+      simp only [leafAt, siblingPath, hbit, if_true]
+      have hsz : (siblingPath HasherTag.H r d index).size = d := siblingPath_size HasherTag.H hr
+      rw [branchFold_congr _ _ ((siblingPath HasherTag.H r d index).map bytesToRoot) d index
+            (fun i hi => by
+              rw [Array.map_push, getElem!_push_lt _ _ _
+                (by rw [Array.size_map, hsz]; exact hi)]),
+          ihr]
+      have htop := getElem!_push_size ((siblingPath HasherTag.H r d index).map bytesToRoot)
+        (bytesToRoot (Node.rootOf HasherTag.H l))
+      rw [Array.size_map, hsz] at htop
+      rw [Array.map_push, htop,
+        vecToBytes_bytesToRoot _ (by rw [rootOf_eq_merkleRoot]; exact hl32),
+        rootOf_eq_merkleRoot HasherTag.H l, merkleRoot_pair HasherTag.H hc]
+
+/-- Sanity: at depth 1, the honest leaf of the left branch (bit 0 clear) is the
+left leaf's bytes, root-typed. The path stops on a leaf, so `leafAt` reads its
+bytes back without hashing.
+
+`Node.rootOf` is `@[irreducible]`, so this enters its leaf arm by the named
+equation lemma rather than by `rfl`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    honestLeaf Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0 = bytesToRoot z := by
+  simp [honestLeaf, leafAt, Node.rootOf_leaf, routeRight]
+
 /-- Root-typing a sibling array preserves its length. Named so the statement
 below can cite it, rather than carrying `(by rw [Array.size_map]; exact hsize)`
 inline where a reader expects a term. -/
 theorem size_map_bytesToRoot {sibs : Array ByteArray} {depth : Nat}
     (hsize : sibs.size = depth) : (sibs.map bytesToRoot).size = depth := by
   rw [Array.size_map]; exact hsize
+
+/-- **Completeness (acceptance #2).** Any openable path makes
+`isValidMerkleBranch` accept its honest opening at `index` (`honestLeaf` and
+`honestBranch`).
+
+`IsOpenable` records the sibling widths itself, so this statement needs no
+`CombineWidth32` instance. The check runs under the ambient `[HasherTag]`, and
+the walk uses the same `HasherTag.H`, so both sides hash identically. -/
+theorem isValidMerkleBranch_complete [HasherTag]
+    {n : Node} {depth index : Nat} (ho : IsOpenable HasherTag.H n depth index) :
+    isValidMerkleBranch (honestLeaf HasherTag.H n depth index)
+        (honestBranch HasherTag.H n depth index)
+        depth index (bytesToRoot (Node.merkleRoot HasherTag.H n))
+      = true := by
+  simp only [honestLeaf, honestBranch]
+  have hleaf : (leafAt HasherTag.H n depth index).size = 32 := leafAt_size HasherTag.H ho
+  -- the honest branch has size `depth`, so the shipped check's length guard passes
+  have hsize :
+      ((siblingPath HasherTag.H n depth index).map bytesToRoot).size = depth :=
+    size_map_bytesToRoot (siblingPath_size HasherTag.H ho)
+  rw [isValidMerkleBranch_iff _ _ _ _ _ hsize,
+    vecToBytes_bytesToRoot _ hleaf, branchFold_eq_merkleRoot ho]
+
+/-- Completeness on a perfect tree at any index, through `isOpenable_of_isPerfect`. The
+`[CombineWidth32]` instance carries the 32-byte `combine` contract. The whole-tree
+hypothesis needs that contract to know the width of every sibling root.
+
+**Axiom use**: resolution at `Sha256` picks the instance proved from
+`sha256Combine_eq_spec`, so an FFI instantiation inherits that axiom silently.
+`Sha256Spec` resolves axiom-free. -/
+theorem isValidMerkleBranch_complete_perfect [HasherTag] [CombineWidth32 HasherTag.H]
+    {n : Node} {depth : Nat} (hp : IsPerfect HasherTag.H n depth) (index : Nat) :
+    isValidMerkleBranch (honestLeaf HasherTag.H n depth index)
+        (honestBranch HasherTag.H n depth index)
+        depth index (bytesToRoot (Node.merkleRoot HasherTag.H n))
+      = true :=
+  isValidMerkleBranch_complete (isOpenable_of_isPerfect hp index)
+
+/-- Completeness specialised to the pure-Lean `Sha256Spec` hasher, whose
+`CombineWidth32` instance (built from `sha256Spec_combine_size`,
+`SizzLean/Hasher/CombineWidth.lean`) supplies the size fact. -/
+theorem isValidMerkleBranch_complete_sha256Spec
+    {n : Node} {depth : Nat} (hp : IsPerfect Sha256Spec n depth) (index : Nat) :
+    @isValidMerkleBranch pureHasherTag (honestLeaf Sha256Spec n depth index)
+        (honestBranch Sha256Spec n depth index)
+        depth index (bytesToRoot (Node.merkleRoot Sha256Spec n))
+      = true := by
+  haveI : CombineWidth32 pureHasherTag.H := inferInstanceAs (CombineWidth32 Sha256Spec)
+  exact @isValidMerkleBranch_complete_perfect pureHasherTag _ n depth hp index
+
+/-- Worked completeness: a concrete depth-1 `combine`-tree of two 32-byte leaves.
+Feeding the honest opening of the left leaf makes the pure-`Sha256Spec` check
+accept, discharged straight from `isValidMerkleBranch_complete_sha256Spec`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    @isValidMerkleBranch pureHasherTag
+        (honestLeaf Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0)
+        (honestBranch Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0)
+        1 0
+        (bytesToRoot (Node.merkleRoot Sha256Spec (.pair (.leaf z) (.leaf o) none)))
+      = true := by
+  exact isValidMerkleBranch_complete_sha256Spec
+    (.pair (.leaf _ (by rfl)) (.leaf _ (by rfl)) (by simp)) 0
 
 end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
@@ -1,0 +1,265 @@
+import EthCLLib.Spec.Arith
+import EthCLLib.Spec.MerklePath
+import SizzLean.Proofs.Perfect
+import SizzLean.Proofs.Util
+
+/-!
+# `EthCLLib.Proofs.MerkleOpening`: openable paths and honest Merkle openings
+
+The path vocabulary the completeness proof quantifies over, and the openers that
+produce a witness for it.
+
+`IsOpenable` is the central predicate: a root-to-leaf path witness at one index,
+which is all a completeness proof ever walks. See its declaration docstring for
+the per-level obligations. `leafAt` and `siblingPath` extract the honest opening,
+and `honestLeaf` / `honestBranch` are their root-typed sugar. `isOpenable_of_isPerfect`
+injects every `IsPerfect` tree from SizzLean into the predicate.
+
+All of it routes by `EthCLLib.Spec.routeRight`, the same bit the shipped check
+folds on. That convention belongs to `is_valid_merkle_branch`, a consensus-spec
+function. The whole opening half therefore sits framework-side, and SizzLean
+keeps only shape and width (`SizzLean.Proofs.Perfect`).
+
+Both openers fall through silently on a shape mismatch. A caller therefore relies
+on holding an `IsOpenable` witness, and not on the openers rejecting bad input.
+
+`rootOf_eq_merkleRoot` licenses reading `siblingPath`'s cache reads as the honest
+`Node.merkleRoot`, unconditionally. `merkleRoot_pair` is the single bridge that
+collapses the cached and uncached readings of `Node.merkleRoot`.
+
+The completeness proof (`Proofs/MerkleBranch.lean`) and the computational
+witnesses (`Tests/MerkleWitness.lean`) both open a tree through this module. The
+tested expressions and the proved ones therefore stay the same.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Proofs
+
+open SizzLean SizzLean.Hasher SizzLean.Cache.MerkleTree EthCLLib.Spec
+open SizzLean.Proofs
+
+/-! ### The path predicate -/
+
+/-- A root-to-leaf *path* witness for `Node` at `index`: the spine the honest
+opening walks. Where `IsPerfect` constrains the whole tree, `IsOpenable`
+constrains only the followed child at each level. For the off-path sibling it
+records the two facts completeness consumes, a 32-byte root and cache validity
+at this level. `hc` says nothing about caches *inside* the sibling subtrees. An
+`IsOpenable` tree may therefore carry poisoned ones, and completeness then proves
+acceptance against that tree's own `merkleRoot`. Every `IsPerfect` tree is
+`IsOpenable` at every index (`isOpenable_of_isPerfect`).
+
+The base case stops at *any* node whose root is 32 bytes, not only a `.leaf`.
+A path can therefore end on a subtree. That is what SSZ means by the leaf at a
+generalized index, since `hash_tree_root` of a composite field is a subtree root.
+`Node.rootOf (.leaf b) = b` definitionally, so a leaf-terminating path is the
+special case, and it changes no deposit-shaped corollary. -/
+inductive IsOpenable (H : Type) [Hasher H] : Node → Nat → Nat → Prop where
+  | stop (m : Node) (hsz : (Node.rootOf H m).size = 32) (index : Nat) :
+      IsOpenable H m 0 index
+  | left {l r : Node} {d index : Nat} {c : Option ByteArray}
+      (hbit : routeRight index d = false)
+      (hl : IsOpenable H l d index)
+      (hr32 : (Node.merkleRoot H r).size = 32)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsOpenable H (.pair l r c) (d + 1) index
+  | right {l r : Node} {d index : Nat} {c : Option ByteArray}
+      (hbit : routeRight index d = true)
+      (hr : IsOpenable H r d index)
+      (hl32 : (Node.merkleRoot H l).size = 32)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsOpenable H (.pair l r c) (d + 1) index
+
+/-! ### The openers -/
+
+/-- The 32-byte chunk at the end of `index`'s bits, read from the root of `n`,
+most-significant bit (level `depth-1`) first. It is the root of whatever node
+the path stops on.
+
+The function is total. Its remaining arm, a `.leaf` asked to open at positive
+depth, is unreachable under `IsOpenable` and falls through to
+`SizzLean.Spec.zero32`, the canonical all-zero chunk.
+
+That fallthrough is silent, so a caller without an `IsOpenable` witness in hand
+gets a plausible-looking zero chunk out of a shape mismatch. Holding the witness
+is what rules that out. The openers themselves report nothing. -/
+def leafAt (H : Type) [Hasher H] : Node → (depth : Nat) → (index : Nat) → ByteArray
+  | m,             0,     _     => Node.rootOf H m
+  | .pair l r _,   d + 1, index =>
+      if routeRight index d then leafAt H r d index else leafAt H l d index
+  | _,             _,     _     => SizzLean.Spec.zero32
+
+/-- `leafAt` at depth 0 is the stop node's root, whatever the node's shape.
+
+The depth-0 arm above matches any `Node`, but the equation compiler splits on the
+*node* first. The arm therefore does not fire while the node is an opaque
+variable, and a `cases` has to show that no other arm applies. Stating that once
+here keeps every base case downstream a plain rewrite. The same holds for
+`siblingPath_zero` below. -/
+theorem leafAt_zero (H : Type) [Hasher H] (m : Node) (index : Nat) :
+    leafAt H m 0 index = Node.rootOf H m := by
+  cases m <;> rfl
+
+/-- The sibling hashes along the root path to the leaf at `index`, ordered
+bottom-to-top. Index `0` is the leaf-level sibling, and index `depth-1` is the
+sibling just under the root.
+
+The recursion enters the chosen subtree first, then pushes this level's sibling,
+the *other* subtree's root, at the end. The top sibling therefore lands at the
+highest array index, which matches `isValidMerkleBranch`'s bit-`i`-at-level-`i`
+fold.
+
+Sibling roots come from `Node.rootOf`, the cache-reading observer, which
+allocates nothing. It agrees with `Node.merkleRoot` on every `Node`
+(`rootOf_eq_merkleRoot`), so reading a sibling's cache as its `merkleRoot` needs
+no hypothesis. -/
+def siblingPath (H : Type) [Hasher H] :
+    Node → (depth : Nat) → (index : Nat) → Array ByteArray
+  | .pair l r _,   d + 1, index =>
+      if routeRight index d
+      then (siblingPath H r d index).push (Node.rootOf H l)
+      else (siblingPath H l d index).push (Node.rootOf H r)
+  | _,             _,     _     => #[]
+
+/-- A depth-0 opening has no siblings, whatever the node's shape. Needs the same
+`cases` as `leafAt_zero`, for the same reason. -/
+theorem siblingPath_zero (H : Type) [Hasher H] (m : Node) (index : Nat) :
+    siblingPath H m 0 index = #[] := by
+  cases m <;> rfl
+
+/-! ### Sizes along an openable path -/
+
+/-- `siblingPath` has exactly `depth` entries along an openable path. Each
+constructor case knows its own bit, so the routing `if` reduces without a
+mirrored `split`. -/
+theorem siblingPath_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      (siblingPath H n depth index).size = depth := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => simp [siblingPath_zero]
+  | left hbit _ _ _ ihl =>
+      unfold siblingPath
+      simp [hbit, Array.size_push, ihl]
+  | right hbit _ _ _ ihr =>
+      unfold siblingPath
+      simp [hbit, Array.size_push, ihr]
+
+/-- Each entry of `siblingPath` along an openable path is 32 bytes. Entries below
+the top come from the sub-path IH. The top entry is the recorded sibling root,
+whose width and honest cache the predicate carries. No `CombineWidth32` here,
+because `IsOpenable` records the widths itself. -/
+theorem siblingPath_entries_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      ∀ i, i < depth → ((siblingPath H n depth index)[i]!).size = 32 := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => intro i hi; omega
+  | @left l r d index c hbit hl hr32 hc ihl =>
+      intro i hi
+      unfold siblingPath
+      simp only [hbit, Bool.false_eq_true, if_false]
+      have hsz : (siblingPath H l d index).size = d := siblingPath_size H hl
+      rcases Nat.lt_or_ge i d with hid | hid
+      · rw [getElem!_push_lt _ _ _ (by rw [hsz]; exact hid)]
+        exact ihl i hid
+      · have hi' : i = d := by omega
+        have htop := getElem!_push_size (siblingPath H l d index) (Node.rootOf H r)
+        rw [hsz] at htop
+        rw [hi', htop, rootOf_eq_merkleRoot H r]
+        exact hr32
+  | @right l r d index c hbit hr hl32 hc ihr =>
+      intro i hi
+      unfold siblingPath
+      simp only [hbit, if_true]
+      have hsz : (siblingPath H r d index).size = d := siblingPath_size H hr
+      rcases Nat.lt_or_ge i d with hid | hid
+      · rw [getElem!_push_lt _ _ _ (by rw [hsz]; exact hid)]
+        exact ihr i hid
+      · have hi' : i = d := by omega
+        have htop := getElem!_push_size (siblingPath H r d index) (Node.rootOf H l)
+        rw [hsz] at htop
+        rw [hi', htop, rootOf_eq_merkleRoot H l]
+        exact hl32
+
+/-- The chunk `leafAt` reaches along an openable path is 32 bytes: it is the stop
+node's root, whose width the `IsOpenable.stop` witness carries directly. -/
+theorem leafAt_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      (leafAt H n depth index).size = 32 := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => rw [leafAt_zero]; exact hsz
+  | left hbit _ _ _ ihl => unfold leafAt; simp [hbit, ihl]
+  | right hbit _ _ _ ihr => unfold leafAt; simp [hbit, ihr]
+
+/-! ### Perfect trees are openable -/
+
+/-- Every perfect tree is openable at every index. The followed child comes from
+the same-depth subtree witness. The off-path sibling root is 32 bytes by
+`merkleRoot_size`, which is why the statement needs `CombineWidth32`. Cache
+validity at this level is `IsPerfect`'s own `hc`.
+
+The name does not extend SizzLean's `IsPerfect` namespace, since the conclusion
+is an EthCLLib predicate. A `SizzLean.Cache.MerkleTree.IsPerfect.isOpenable`
+would put a framework-typed declaration inside the SSZ library's namespace, which
+is the coupling this split removes. -/
+theorem isOpenable_of_isPerfect {H : Type} [Hasher H] [CombineWidth32 H] :
+    ∀ {n : Node} {d : Nat}, IsPerfect H n d → ∀ (index : Nat),
+      IsOpenable H n d index := by
+  intro n d hp
+  induction hp with
+  | leaf b hsz =>
+      intro index
+      exact .stop (.leaf b) (by rw [Node.rootOf_leaf]; exact hsz) index
+  | @pair l r d c hl hr hc ihl ihr =>
+      intro index
+      cases hbit : routeRight index d
+      · exact .left hbit (ihl index) (merkleRoot_size H hr) hc
+      · exact .right hbit (ihr index) (merkleRoot_size H hl) hc
+
+/-! ### The root-typed sugar -/
+
+/-- The honest leaf opening at `index`: the root of the node the path stops on,
+root-typed.
+
+No width hypothesis: `bytesToRoot` zero-pads a short buffer rather than failing,
+so this silently widens a malformed tree (see the `#guard` below). The theorems
+are safe because `IsOpenable.stop` carries
+`hsz : (Node.rootOf H m).size = 32`. -/
+def honestLeaf (H : Type) [Hasher H] (n : Node) (depth index : Nat) : Vector UInt8 32 :=
+  bytesToRoot (leafAt H n depth index)
+
+/-- The honest branch opening at `index`: the sibling path, root-typed entrywise.
+Same absent width hypothesis as `honestLeaf`, applied per entry. -/
+def honestBranch (H : Type) [Hasher H] (n : Node) (depth index : Nat) :
+    Array (Vector UInt8 32) :=
+  (siblingPath H n depth index).map bytesToRoot
+
+/-! **Pin: the sugar zero-pads a wrong-width leaf.** A 3-byte leaf opened at
+depth 0 comes back widened to 32. `honestBranch` returns an empty array, whose
+size matches depth 0. -/
+#guard
+  let b : ByteArray := ByteArray.mk #[1, 2, 3]
+  (honestLeaf Sha256Spec (.leaf b) 0 0).toList == [1, 2, 3] ++ List.replicate 29 0
+    && (honestBranch Sha256Spec (.leaf b) 0 0).size == 0
+
+/-- `bytesToRoot` then `vecToBytes` is the identity on exactly-32-byte buffers.
+`bytesToRoot b` reads the 32 bytes of `b` into a vector, and `vecToBytes`
+unwraps it. The composite is `b` iff `b` has exactly its 32 bytes. For
+`b.size ≠ 32` it truncates or zero-pads, which is why the hypothesis is there. -/
+theorem vecToBytes_bytesToRoot (b : ByteArray) (hsz : b.size = 32) :
+    vecToBytes (bytesToRoot b) = b := by
+  apply ByteArray.ext
+  show (Vector.ofFn (fun i : Fin 32 => b.get! i.val)).toArray = b.data
+  rw [Vector.toArray_ofFn]
+  apply Array.ext
+  · rw [Array.size_ofFn]; exact (ByteArray.size_data.trans hsz).symm
+  · intro i h1 h2
+    rw [Array.getElem_ofFn, SizzLean.Proofs.get!_eq_getElem b i h2,
+        ByteArray.getElem_eq_getElem_data]
+
+end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Tests.lean
+++ b/packages/EthCLLib/EthCLLib/Tests.lean
@@ -5,6 +5,7 @@ import EthCLLib.Tests.TierMerge
 import EthCLLib.Tests.CryptoBackendSpike
 import EthCLLib.Tests.ContainerForm
 import EthCLLib.Tests.FrameworkUtils
+import EthCLLib.Tests.MerkleWitness
 import EthCLLib.Tests.PreambleSection
 
 /-!

--- a/packages/EthCLLib/EthCLLib/Tests/MerkleWitness.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/MerkleWitness.lean
@@ -1,0 +1,74 @@
+import EthCLLib.Proofs.MerkleOpening
+import EthCLLib.Proofs.MerkleBranch
+import EthCLLib.Spec.SigningRoot
+
+/-!
+# `EthCLLib.Tests.MerkleWitness`: Merkle-branch length-guard witnesses
+
+Two rejection witnesses for `isValidMerkleBranch`, an over-length branch and a
+short one, pinning the guard in both directions.
+
+The spec returns early on `depth != len(branch)`
+(`specs/phase0/beacon-chain.md:809`). Completeness covers only the branches an
+honest opening produces, so it says nothing about this direction. These two
+statements are the ones `Proofs/MerkleBranch.lean` does not imply.
+
+The guard settles both before any hashing, so they close by `simp` and carry no
+compiler axiom.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Tests
+
+open SizzLean SizzLean.Hasher SizzLean.Cache.MerkleTree
+open EthCLLib.Spec EthCLLib.Proofs
+
+/-- **Over-length rejection.** The spec's `is_valid_merkle_branch` guards
+`depth != len(branch)` (`specs/phase0/beacon-chain.md:809`), so it rejects a
+branch longer than `depth` outright. Padding the depth-1 witness's honest branch
+with an extra sibling makes `branch.size = 2 ≠ 1 = depth`, so the check returns
+`false`.
+
+The guard decides this before the fold runs. Nothing hashes, and the root
+argument never forces. `simp` closes it on the branch's size alone. Plain
+`decide` does not: its `Decidable` instance will not reduce through
+`siblingPath`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    letI : HasherTag := fastHasherTag
+    let tree : Node := .pair (.leaf z) (.leaf o) none
+    isValidMerkleBranch
+        (honestLeaf Sha256 tree 1 0)
+        ((honestBranch Sha256 tree 1 0).push (bytesToRoot o))
+        1 0
+        (bytesToRoot (Node.merkleRoot Sha256 tree))
+      = false := by
+  simp [isValidMerkleBranch, honestBranch, siblingPath, routeRight]
+
+/-- **Short-branch rejection.** The same guard cuts the other way. The spec
+compares `depth != len(branch)`, so it rejects a branch *shorter* than `depth`
+too. Popping the depth-1 witness's single sibling leaves `branch.size = 0 ≠ 1 =
+depth`, so the check returns `false` even though the leaf and root are the honest
+ones. `simp` closes it for the same reason as above.
+
+**Why index 1 and not 0.** At index 1 the removed sibling is the left child `z`,
+32 zero bytes. That is exactly what an unguarded `branch[0]!` returns on an empty
+array. The reconstruction would therefore still succeed, so the guard alone
+accounts for the `false`. At index 0 the sibling is `o`, the reconstruction fails
+on its own, and the test no longer isolates the guard. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    letI : HasherTag := fastHasherTag
+    let tree : Node := .pair (.leaf z) (.leaf o) none
+    isValidMerkleBranch
+        (honestLeaf Sha256 tree 1 1)
+        ((honestBranch Sha256 tree 1 1).pop)
+        1 1
+        (bytesToRoot (Node.merkleRoot Sha256 tree))
+      = false := by
+  simp [isValidMerkleBranch, honestBranch, siblingPath, routeRight]
+
+end EthCLLib.Tests

--- a/packages/SizzLean/SizzLean.lean
+++ b/packages/SizzLean/SizzLean.lean
@@ -15,6 +15,7 @@ import SizzLean.Cache.Update
 import SizzLean.Proofs.SSZListPush
 import SizzLean.Proofs.SSZListGetElem
 import SizzLean.Proofs.SSZListSet
+import SizzLean.Proofs.Perfect
 
 /-!
 # `SizzLean`: library root

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
@@ -64,6 +64,31 @@ call sites that just need the digest. -/
 def Node.merkleRoot (H : Type) [Hasher H] (n : Node) : ByteArray :=
   (n.merkleRootWithCache H).1
 
+/-! ### The three arms, stated before the seal
+
+`Node.merkleRoot` and `Node.rootOf` are the same structural recursion
+(`Proofs/Perfect.lean`'s `rootOf_eq_merkleRoot`), and they carry the same
+unfolding hazard. Both are therefore sealed. `Node.merkleRootWithCache` is the
+recursion, and `Node.merkleRoot` returns its first component, so the seal covers
+both. See `Cache/MerkleTree/Zero.lean`'s `Node.rootOf` for the reasoning and for
+why the attribute sits after the equations. -/
+
+/-- `merkleRoot` on a leaf is the leaf's bytes. -/
+theorem Node.merkleRoot_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.merkleRoot H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, honest or not. -/
+theorem Node.merkleRoot_pair_some (H : Type) [Hasher H]
+    (l r : Node) (root : ByteArray) :
+    Node.merkleRoot H (.pair l r (some root)) = root := rfl
+
+/-- An empty slot recurses and combines. -/
+theorem Node.merkleRoot_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.merkleRoot H (.pair l r none)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := rfl
+
+attribute [irreducible] Node.merkleRoot Node.merkleRootWithCache
+
 /-! ### Acceptance: cached path matches the spec oracle
 
 Two small hand-built trees, each compared against

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
@@ -141,12 +141,39 @@ slot at construction time.
 Not a substitute for `merkleRootWithCache`, since it doesn't fill
 cache slots in the input tree. Use when you only need the root
 *value* and the input is expected to be already cached (in which
-case it's O(1)). -/
-partial def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
+case it's O(1)).
+
+**Do not unfold this in a tactic.** Reason about it through
+`rootOf_eq_merkleRoot`, or through the equation lemmas below. See the seal note
+there for what the `@[irreducible]` attribute does and does not stop. -/
+def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
   | .leaf b               => b
   | .pair _ _ (some r)    => r
   | .pair l r none        =>
       Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r)
+
+/-! ### `Node.rootOf`'s equations, then the seal
+
+The three arms, stated before `Node.rootOf` goes irreducible. Proofs reach the
+recursion through these (or, better, through `rootOf_eq_merkleRoot`) instead of
+unfolding the definition and walking a real tree. -/
+
+/-- A leaf is its own root. -/
+theorem Node.rootOf_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.rootOf H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, with no descent. This arm
+makes `rootOf` O(1) on a committed tree, and it is why `rootOf` cannot notice a
+poisoned cache. -/
+theorem Node.rootOf_pair_some (H : Type) [Hasher H] (l r : Node) (root : ByteArray) :
+    Node.rootOf H (.pair l r (some root)) = root := rfl
+
+/-- An empty cache slot combines the children's roots. -/
+theorem Node.rootOf_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.rootOf H (.pair l r none)
+      = Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r) := rfl
+
+attribute [irreducible] Node.rootOf
 
 /-- A `Node` whose root is the all-zero subtree of depth `d`. Used
 by `Node.ofLeaves` to pad the right of an underfilled tree, and by

--- a/packages/SizzLean/SizzLean/Hasher/Class.lean
+++ b/packages/SizzLean/SizzLean/Hasher/Class.lean
@@ -63,4 +63,16 @@ Naming it explicitly resolves the ambiguity. Downstream files
 example {H : Type} [Hasher H] (b₁ b₂ : ByteArray) : ByteArray :=
   Hasher.combine (H := H) (Hasher.hash (H := H) b₁) b₂
 
+/-- The 32-byte-output contract of `Hasher.combine`, as a class the Merkle-proof
+lemmas take instead of threading `∀ a b, (combine a b).size = 32` through every
+statement.
+
+The class introduces no axiom of its own. Discharging the binder pulls in
+whatever the chosen instance rests on, so add an instance resting on an
+`@[extern]` bridge deliberately. `Prop` rather than `Type` keeps the witness
+proof-irrelevant and erased from compiled code. -/
+class CombineWidth32 (H : Type) [Hasher H] : Prop where
+  /-- `combine` returns exactly 32 bytes on any two inputs. -/
+  size : ∀ a b : ByteArray, (Hasher.combine (H := H) a b).size = 32
+
 end SizzLean

--- a/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
+++ b/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
@@ -1,0 +1,35 @@
+import SizzLean.Hasher.Sha256Spec
+import SizzLean.Hasher.Sha256Equiv
+
+/-!
+# `SizzLean.Hasher.CombineWidth`: the combine-width witnesses
+
+`CombineWidth32` instances for both concrete hashers. The class itself is in
+`Hasher/Class.lean`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Hasher
+
+/-- `Sha256Spec.combine` always returns a 32-byte digest, by
+`LeanSha256.combine_size_eq_32`. No axiom. -/
+theorem sha256Spec_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256Spec) a b).size = 32 :=
+  LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the pure-Lean hasher. -/
+instance : CombineWidth32 Sha256Spec := ⟨sha256Spec_combine_size⟩
+
+/-- `Sha256.combine` always returns a 32-byte digest, by `sha256Combine_eq_spec`
+then `LeanSha256.combine_size_eq_32`. -/
+theorem sha256_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256) a b).size = 32 := by
+  show (LeanHazmat.Sha256.sha256Combine a b).size = 32
+  rw [sha256Combine_eq_spec]
+  exact LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the FFI hasher. -/
+instance : CombineWidth32 Sha256 := ⟨sha256_combine_size⟩
+
+end SizzLean.Hasher

--- a/packages/SizzLean/SizzLean/Proofs/Perfect.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Perfect.lean
@@ -1,0 +1,113 @@
+import SizzLean.Cache.MerkleTree.Merkle
+import SizzLean.Hasher.CombineWidth
+
+/-!
+# `SizzLean.Proofs.Perfect`: perfect combine-trees
+
+The tree-shape vocabulary Merkle-proof theorems quantify over. `IsPerfect` says a
+`Node` is a perfect binary combine-tree of a given depth under a hasher. Three
+shape facts follow. `merkleRoot_pair` collapses the cached and uncached readings
+of a pair. `rootOf_eq_merkleRoot` licenses reading any cache observation as the
+honest root. `merkleRoot_size` gives every root in such a tree 32 bytes.
+
+The path vocabulary sits one layer up, in `EthCLLib.Proofs.MerkleOpening`.
+`IsOpenable`, `leafAt` and `siblingPath` all route by a convention that
+`is_valid_merkle_branch` owns, and that check is a consensus-spec function rather
+than an SSZ-document one. SizzLean therefore states shape and width, and the
+framework states openings.
+
+Pure `Node` vocabulary, hasher-generic. The declarations sit in the
+`SizzLean.Cache.MerkleTree` namespace, where `Node` and the cache walkers live,
+while the file sits under `SizzLean/Proofs/`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+
+/-- A `Node` that is a *perfect* binary combine-tree of depth `d` under hasher
+`H`. Leaves at depth `0` carry exactly 32 bytes. Interior nodes at depth `d+1`
+are pairs of depth-`d` perfect subtrees whose cache slot, *if populated*, holds
+the honest `combine` of the children's roots.
+
+The cache-validity side condition (`hc`) lets these theorems reach cached trees.
+For an uncached pair (`c = none`) `hc` is vacuous. For a cached pair it pins the
+stored root to `combine (merkleRoot H l) (merkleRoot H r)`, the value
+`merkleRootWithCache` computes. `Node.merkleRoot` therefore agrees either way
+(`merkleRoot_pair`).
+
+Two shapes fall outside the predicate. A `zeroLeaf`-padded subtree caches
+Sha256-specific zero-hash bytes, so it meets `hc` only for that hasher.
+`Node.mixInLength` pairs a depth-`d` subtree with a depth-0 length leaf. Above
+`d = 0` its two children sit at different depths, so it is not `IsPerfect`. At
+`d = 0` both children are depth-0 leaves and it is, which nothing here depends
+on.
+
+The hasher `H` is a parameter because the invariant refers to
+`Node.merkleRoot H`. -/
+inductive IsPerfect (H : Type) [Hasher H] : Node → Nat → Prop where
+  | leaf (b : ByteArray) (hsz : b.size = 32) : IsPerfect H (.leaf b) 0
+  | pair {l r : Node} {d : Nat} {c : Option ByteArray}
+      (hl : IsPerfect H l d) (hr : IsPerfect H r d)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsPerfect H (.pair l r c) (d + 1)
+
+/-- The root of a valid perfect pair is the honest `combine` of the children's
+roots, at a populated cache slot and an empty one alike. For `none` this is
+`merkleRootWithCache`'s own recursion. For `some root` the cache-validity witness
+`hc` pins the stored value.
+
+The tree-walking proofs go through this bridge instead of unfolding
+`merkleRootWithCache` on an uncached node. They therefore apply unchanged to the
+cached trees the constructors emit. -/
+theorem merkleRoot_pair (H : Type) [Hasher H] {l r : Node} {c : Option ByteArray}
+    (hc : ∀ root, c = some root →
+      root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+    Node.merkleRoot H (.pair l r c)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := by
+  cases c with
+  | none => exact Node.merkleRoot_pair_none H l r
+  | some root =>
+      rw [Node.merkleRoot_pair_some H l r root]
+      exact hc root rfl
+
+/-- `Node.rootOf` agrees with `Node.merkleRoot` on **every** `Node`, with no
+shape or cache-validity hypothesis: the two are the same structural recursion.
+Neither inspects whether a populated cache slot is honest, so this holds for a
+tree carrying poisoned caches too, both read the same poison.
+
+Both walkers are `@[irreducible]`, since unfolding either in a tactic walks a
+real 262144-leaf tree. Every arm therefore enters by its named equation lemma,
+and not by `simp [Node.rootOf]` or `simp [Node.merkleRoot]`. -/
+theorem rootOf_eq_merkleRoot (H : Type) [Hasher H] (n : Node) :
+    Node.rootOf H n = Node.merkleRoot H n := by
+  induction n with
+  | leaf b => rw [Node.rootOf_leaf, Node.merkleRoot_leaf]
+  | pair l r c ihl ihr =>
+      cases c with
+      | some x => rw [Node.rootOf_pair_some, Node.merkleRoot_pair_some]
+      | none =>
+          rw [Node.rootOf_pair_none, Node.merkleRoot_pair_none, ihl, ihr]
+
+/-- Every root in a perfect tree is 32 bytes. Leaves are 32 by `IsPerfect.leaf`.
+Interior nodes are `combine` outputs, 32 by the `CombineWidth32` contract. The
+proof reaches that contract through `merkleRoot_pair`, which covers a cached pair
+and an uncached one alike.
+
+The contract arrives as a `[CombineWidth32 H]` instance, so this theorem
+introduces no axiom of its own. An instantiation costs whatever the supplied
+instance rests on (see `SizzLean/Hasher/Class.lean`). -/
+theorem merkleRoot_size (H : Type) [Hasher H] [CombineWidth32 H] :
+    ∀ {n : Node} {depth : Nat}, IsPerfect H n depth →
+      (Node.merkleRoot H n).size = 32 := by
+  intro n depth hp
+  induction hp with
+  | leaf b hsz => simpa [Node.merkleRoot_leaf] using hsz
+  | @pair l r d c hl hr hc ihl ihr =>
+      rw [merkleRoot_pair H hc]
+      exact CombineWidth32.size _ _
+
+end SizzLean.Cache.MerkleTree


### PR DESCRIPTION
## Summary

`isValidMerkleBranch` accepts the honest opening of any tree it can open. Open a
tree at `index`, hand the check the leaf and the sibling path, and the check
returns `true`. No behaviour change.

Builds on #71 and #72.

## What changed

- `IsOpenable`, `leafAt`, `siblingPath`, `honestLeaf` and `honestBranch`, with
  their size lemmas, in a new `EthCLLib/Proofs/MerkleOpening.lean`.
- `isOpenable_of_isPerfect`.
- `isValidMerkleBranch_complete`, with corollaries for a perfect tree and for
  `Sha256Spec`.
- `Tests/MerkleWitness.lean`: two rejection witnesses for the length guard, one
  branch too long and one too short.

## Test plan

- [x] `lake build` (full monorepo, on the pinned toolchain) is green.
- [x] Per-package test suites pass:
  - [x] `lake build LeanSha256Tests`
  - [x] `lake build SizzLeanTests`
  - [x] `just ethcl-test`
- [x] If this touches spec types or cache behaviour:
      `just ethcl-pyspec` is green.
- [ ] If this touches a bench-measured hot path: included
      before/after `lake exe ssz_bench` TSV (or relevant rows) in
      the PR description.
- [x] New SSZ shapes / cache cases come with a `native_decide` or
      property test that exercises them.

## Risk / trust footprint

- Adds no axiom directly. `isValidMerkleBranch_complete` needs no
  `CombineWidth32` instance, because `IsOpenable` records the sibling widths
  itself.
- The perfect-tree corollary takes a `CombineWidth32` instance. At `Sha256` that
  resolves to the instance proved from `sha256Combine_eq_spec`, so an FFI
  instantiation inherits that axiom. The `Sha256Spec` corollary resolves with no
  axiom.
- Adds and removes no `sorry`, `partial def`, `native_decide`, `unsafe` block
  or `@[extern]` declaration.

## Notes for reviewers

The openers sit in EthCLLib while shape and width stay in SizzLean. The routing
convention belongs to `is_valid_merkle_branch`.

The injection theorem takes the name `isOpenable_of_isPerfect` instead of
`IsPerfect.isOpenable`, which keeps an EthCLLib-typed result out of SizzLean's
namespace.

On a shape mismatch, `leafAt` and `siblingPath` return a zero chunk and report
nothing. A caller therefore depends on holding the `IsOpenable` witness.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.

