### PR TITLE
feat(heze-focil-enforcement-proof): prove shouldExtendPayload rejects recorded-unsatisfied payloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,8 +156,24 @@ about `Heze.f`, and the per-fork directory is what keeps the two claims apart.
    target no `forkdef` declared, a target your statement never mentions, and a
    tag written outside the target fork's directory. Supporting lemmas stay
    untagged; they still count as touched.
-4. **Flip the ledger row** to `proved`, and name the pull request and the module
-   in its Tracking cell. A row stays in the ledger for its whole life.
+4. **Flip the ledger row**, and name the pull request and the module in its
+   Tracking cell. A row stays in the ledger for its whole life.
+
+   Set `proved` when the theorem states what the row asks for. Set
+   `in progress` when it lands part of that claim. The split follows step 3. A
+   theorem that states the function's contract carries a `@[characterizes]` tag,
+   and its row reads `proved`. A theorem that states one branch, one call
+   pattern, or a restatement of a helper carries no tag, and its row stays
+   `in progress`.
+
+   A partly landed row then says in its Property cell what is landed and what is
+   open, so the next author reads the remainder off the row. `getPtc` and
+   `shouldExtendPayload` are the two worked cases.
+
+   `just proof-coverage` cross-checks the status against the tags. It warns when
+   a `proved` row carries no tag, and when a tagged function has no `proved`
+   row. Both warnings are advisory, and both say the same thing: the status and
+   the tag disagree, so one of them is wrong.
 5. **Run `just proof-coverage-update` and commit the diff.** It rewrites the two
    baselines and the two README blocks. That diff is the coverage change, so it
    belongs in the pull request with the proof. CI never writes it for you.

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ package stands.
 <!-- proof-coverage:begin -->
 | Package | What a proof covers here | Where it stands |
 | --- | --- | --- |
-| `EthCLSpecs` | the spec functions the fork bodies declare | 8 characterized, 23 touched, of 585 |
+| `EthCLSpecs` | the spec functions the fork bodies declare | 8 characterized, 26 touched, of 585 |
 | `SizzLean` | SSZ properties over the whole `SSZType` universe, gated by a predicate | 3 of 5 properties, over 13 admitted arms; open: any `hashTreeRoot` property, cached tree ≡ uncached `hashTreeRoot` |
 | `LeanSha256`, `LeanHazmat*` | nothing to cover: `@[extern]` bindings, and a spec side pinned by the NIST CAVP vectors | 2 named equivalence axioms: `sha256Hash_eq_spec`, `sha256Combine_eq_spec` |
 | `LeanPoseidon` | `permute_eq_permuteRef`, in the standalone `LeanPoseidonProofs` package | outside this run: it pins mathlib of its own |

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -1,5 +1,6 @@
 import EthCLSpecs.Proofs.Gloas
 import EthCLSpecs.Proofs.Heze
+import EthCLSpecs.Proofs.StoreRun
 
 /-!
 # `EthCLSpecs.Proofs`: consensus-spec theorems (index)
@@ -35,4 +36,6 @@ Re-exports:
 
 * `EthCLSpecs.Proofs.Gloas`: the Gloas fork's theorems, one module per subject.
 * `EthCLSpecs.Proofs.Heze`: the Heze fork's theorems, one module per subject.
+* `EthCLSpecs.Proofs.StoreRun`: `ForkChoiceStoreRun`, the pure store-machine
+  runner every fork's fork-choice proofs pin at that fork's `Store`.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs.lean
@@ -1,4 +1,5 @@
 import EthCLSpecs.Proofs.Gloas
+import EthCLSpecs.Proofs.Heze
 
 /-!
 # `EthCLSpecs.Proofs`: consensus-spec theorems (index)
@@ -33,4 +34,5 @@ target fork's directory.
 Re-exports:
 
 * `EthCLSpecs.Proofs.Gloas`: the Gloas fork's theorems, one module per subject.
+* `EthCLSpecs.Proofs.Heze`: the Heze fork's theorems, one module per subject.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/ForkChoiceRun.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/ForkChoiceRun.lean
@@ -1,12 +1,15 @@
 import EthCLSpecs.Gloas.ForkChoice
+import EthCLSpecs.Proofs.StoreRun
 import EthCLSpecs.Proofs.Gloas.InitiateBuilderExit
 import EthCLSpecs.Proofs.Gloas.BuilderPendingPayments
 
 /-!
 # `EthCLSpecs.Proofs.Gloas.ForkChoiceRun`: the fork-choice store monad these proofs would run at
 
-`Proofs/Gloas/Run.lean` names the monad for the *state* machine. This names the one for the
-*store* machine, and proves a fork-choice `forkdef` at it.
+`Proofs/Gloas/Run.lean` names the monad for the *state* machine (`GloasRun`), and
+`Proofs/StoreRun.lean` names the fork-generic one for the *store* machine
+(`ForkChoiceStoreRun`). This file specializes the latter to Gloas's `Store` as
+`GloasStoreRun`, and proves a fork-choice `forkdef` at it.
 
 Nothing here is a fork-choice proof yet; `PROOF_LEDGER.md` queues five under Gloas
 "Fork-choice correctness".
@@ -40,15 +43,10 @@ open EthCLSpecs.Gloas (Store getSlotsSinceGenesis getCurrentSlot State currentEp
 open SizzLean.Repr
 open SizzLean.Cache
 
-/-- The store machine's pure monad: `StateT` over `Except`, threading the fork-choice
-`Store` and rejecting with `StoreTransitionError`. The store-side counterpart of
-`GloasRun`, and the store-side reading of `SPECS_ARCHITECTURE.md` §11.1.
-
-Parameterized by the map backing rather than fixed to `treeMap`: the backing is a
-separate axis of the fast/pure duality from the monad, and a theorem that does not
-read a map should not pin one. -/
+/-- Gloas specialization of `ForkChoiceStoreRun`: pure `StateT`/`Except` over
+`Gloas.Store`, parameterized by the map backing rather than fixed to `treeMap`. -/
 abbrev GloasStoreRun [Preset] [HasherTag] (map : MapKind) : Type → Type :=
-  StateT (Store map) (Except StoreTransitionError)
+  ForkChoiceStoreRun (Store map)
 
 /-- **A fork-choice `forkdef`, at the pure store monad.** `get_slots_since_genesis` on a
 store whose clock has not advanced past genesis returns `0`, leaving the store alone.

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
@@ -4,17 +4,17 @@ import EthCLSpecs.Gloas.State
 # `EthCLSpecs.Proofs.Gloas.Run`: the Gloas state-transition runner these proofs run against
 
 A theorem about a `forkdef`'s effect has to pin down the monad the spec body is
-elaborated into, since `StateTransition` / `StoreTransition` are parameters of the fork
-body rather than fixed types. Every Gloas state-transition proof in this directory pins
-`GloasRun`; every fork-choice store proof pins `ForkChoiceStoreRun` at the fork's `Store`.
+elaborated into, since `StateTransition` is a parameter of the fork body rather than a
+fixed type. Every Gloas proof in this directory pins the same one, so it is named once
+here and instantiated at each theorem through `(StateTransition := GloasRun)`. The store
+machine's counterpart is `ForkChoiceStoreRun`, in `Proofs/StoreRun.lean`.
 
 ## Which monad, and why not the fast one
 
 `SPEC_AUTHORING_MODEL.md` sets out a fast/pure duality across four axes, and names
 `StateT State (Except StateTransitionError)` as the proving column's effect monad;
 `SPECS_ARCHITECTURE.md` §11.1 states that the fast configuration (`FastBox`, `EStateM`,
-`hashMap`) is never a proof target. This is that monad, for both the state machine
-(`GloasRun`) and the store machine (`ForkChoiceStoreRun`).
+`hashMap`) is never a proof target. This is that monad.
 
 No fork body names it. The three raw constraints `state_section` emits (`Monad`,
 `MonadStateOf State`, `MonadExceptOf StateTransitionError`) all resolve for `StateT` over

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
@@ -54,16 +54,6 @@ boxed Gloas `BeaconState` and rejecting with `StateTransitionError`. `abbrev`
 abbrev GloasRun [Preset] [HasherTag] : Type → Type :=
   StateT State (Except StateTransitionError)
 
-/-- Pure runner for fork-choice store proofs: `StateT` over `Except`, threading an
-arbitrary store state `σ` and rejecting with `StoreTransitionError`. The store-side
-counterpart of `GloasRun`, and the store-side reading of `SPECS_ARCHITECTURE.md` §11.1.
-
-Parameterized by the store type rather than a fork-specific `Store`, so Gloas and Heze
-(and any later fork) pin `(StoreTransition := ForkChoiceStoreRun (Store map))` at the same
-shared name. -/
-abbrev ForkChoiceStoreRun (σ : Type) : Type → Type :=
-  StateT σ (Except StoreTransitionError)
-
 /-! ## Running a bind
 
 `EStateM` ships `run_bind` / `run_pure` as `simp` lemmas; the `StateT`-over-`Except`

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Gloas/Run.lean
@@ -4,16 +4,17 @@ import EthCLSpecs.Gloas.State
 # `EthCLSpecs.Proofs.Gloas.Run`: the Gloas state-transition runner these proofs run against
 
 A theorem about a `forkdef`'s effect has to pin down the monad the spec body is
-elaborated into, since `StateTransition` is a parameter of the fork body rather than a
-fixed type. Every Gloas proof in this directory pins the same one, so it is named once
-here and instantiated at each theorem through `(StateTransition := GloasRun)`.
+elaborated into, since `StateTransition` / `StoreTransition` are parameters of the fork
+body rather than fixed types. Every Gloas state-transition proof in this directory pins
+`GloasRun`; every fork-choice store proof pins `ForkChoiceStoreRun` at the fork's `Store`.
 
 ## Which monad, and why not the fast one
 
 `SPEC_AUTHORING_MODEL.md` sets out a fast/pure duality across four axes, and names
 `StateT State (Except StateTransitionError)` as the proving column's effect monad;
 `SPECS_ARCHITECTURE.md` §11.1 states that the fast configuration (`FastBox`, `EStateM`,
-`hashMap`) is never a proof target. This is that monad.
+`hashMap`) is never a proof target. This is that monad, for both the state machine
+(`GloasRun`) and the store machine (`ForkChoiceStoreRun`).
 
 No fork body names it. The three raw constraints `state_section` emits (`Monad`,
 `MonadStateOf State`, `MonadExceptOf StateTransitionError`) all resolve for `StateT` over
@@ -52,6 +53,16 @@ boxed Gloas `BeaconState` and rejecting with `StateTransitionError`. `abbrev`
 `.ok (a, state')` and a rejecting one reads `.error e`, carrying no state. -/
 abbrev GloasRun [Preset] [HasherTag] : Type → Type :=
   StateT State (Except StateTransitionError)
+
+/-- Pure runner for fork-choice store proofs: `StateT` over `Except`, threading an
+arbitrary store state `σ` and rejecting with `StoreTransitionError`. The store-side
+counterpart of `GloasRun`, and the store-side reading of `SPECS_ARCHITECTURE.md` §11.1.
+
+Parameterized by the store type rather than a fork-specific `Store`, so Gloas and Heze
+(and any later fork) pin `(StoreTransition := ForkChoiceStoreRun (Store map))` at the same
+shared name. -/
+abbrev ForkChoiceStoreRun (σ : Type) : Type → Type :=
+  StateT σ (Except StoreTransitionError)
 
 /-! ## Running a bind
 

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
@@ -1,0 +1,22 @@
+import EthCLSpecs.Proofs.Heze.ShouldExtendPayload
+
+/-!
+# `EthCLSpecs.Proofs.Heze`: the Heze fork's theorems (index)
+
+Every theorem about an `EthCLSpecs.Heze` declaration, one module per subject.
+The directory mirrors `EthCLSpecs/Heze/`, for the reason `Proofs/Gloas.lean`
+states: a fork elaborates its own constant for every declaration, inherited ones
+included, so a theorem here is about the Heze constant and about no other fork's.
+`shouldExtendPayload` is the case that shows it. Gloas declares it and Heze
+overrides it with the FOCIL gate, so the Gloas theorems say nothing about the
+Heze constant.
+
+Every declaration here sits in the `EthCLSpecs.Proofs.Heze` namespace.
+
+Re-exports:
+
+* `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: `HezeStoreRun`, the store-side
+  pure monad for Heze, plus the FOCIL enforcement theorem for Heze's
+  `shouldExtendPayload` override
+  (`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied`).
+-/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
@@ -15,8 +15,8 @@ Every declaration here sits in the `EthCLSpecs.Proofs.Heze` namespace.
 
 Re-exports:
 
-* `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: `HezeStoreRun`, the store-side
-  pure monad for Heze, plus the FOCIL enforcement theorem for Heze's
-  `shouldExtendPayload` override
-  (`shouldExtendPayload_run_eq_false_of_verified_unsatisfied`).
+* `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: Heze's verified,
+  recorded-unsatisfied FOCIL rejection theorem
+  (`shouldExtendPayload_run_eq_false_of_verified_unsatisfied`), proved with
+  `ForkChoiceStoreRun`.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
@@ -17,6 +17,6 @@ Re-exports:
 
 * `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: Heze's verified,
   recorded-unsatisfied FOCIL rejection theorem
-  (`shouldExtendPayload_run_eq_false_of_verified_unsatisfied`), proved with
+  (`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied`), proved with
   `ForkChoiceStoreRun`.
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze.lean
@@ -18,5 +18,5 @@ Re-exports:
 * `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: `HezeStoreRun`, the store-side
   pure monad for Heze, plus the FOCIL enforcement theorem for Heze's
   `shouldExtendPayload` override
-  (`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied`).
+  (`shouldExtendPayload_run_eq_false_of_verified_unsatisfied`).
 -/

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -1,0 +1,99 @@
+import EthCLSpecs.Heze.ForkChoice
+import EthCLSpecs.Proofs.Gloas.Run
+
+/-!
+# `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: Heze's FOCIL rejection gate
+
+Public declarations live in `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists
+in both Gloas and Heze and this module's theorem is about the Heze override alone
+(`EthCLSpecs/Proofs/Gloas/UpdateCheckpoints.lean` documents the same naming reason for
+`updateCheckpoints`).
+
+`[New in Heze:EIP7805]` adds one gate to Gloas's `should_extend_payload`: after the
+ordinary `is_payload_verified` check, a payload whose recorded inclusion-list
+satisfaction verdict is `false` is not extended, before any of the later timeliness,
+data-availability, or proposer-boost reads run. This module proves that gate fires:
+`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` shows that once the
+preliminary block/slot checks succeed and the payload is verified, a `false` recorded
+verdict alone determines the result, at the pure `HezeStoreRun` monad this file also
+names (the store-side sibling of `GloasStoreRun` in `Proofs/Gloas/ForkChoiceRun.lean`, used
+here rather than the `EStateM` pin configuration because the theorem's `.run store`
+equation states non-mutation of the store directly, with no separate frame lemma
+needed).
+
+The preliminary preconditions the theorem still takes as hypotheses, rather than
+proving: `store.blocks[root]` resolving to a concrete block, `getCurrentSlot store`
+already equal to `rootBlock.slot + 1` (so the slot-equality assertion the
+implementation opens with does not fire its own reject), and that addition not
+overflowing. None of those are FOCIL-specific; they are the same guard Gloas's
+`should_extend_payload` opens with, unconditional on the inclusion-list gate this
+module is about.
+
+Out of scope: how a `payloadInclusionListSatisfaction` verdict comes to be recorded
+(`onExecutionPayloadEnvelope`'s write, and the invariant that it always accompanies a
+`payloads` write), the missing-record `assert` branch this precondition rules out,
+execution-engine correctness, inclusion-list ingestion and validation, PTC committee
+selection, signature verification, transaction collection, block production, P2P
+propagation, global fork-choice canonicality, and liveness. This module claims only
+that the gate rejects when given an already-recorded `false` verdict, nothing about
+where that verdict comes from or whether it is correct.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLSpecs.Proofs.Heze
+
+open EthCLLib.Spec (HasherTag StoreTransitionError MapKind FcMap checkedAdd)
+open EthCLSpecs.Fulu (Preset Config Root Slot)
+open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied isPayloadVerified
+  getCurrentSlot BeaconBlock)
+
+/-- The Heze store machine's pure monad: `StateT` over `Except`, threading the Heze
+fork-choice `Store` and rejecting with `StoreTransitionError`. The Heze-side sibling of
+`GloasStoreRun` (`Proofs/Gloas/ForkChoiceRun.lean`): a separate abbrev because `Heze.Store` is
+its own `forkstruct`, distinct from `Gloas.Store`, not a renaming of the same type.
+
+Parameterized by the map backing rather than fixed to `treeMap`, for the same reason as
+`GloasStoreRun`: the backing is a separate axis of the fast/pure duality from the
+monad, and a theorem that does not read a map should not pin one. -/
+abbrev HezeStoreRun [Preset] [HasherTag] (map : MapKind) : Type → Type :=
+  StateT (Store map) (Except StoreTransitionError)
+
+/-- **The FOCIL enforcement theorem.** A verified payload whose recorded inclusion-list
+satisfaction verdict is `false` causes `should_extend_payload` to return exactly `false`,
+with the runner state unchanged (the trailing `store` in the result, not some other
+state): the FOCIL guard is the branch that decides the outcome, and it stops before any
+later logic runs.
+
+`hVerified` is not needed to derive the `false` result, `isPayloadInclusionListSatisfied`
+itself returns `false` whenever the payload is unverified (its own `else` branch), so an
+unverified payload already forces `false` before the FOCIL gate is even reached. The
+hypothesis is kept anyway: it fixes which branch is doing the rejecting. Without it, this
+theorem would be equally true of an unverified payload, and would say nothing about the
+inclusion-list gate specifically. With it, the ordinary verification guard is recorded as
+already having passed, so the `false` this theorem proves is the FOCIL gate's rejection,
+not a restatement of the ordinary unverified-payload case Gloas already has.
+
+This theorem does not evaluate, and says nothing about, the timeliness vote, the
+data-availability vote, the proposer-boost root, or the parent block; those all sit past
+the gate this theorem's hypotheses stop at. It also assumes the recorded verdict as given,
+`hUnsatisfied` is a hypothesis, not a derived fact, so this theorem does not establish
+that the verdict itself is correct, only that the gate honors it once recorded. -/
+theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
+    {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map]
+    (store : Store map) (root : Root) (rootBlock : BeaconBlock)
+    (hBlock : FcMap.lookup store.blocks root = some rootBlock)
+    (hCurrentSlot :
+      (getCurrentSlot (StoreTransition := HezeStoreRun map) store).run store
+        = .ok (rootBlock.slot + 1, store))
+    (hNoOverflow : ¬ (rootBlock.slot + 1 < rootBlock.slot))
+    (hVerified : isPayloadVerified store root = true)
+    (hUnsatisfied : FcMap.lookup store.payloadInclusionListSatisfaction root = some false) :
+    (shouldExtendPayload (StoreTransition := HezeStoreRun map) store root).run store
+      = .ok (false, store) := by
+  simp [shouldExtendPayload, isPayloadInclusionListSatisfied, FcMap.getOrThrow,
+    FcMap.getOrThrowKey, FcMap.getOrAssert, hBlock, checkedAdd, hNoOverflow, hVerified,
+    hUnsatisfied, hCurrentSlot, Gloas.GloasRun.except_bind_ok]
+  rfl
+
+end EthCLSpecs.Proofs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -14,10 +14,14 @@ in the pure fork-choice runner `ForkChoiceStoreRun (Store map)`, leaving its
 runner state unchanged.
 
 The theorem assumes the successful block lookup, current-slot calculation,
-non-overflowing slot increment, and recorded verdict. It does not prove verdict
-production or correctness, the payload/verdict pairing invariant, missing-record
-behavior, inclusion-list construction or validation, or end-to-end canonicality
-and liveness.
+non-overflowing slot increment, and recorded verdict. It needs no
+`[ExecutionEngine]` binder: Heze records the inclusion-list satisfaction verdict
+behind that seam in `recordPayloadInclusionListSatisfaction`, while
+`shouldExtendPayload` only reads the stored result through
+`isPayloadInclusionListSatisfied`. Verdict production and correctness, the
+payload/verdict pairing invariant, missing-record behavior, inclusion-list
+construction or validation, and end-to-end canonicality and liveness stay out of
+scope.
 
 The theorem lives in `EthCLSpecs.Proofs.Heze` because `shouldExtendPayload` exists
 in both Gloas and Heze.

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -42,7 +42,7 @@ logic.
 payload is rejected earlier. It is retained to establish that the FOCIL gate is
 the rejecting branch. The converse is not claimed: `shouldExtendPayload` can also
 return `false` for an unverified payload or because of later Gloas logic. -/
-theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
+theorem shouldExtendPayload_run_eq_false_of_verified_unsatisfied
     {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map] :
     ∀ (store : Store map) (root : Root) (rootBlock : BeaconBlock),
       FcMap.lookup store.blocks root = some rootBlock →

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -34,9 +34,12 @@ namespace EthCLSpecs.Proofs.Heze
 open EthCLSpecs.Proofs (ForkChoiceStoreRun)
 open EthCLSpecs.Proofs.Gloas (GloasRun)
 open EthCLLib.Spec (HasherTag MapKind FcMap checkedAdd)
-open EthCLSpecs.Fulu (Preset Config Root)
-open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied isPayloadVerified
-  getCurrentSlot BeaconBlock)
+open EthCLSpecs.Fulu (Root)
+-- `Preset` and `Config` come from Heze, not Fulu: `forkpreset` gives each fork its own
+-- class, and `Heze.Store` is elaborated against Heze's. The downgrade instances run the
+-- other way, so a Fulu binder would not synthesize here.
+open EthCLSpecs.Heze (Preset Config Store shouldExtendPayload isPayloadInclusionListSatisfied
+  isPayloadVerified getCurrentSlot BeaconBlock)
 
 /-- A verified payload with a recorded `false` inclusion-list satisfaction verdict
 is rejected by Heze's FOCIL gate once the preliminary block/slot checks succeed.

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -40,14 +40,13 @@ open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied 
 
 /-- A verified payload with a recorded `false` inclusion-list satisfaction verdict
 is rejected by Heze's FOCIL gate once the preliminary block/slot checks succeed.
-The result preserves the runner state and short-circuits the later inherited Gloas
-logic.
+The result preserves the runner state and short-circuits later logic shared with Gloas.
 
 `hverified` is logically unnecessary for the Boolean conclusion: an unverified
 payload is rejected earlier. It is retained to establish that the FOCIL gate is
 the rejecting branch. The converse is not claimed: `shouldExtendPayload` can also
 return `false` for an unverified payload or because of later Gloas logic. -/
-theorem shouldExtendPayload_run_eq_false_of_verified_unsatisfied
+theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
     {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map] :
     ∀ (store : Store map) (root : Root) (rootBlock : BeaconBlock),
       FcMap.lookup store.blocks root = some rootBlock →

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -9,7 +9,7 @@ in both Gloas and Heze and this module's theorem is about the Heze override alon
 (`EthCLSpecs/Proofs/Gloas/UpdateCheckpoints.lean` documents the same naming reason for
 `updateCheckpoints`).
 
-`[New in Heze:EIP7805]` adds one gate to Gloas's `should_extend_payload`: after the
+Heze's EIP-7805 fork adds one gate to Gloas's `should_extend_payload`: after the
 ordinary `is_payload_verified` check, a payload whose recorded inclusion-list
 satisfaction verdict is `false` is not extended, before any of the later timeliness,
 data-availability, or proposer-boost reads run. This module proves that gate fires:
@@ -53,9 +53,9 @@ fork-choice `Store` and rejecting with `StoreTransitionError`. The Heze-side sib
 `GloasStoreRun` (`Proofs/Gloas/ForkChoiceRun.lean`): a separate abbrev because `Heze.Store` is
 its own `forkstruct`, distinct from `Gloas.Store`, not a renaming of the same type.
 
-Parameterized by the map backing rather than fixed to `treeMap`, for the same reason as
-`GloasStoreRun`: the backing is a separate axis of the fast/pure duality from the
-monad, and a theorem that does not read a map should not pin one. -/
+Parameterized by the map backing rather than fixed to `treeMap`, because the
+runner representation and map backing are independent implementation choices;
+the theorem requires only the abstract `FcMap` interface. -/
 abbrev HezeStoreRun [Preset] [HasherTag] (map : MapKind) : Type → Type :=
   StateT (Store map) (Except StoreTransitionError)
 
@@ -65,14 +65,10 @@ with the runner state unchanged (the trailing `store` in the result, not some ot
 state): the FOCIL guard is the branch that decides the outcome, and it stops before any
 later logic runs.
 
-`hVerified` is not needed to derive the `false` result, `isPayloadInclusionListSatisfied`
-itself returns `false` whenever the payload is unverified (its own `else` branch), so an
-unverified payload already forces `false` before the FOCIL gate is even reached. The
-hypothesis is kept anyway: it fixes which branch is doing the rejecting. Without it, this
-theorem would be equally true of an unverified payload, and would say nothing about the
-inclusion-list gate specifically. With it, the ordinary verification guard is recorded as
-already having passed, so the `false` this theorem proves is the FOCIL gate's rejection,
-not a restatement of the ordinary unverified-payload case Gloas already has.
+`hVerified` is not logically necessary for the Boolean conclusion: without it,
+an unverified payload is rejected by `shouldExtendPayload` before the FOCIL helper
+is called. It is retained to establish that ordinary payload verification has
+passed, so the recorded unsatisfied verdict is the rejecting branch.
 
 This theorem does not evaluate, and says nothing about, the timeliness vote, the
 data-availability vote, the proposer-boost root, or the parent block; those all sit past

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -1,5 +1,6 @@
 import EthCLSpecs.Heze.ForkChoice
 import EthCLSpecs.Proofs.Gloas.Run
+import EthCLSpecs.Proofs.StoreRun
 
 /-!
 # `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: Heze's FOCIL rejection gate
@@ -9,7 +10,7 @@ inserts a FOCIL gate after payload verification and before the later timeliness,
 data-availability, and proposer-boost logic.
 This module proves that, once the common block/slot prefix succeeds, a verified
 payload with a recorded `false` inclusion-list satisfaction verdict returns `false`
-in the pure `HezeStoreRun`, leaving its runner state unchanged.
+at `ForkChoiceStoreRun (Store map)`, leaving its runner state unchanged.
 
 The theorem assumes the successful block lookup, current-slot calculation,
 non-overflowing slot increment, and recorded verdict. It does not prove verdict
@@ -25,16 +26,12 @@ set_option autoImplicit false
 
 namespace EthCLSpecs.Proofs.Heze
 
-open EthCLLib.Spec (HasherTag StoreTransitionError MapKind FcMap checkedAdd)
+open EthCLSpecs.Proofs (ForkChoiceStoreRun)
+open EthCLSpecs.Proofs.Gloas (GloasRun)
+open EthCLLib.Spec (HasherTag MapKind FcMap checkedAdd)
 open EthCLSpecs.Fulu (Preset Config Root)
 open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied isPayloadVerified
   getCurrentSlot BeaconBlock)
-
-/-- Pure `StateT`/`Except` runner for Heze fork-choice proofs, mirroring
-`GloasStoreRun`. A separate abbreviation is required because `Heze.Store` is a
-distinct fork structure. The map backing remains abstract through `MapKind`. -/
-abbrev HezeStoreRun [Preset] [HasherTag] (map : MapKind) : Type → Type :=
-  StateT (Store map) (Except StoreTransitionError)
 
 /-- A verified payload with a recorded `false` inclusion-list satisfaction verdict
 is rejected by Heze's FOCIL gate once the preliminary block/slot checks succeed.
@@ -49,12 +46,13 @@ theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
     {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map] :
     ∀ (store : Store map) (root : Root) (rootBlock : BeaconBlock),
       FcMap.lookup store.blocks root = some rootBlock →
-      (getCurrentSlot (StoreTransition := HezeStoreRun map) store).run store
+      (getCurrentSlot (StoreTransition := ForkChoiceStoreRun (Store map)) store).run store
         = .ok (rootBlock.slot + 1, store) →
       ¬ (rootBlock.slot + 1 < rootBlock.slot) →
       isPayloadVerified store root = true →
       FcMap.lookup store.payloadInclusionListSatisfaction root = some false →
-      (shouldExtendPayload (StoreTransition := HezeStoreRun map) store root).run store
+      (shouldExtendPayload (StoreTransition := ForkChoiceStoreRun (Store map)) store root).run
+          store
         = .ok (false, store) := by
   intro store root rootBlock hblock hcurrentslot hnooverflow hverified hunsatisfied
   -- `checkedAdd` takes its non-overflow branch under `hnooverflow`, so `nextSlot =

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -60,12 +60,7 @@ theorem shouldExtendPayload_run_eq_false_of_verified_unsatisfied
           store
         = .ok (false, store) := by
   intro store root rootBlock hblock hcurrentslot hnooverflow hverified hunsatisfied
-  -- `checkedAdd` takes its non-overflow branch under `hnooverflow`, so `nextSlot =
-  -- rootBlock.slot + 1`, matching `hcurrentslot` and discharging the slot-equality
-  -- `assert`. `hverified` sends both `isPayloadVerified` checks to their `else`
-  -- branch, and `isPayloadInclusionListSatisfied` then reduces to `hunsatisfied`'s
-  -- recorded `false`, so `shouldExtendPayload`'s inclusion-list guard takes its
-  -- `then` branch, forcing the whole result to `pure false`.
+  -- Targeted unfold of the FOCIL gate; residual goal is definitional.
   simp [shouldExtendPayload, isPayloadInclusionListSatisfied, FcMap.getOrThrow,
     FcMap.getOrThrowKey, FcMap.getOrAssert, hblock, checkedAdd, hnooverflow, hverified,
     hunsatisfied, hcurrentslot, Gloas.GloasRun.except_bind_ok]

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -4,39 +4,21 @@ import EthCLSpecs.Proofs.Gloas.Run
 /-!
 # `EthCLSpecs.Proofs.Heze.ShouldExtendPayload`: Heze's FOCIL rejection gate
 
-Public declarations live in `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists
-in both Gloas and Heze and this module's theorem is about the Heze override alone
-(`EthCLSpecs/Proofs/Gloas/UpdateCheckpoints.lean` documents the same naming reason for
-`updateCheckpoints`).
+Heze's `shouldExtendPayload` follows the Gloas fork-choice decision flow but
+inserts a FOCIL gate after payload verification and before the later timeliness,
+data-availability, and proposer-boost logic.
+This module proves that, once the common block/slot prefix succeeds, a verified
+payload with a recorded `false` inclusion-list satisfaction verdict returns `false`
+in the pure `HezeStoreRun`, leaving its runner state unchanged.
 
-Heze's EIP-7805 fork adds one gate to Gloas's `should_extend_payload`: after the
-ordinary `is_payload_verified` check, a payload whose recorded inclusion-list
-satisfaction verdict is `false` is not extended, before any of the later timeliness,
-data-availability, or proposer-boost reads run. This module proves that gate fires:
-`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` shows that once the
-preliminary block/slot checks succeed and the payload is verified, a `false` recorded
-verdict alone determines the result, at the pure `HezeStoreRun` monad this file also
-names (the store-side sibling of `GloasStoreRun` in `Proofs/Gloas/ForkChoiceRun.lean`, used
-here rather than the `EStateM` pin configuration because the theorem's `.run store`
-equation states non-mutation of the store directly, with no separate frame lemma
-needed).
+The theorem assumes the successful block lookup, current-slot calculation,
+non-overflowing slot increment, and recorded verdict. It does not prove verdict
+production or correctness, the payload/verdict pairing invariant, missing-record
+behavior, inclusion-list construction or validation, or end-to-end canonicality
+and liveness.
 
-The preliminary preconditions the theorem still takes as hypotheses, rather than
-proving: `store.blocks[root]` resolving to a concrete block, `getCurrentSlot store`
-already equal to `rootBlock.slot + 1` (so the slot-equality assertion the
-implementation opens with does not fire its own reject), and that addition not
-overflowing. None of those are FOCIL-specific; they are the same guard Gloas's
-`should_extend_payload` opens with, unconditional on the inclusion-list gate this
-module is about.
-
-Out of scope: how a `payloadInclusionListSatisfaction` verdict comes to be recorded
-(`onExecutionPayloadEnvelope`'s write, and the invariant that it always accompanies a
-`payloads` write), the missing-record `assert` branch this precondition rules out,
-execution-engine correctness, inclusion-list ingestion and validation, PTC committee
-selection, signature verification, transaction collection, block production, P2P
-propagation, global fork-choice canonicality, and liveness. This module claims only
-that the gate rejects when given an already-recorded `false` verdict, nothing about
-where that verdict comes from or whether it is correct.
+The theorem lives in `EthCLSpecs.Proofs.Heze` because `shouldExtendPayload` exists
+in both Gloas and Heze.
 -/
 
 set_option autoImplicit false
@@ -48,33 +30,21 @@ open EthCLSpecs.Fulu (Preset Config Root Slot)
 open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied isPayloadVerified
   getCurrentSlot BeaconBlock)
 
-/-- The Heze store machine's pure monad: `StateT` over `Except`, threading the Heze
-fork-choice `Store` and rejecting with `StoreTransitionError`. The Heze-side sibling of
-`GloasStoreRun` (`Proofs/Gloas/ForkChoiceRun.lean`): a separate abbrev because `Heze.Store` is
-its own `forkstruct`, distinct from `Gloas.Store`, not a renaming of the same type.
-
-Parameterized by the map backing rather than fixed to `treeMap`, because the
-runner representation and map backing are independent implementation choices;
-the theorem requires only the abstract `FcMap` interface. -/
+/-- Pure `StateT`/`Except` runner for Heze fork-choice proofs, mirroring
+`GloasStoreRun`. A separate abbreviation is required because `Heze.Store` is a
+distinct fork structure. The map backing remains abstract through `MapKind`. -/
 abbrev HezeStoreRun [Preset] [HasherTag] (map : MapKind) : Type → Type :=
   StateT (Store map) (Except StoreTransitionError)
 
-/-- **The FOCIL enforcement theorem.** A verified payload whose recorded inclusion-list
-satisfaction verdict is `false` causes `should_extend_payload` to return exactly `false`,
-with the runner state unchanged (the trailing `store` in the result, not some other
-state): the FOCIL guard is the branch that decides the outcome, and it stops before any
-later logic runs.
+/-- A verified payload with a recorded `false` inclusion-list satisfaction verdict
+is rejected by Heze's FOCIL gate once the preliminary block/slot checks succeed.
+The result preserves the runner state and short-circuits the later inherited Gloas
+logic.
 
-`hVerified` is not logically necessary for the Boolean conclusion: without it,
-an unverified payload is rejected by `shouldExtendPayload` before the FOCIL helper
-is called. It is retained to establish that ordinary payload verification has
-passed, so the recorded unsatisfied verdict is the rejecting branch.
-
-This theorem does not evaluate, and says nothing about, the timeliness vote, the
-data-availability vote, the proposer-boost root, or the parent block; those all sit past
-the gate this theorem's hypotheses stop at. It also assumes the recorded verdict as given,
-`hUnsatisfied` is a hypothesis, not a derived fact, so this theorem does not establish
-that the verdict itself is correct, only that the gate honors it once recorded. -/
+`hVerified` is logically unnecessary for the Boolean conclusion: an unverified
+payload is rejected earlier. It is retained to establish that the FOCIL gate is
+the rejecting branch. The converse is not claimed: `shouldExtendPayload` can also
+return `false` for an unverified payload or because of later Gloas logic. -/
 theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
     {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map]
     (store : Store map) (root : Root) (rootBlock : BeaconBlock)

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -26,7 +26,7 @@ set_option autoImplicit false
 namespace EthCLSpecs.Proofs.Heze
 
 open EthCLLib.Spec (HasherTag StoreTransitionError MapKind FcMap checkedAdd)
-open EthCLSpecs.Fulu (Preset Config Root Slot)
+open EthCLSpecs.Fulu (Preset Config Root)
 open EthCLSpecs.Heze (Store shouldExtendPayload isPayloadInclusionListSatisfied isPayloadVerified
   getCurrentSlot BeaconBlock)
 
@@ -41,25 +41,31 @@ is rejected by Heze's FOCIL gate once the preliminary block/slot checks succeed.
 The result preserves the runner state and short-circuits the later inherited Gloas
 logic.
 
-`hVerified` is logically unnecessary for the Boolean conclusion: an unverified
+`hverified` is logically unnecessary for the Boolean conclusion: an unverified
 payload is rejected earlier. It is retained to establish that the FOCIL gate is
 the rejecting branch. The converse is not claimed: `shouldExtendPayload` can also
 return `false` for an unverified payload or because of later Gloas logic. -/
 theorem shouldExtendPayload_run_eq_false_of_recorded_unsatisfied
-    {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map]
-    (store : Store map) (root : Root) (rootBlock : BeaconBlock)
-    (hBlock : FcMap.lookup store.blocks root = some rootBlock)
-    (hCurrentSlot :
+    {map : MapKind} [Preset] [HasherTag] [Config] [FcMap map] :
+    ∀ (store : Store map) (root : Root) (rootBlock : BeaconBlock),
+      FcMap.lookup store.blocks root = some rootBlock →
       (getCurrentSlot (StoreTransition := HezeStoreRun map) store).run store
-        = .ok (rootBlock.slot + 1, store))
-    (hNoOverflow : ¬ (rootBlock.slot + 1 < rootBlock.slot))
-    (hVerified : isPayloadVerified store root = true)
-    (hUnsatisfied : FcMap.lookup store.payloadInclusionListSatisfaction root = some false) :
-    (shouldExtendPayload (StoreTransition := HezeStoreRun map) store root).run store
-      = .ok (false, store) := by
+        = .ok (rootBlock.slot + 1, store) →
+      ¬ (rootBlock.slot + 1 < rootBlock.slot) →
+      isPayloadVerified store root = true →
+      FcMap.lookup store.payloadInclusionListSatisfaction root = some false →
+      (shouldExtendPayload (StoreTransition := HezeStoreRun map) store root).run store
+        = .ok (false, store) := by
+  intro store root rootBlock hblock hcurrentslot hnooverflow hverified hunsatisfied
+  -- `checkedAdd` takes its non-overflow branch under `hnooverflow`, so `nextSlot =
+  -- rootBlock.slot + 1`, matching `hcurrentslot` and discharging the slot-equality
+  -- `assert`. `hverified` sends both `isPayloadVerified` checks to their `else`
+  -- branch, and `isPayloadInclusionListSatisfied` then reduces to `hunsatisfied`'s
+  -- recorded `false`, so `shouldExtendPayload`'s inclusion-list guard takes its
+  -- `then` branch, forcing the whole result to `pure false`.
   simp [shouldExtendPayload, isPayloadInclusionListSatisfied, FcMap.getOrThrow,
-    FcMap.getOrThrowKey, FcMap.getOrAssert, hBlock, checkedAdd, hNoOverflow, hVerified,
-    hUnsatisfied, hCurrentSlot, Gloas.GloasRun.except_bind_ok]
+    FcMap.getOrThrowKey, FcMap.getOrAssert, hblock, checkedAdd, hnooverflow, hverified,
+    hunsatisfied, hcurrentslot, Gloas.GloasRun.except_bind_ok]
   rfl
 
 end EthCLSpecs.Proofs.Heze

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/Heze/ShouldExtendPayload.lean
@@ -10,7 +10,8 @@ inserts a FOCIL gate after payload verification and before the later timeliness,
 data-availability, and proposer-boost logic.
 This module proves that, once the common block/slot prefix succeeds, a verified
 payload with a recorded `false` inclusion-list satisfaction verdict returns `false`
-at `ForkChoiceStoreRun (Store map)`, leaving its runner state unchanged.
+in the pure fork-choice runner `ForkChoiceStoreRun (Store map)`, leaving its
+runner state unchanged.
 
 The theorem assumes the successful block lookup, current-slot calculation,
 non-overflowing slot increment, and recorded verdict. It does not prove verdict

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/StoreRun.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/StoreRun.lean
@@ -1,0 +1,37 @@
+import EthCLLib.Spec
+
+/-!
+# `EthCLSpecs.Proofs.StoreRun`: the fork-choice store runner these proofs run against
+
+A theorem about a fork-choice `forkdef`'s effect has to pin down the monad the spec
+body is elaborated into, since `StoreTransition` is a parameter of the fork body
+rather than a fixed type. Every fork-choice proof pins the runner named here, at its
+own fork's `Store`, through `(StoreTransition := ForkChoiceStoreRun (Store map))`.
+
+The module sits beside the per-fork directories rather than inside one. The runner
+is a monad over an arbitrary store type, so it belongs to no fork, and the theorems
+that pin it live in `Proofs/Gloas/` and `Proofs/Heze/` alike.
+
+`SPEC_AUTHORING_MODEL.md` sets out a fast/pure duality across four axes, and
+`SPECS_ARCHITECTURE.md` §11.1 states that the fast configuration (`FastBox`,
+`EStateM`, `hashMap`) is never a proof target. This is the pure column's store
+monad, the store-side counterpart of `Proofs/Gloas/Run.lean`'s `GloasRun`.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLSpecs.Proofs
+
+open EthCLLib.Spec (StoreTransitionError)
+
+/-- Pure runner for fork-choice store proofs: `StateT` over `Except`, threading an
+arbitrary store state `σ` and rejecting with `StoreTransitionError`.
+
+Parameterized by the store type rather than by a fork-specific `Store`, so Gloas and
+Heze, and any later fork, pin `(StoreTransition := ForkChoiceStoreRun (Store map))` at
+the same shared name. `abbrev` (reducible) so a goal mentioning it unifies with the
+spelled-out `StateT σ (Except StoreTransitionError)`. -/
+abbrev ForkChoiceStoreRun (σ : Type) : Type → Type :=
+  StateT σ (Except StoreTransitionError)
+
+end EthCLSpecs.Proofs

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -132,14 +132,14 @@ column is the fork's own diff, for scale.
 | --- | --- | --- | --- | --- |
 | `EthCLSpecs.Fulu` | 0 | 2 | 158 | 158 |
 | `EthCLSpecs.Gloas` | 8 | 21 | 209 | 109 |
-| `EthCLSpecs.Heze` | 0 | 0 | 218 | 12 |
-| **Total** | 8 | 23 | 585 | 279 |
+| `EthCLSpecs.Heze` | 0 | 3 | 218 | 12 |
+| **Total** | 8 | 26 | 585 | 279 |
 
 | Axiom | Theorems resting on it |
 | --- | --- |
-| `propext` | 45 |
-| `Classical.choice` | 40 |
-| `Quot.sound` | 44 |
+| `propext` | 46 |
+| `Classical.choice` | 41 |
+| `Quot.sound` | 45 |
 | `Lean.ofReduceBool` | 0 |
 | `Lean.trustCompiler` | 0 |
 | `SizzLean.sha256Hash_eq_spec` | 0 |

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -846,7 +846,7 @@ separation.
 
 - **`Proofs/Heze/ShouldExtendPayload.lean`** places its theorem in
   `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists in both Gloas
-  and Heze. `shouldExtendPayload_run_eq_false_of_verified_unsatisfied` proves
+  and Heze. `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` proves
   only this FOCIL-gate claim at `ForkChoiceStoreRun (Store map)`: under
   successful preliminary lookup/slot checks, a verified payload with a present
   recorded `false` satisfaction verdict is rejected by the Heze FOCIL gate, with

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -823,9 +823,15 @@ separation.
   withdrawability-delay addition does not wrap for the shipped minimal and
   mainnet configurations.
 
-- **`Proofs/Gloas/Run.lean`** names `GloasRun`, the `EStateM StateTransitionError State`
-  the Gloas proofs pin their `forkdef` bodies to. `StateTransition` is a parameter
-  of a fork body, so every run theorem has to fix it; this fixes it once.
+- **`Proofs/Gloas/Run.lean`** names `GloasRun`, the pure `StateT`/`Except`
+  state-transition monad the Gloas proofs pin their `forkdef` bodies to.
+  `StateTransition` is a parameter of a fork body, so every run theorem has to fix
+  it; this fixes it once.
+
+- **`Proofs/StoreRun.lean`** names `ForkChoiceStoreRun`, the shared pure
+  store-machine runner every fork's fork-choice proofs pin at that fork's
+  `Store`. It sits beside the per-fork directories because the runner is a monad
+  over an arbitrary store type and so belongs to no fork.
 
 - **`Proofs/Gloas/IsValidIndexedPayloadAttestation.lean`** proves a two-layer,
   backend-generic characterization of `isValidIndexedPayloadAttestation`. Layer 1
@@ -838,18 +844,16 @@ separation.
   `EthCLSpecs.Proofs.Gloas`. It characterizes Gloas `processOperations` at
   `GloasRun`; handlers and later failure postconditions remain opaque.
 
-- **`Proofs/Heze/ShouldExtendPayload.lean`** names `HezeStoreRun`, the pure
-  `StateT`/`Except` store monad for Heze (the store-side sibling of
-  `GloasStoreRun` in `Proofs/Gloas/ForkChoiceRun.lean`), and places its theorem in
+- **`Proofs/Heze/ShouldExtendPayload.lean`** places its theorem in
   `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists in both Gloas
   and Heze. `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` proves
-  Heze's EIP-7805 FOCIL gate: once the preliminary block/slot
-  checks succeed, a verified payload with a recorded `false` inclusion-list
-  satisfaction verdict is rejected before the later timeliness,
-  data-availability, and proposer-boost logic is evaluated, with the store left
-  unchanged. It takes the recorded verdict as a hypothesis rather than
-  deriving it, and says nothing about verdict production or the missing-record
-  `assert` branch.
+  Heze's EIP-7805 FOCIL gate at `ForkChoiceStoreRun (Store map)`: once the
+  preliminary block/slot checks succeed, a verified payload with a recorded
+  `false` inclusion-list satisfaction verdict is rejected before the later
+  timeliness, data-availability, and proposer-boost logic is evaluated, with
+  the store left unchanged. It takes the recorded verdict as a hypothesis rather
+  than deriving it, and says nothing about verdict production or the
+  missing-record `assert` branch.
 
 - **`Proofs/Gloas/UpdateCheckpoints.lean`** rewrites Gloas's `updateCheckpoints` as a
   single record update, which doubles as the frame condition that no other Store

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -846,7 +846,7 @@ separation.
 
 - **`Proofs/Heze/ShouldExtendPayload.lean`** places its theorem in
   `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists in both Gloas
-  and Heze. `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` proves
+  and Heze. `shouldExtendPayload_run_eq_false_of_verified_unsatisfied` proves
   Heze's EIP-7805 FOCIL gate at `ForkChoiceStoreRun (Store map)`: once the
   preliminary block/slot checks succeed, a verified payload with a recorded
   `false` inclusion-list satisfaction verdict is rejected before the later

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -838,6 +838,19 @@ separation.
   `EthCLSpecs.Proofs.Gloas`. It characterizes Gloas `processOperations` at
   `GloasRun`; handlers and later failure postconditions remain opaque.
 
+- **`Proofs/Heze/ShouldExtendPayload.lean`** names `HezeStoreRun`, the pure
+  `StateT`/`Except` store monad for Heze (the store-side sibling of
+  `GloasStoreRun` in `Proofs/Gloas/ForkChoiceRun.lean`), and places its theorem in
+  `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists in both Gloas
+  and Heze. `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` proves
+  Heze's EIP-7805 FOCIL gate: once the preliminary block/slot
+  checks succeed, a verified payload with a recorded `false` inclusion-list
+  satisfaction verdict is rejected before the later timeliness,
+  data-availability, and proposer-boost reads run, with the store left
+  unchanged. It takes the recorded verdict as a hypothesis rather than
+  deriving it, and says nothing about verdict production or the missing-record
+  `assert` branch.
+
 - **`Proofs/Gloas/UpdateCheckpoints.lean`** rewrites Gloas's `updateCheckpoints` as a
   single record update, which doubles as the frame condition that no other Store
   field moves. On top of it sit unchanged-or-advances characterizations for the

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -847,13 +847,14 @@ separation.
 - **`Proofs/Heze/ShouldExtendPayload.lean`** places its theorem in
   `EthCLSpecs.Proofs.Heze`, since `shouldExtendPayload` exists in both Gloas
   and Heze. `shouldExtendPayload_run_eq_false_of_verified_unsatisfied` proves
-  Heze's EIP-7805 FOCIL gate at `ForkChoiceStoreRun (Store map)`: once the
-  preliminary block/slot checks succeed, a verified payload with a recorded
-  `false` inclusion-list satisfaction verdict is rejected before the later
-  timeliness, data-availability, and proposer-boost logic is evaluated, with
-  the store left unchanged. It takes the recorded verdict as a hypothesis rather
-  than deriving it, and says nothing about verdict production or the
-  missing-record `assert` branch.
+  only this FOCIL-gate claim at `ForkChoiceStoreRun (Store map)`: under
+  successful preliminary lookup/slot checks, a verified payload with a present
+  recorded `false` satisfaction verdict is rejected by the Heze FOCIL gate, with
+  the pure runner state unchanged. It is not complete correctness of
+  `shouldExtendPayload`. The recorded verdict is an assumption, so payload/verdict
+  pairing and exact agreement of the recorded verdict with
+  `isInclusionListSatisfied` remain follow-up candidates in
+  `PROOF_LEDGER.md`.
 
 - **`Proofs/Gloas/UpdateCheckpoints.lean`** rewrites Gloas's `updateCheckpoints` as a
   single record update, which doubles as the frame condition that no other Store

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -846,7 +846,7 @@ separation.
   Heze's EIP-7805 FOCIL gate: once the preliminary block/slot
   checks succeed, a verified payload with a recorded `false` inclusion-list
   satisfaction verdict is rejected before the later timeliness,
-  data-availability, and proposer-boost reads run, with the store left
+  data-availability, and proposer-boost logic is evaluated, with the store left
   unchanged. It takes the recorded verdict as a hypothesis rather than
   deriving it, and says nothing about verdict production or the missing-record
   `assert` branch.

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -26,9 +26,13 @@ diff, so the ledger reads as the full list of candidates and the baseline reads
 as the subset that is done.
 
 `in progress` covers a theorem being written and one that is partly landed
-alike. The Property cell then says what is landed and what is open, which is the
-case `getPtc` shows. `out of scope` carries its reason in the Property cell,
-cryptographic assumptions being the standing case.
+alike. A theorem lands partly when it states one branch, one call pattern, or a
+restatement of a helper rather than the whole claim the row asks for. It then
+carries no `@[characterizes]` tag, and the Property cell says what is landed and
+what is open. `getPtc` and `shouldExtendPayload` are the two cases that show it.
+
+`out of scope` carries its reason in the Property cell, cryptographic
+assumptions being the standing case.
 
 ## The Location column
 

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -179,10 +179,20 @@ Functions where the theorem is a numeric bound, no overflow, no underflow, never
 
 ## Heze
 
-No rows yet. Heze is a twelve-declaration diff over Gloas, and its own
-declarations have not been read for proof candidates. Every Gloas row above
-applies to Heze's re-elaboration of that declaration as a separate claim about a
-separate constant.
+Heze is a twelve-declaration diff over Gloas, and only its FOCIL gate has been
+read for proof candidates so far. Every Gloas row above applies to Heze's
+re-elaboration of that declaration as a separate claim about a separate
+constant.
+
+### Fork-choice correctness
+
+Properties specific to the fork-choice store and the LMD-GHOST tree: agreement between two ways of computing the same relation, preconditions gating block/attestation acceptance, and correctness of the store's own bookkeeping.
+
+| Function | Location | Property | Status | Tracking |
+| --- | --- | --- | --- | --- |
+| `shouldExtendPayload` | `Heze/ForkChoice.lean:320-344` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | proved | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
+| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
+| `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-450` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
 
 ---
 

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -190,9 +190,9 @@ Properties specific to the fork-choice store and the LMD-GHOST tree: agreement b
 
 | Function | Location | Property | Status | Tracking |
 | --- | --- | --- | --- | --- |
-| `shouldExtendPayload` | `Heze/ForkChoice.lean:320-344` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | proved | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
-| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
-| `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-450` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
+| `shouldExtendPayload` | `Heze/ForkChoice.lean:320-342` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | in progress | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
+| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-418` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
+| `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-448` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
 
 ---
 

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -191,7 +191,7 @@ Properties specific to the fork-choice store and the LMD-GHOST tree: agreement b
 | Function | Location | Property | Status | Tracking |
 | --- | --- | --- | --- | --- |
 | `shouldExtendPayload` | `Heze/ForkChoice.lean:320-344` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | proved | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
-| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
+| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_verified_unsatisfied` | proposed |  |
 | `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-450` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
 
 ---

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -191,7 +191,7 @@ Properties specific to the fork-choice store and the LMD-GHOST tree: agreement b
 | Function | Location | Property | Status | Tracking |
 | --- | --- | --- | --- | --- |
 | `shouldExtendPayload` | `Heze/ForkChoice.lean:320-344` | Under successful preliminary lookup and slot checks, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by the FOCIL gate, with the pure runner state unchanged. This is not complete correctness of `shouldExtendPayload`: the later Gloas accept and reject paths and the missing-record `assert` branch stay out of scope, and the two write-path rows below stay open | proved | #63, `Proofs/Heze/ShouldExtendPayload.lean` |
-| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_verified_unsatisfied` | proposed |  |
+| `recordPayloadInclusionListSatisfaction` | `Heze/ForkChoice.lean:406-420` | The value inserted at `root` equals `isInclusionListSatisfied payload ilTxs`. Its `false` corollary discharges the recorded-unsatisfaction hypothesis of `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied` | proposed |  |
 | `onExecutionPayloadEnvelope` | `Heze/ForkChoice.lean:426-450` | After a successful envelope acceptance, `payloads[root]` and `payloadInclusionListSatisfaction[root]` are written together for the same `root`, so a verified payload is paired with some recorded satisfaction verdict | proposed |  |
 
 ---

--- a/packages/EthCLSpecs/docs/proof-coverage.baseline
+++ b/packages/EthCLSpecs/docs/proof-coverage.baseline
@@ -15,6 +15,9 @@ tier1 EthCLSpecs.Gloas.processBlsToExecutionChange
 tier1 EthCLSpecs.Gloas.processPayloadAttestation
 tier1 EthCLSpecs.Gloas.processProposerSlashing
 tier1 EthCLSpecs.Gloas.processVoluntaryExit
+tier1 EthCLSpecs.Heze.getCurrentSlot
+tier1 EthCLSpecs.Heze.isPayloadVerified
+tier1 EthCLSpecs.Heze.shouldExtendPayload
 tier2 EthCLSpecs.Gloas.canBuilderCoverBid
 tier2 EthCLSpecs.Gloas.convertBuilderIndexToValidatorIndex
 tier2 EthCLSpecs.Gloas.initiateBuilderExit


### PR DESCRIPTION
## Summary
Adds `EthCLSpecs/Proofs/ShouldExtendPayload.lean`, proving Heze’s EIP-7805 FOCIL rejection gate over the pure fork-choice runner:
- Once the preliminary block and slot checks succeed, a verified payload with a recorded `false` inclusion-list satisfaction verdict is rejected by Heze’s `shouldExtendPayload`, with the runner state unchanged (`shouldExtendPayload_run_eq_false_of_recorded_unsatisfied`).
- The theorem instantiates `StoreTransition` with `ForkChoiceStoreRun (Store map)` and lives in `EthCLSpecs.Proofs.Heze`.
## Supporting Changes
- Introduces the shared `ForkChoiceStoreRun` abstraction in `Proofs/Run.lean` and defines `GloasStoreRun` in terms of it, without changing the existing Gloas public theorem types.
- Re-exports the new module from `EthCLSpecs/Proofs.lean`.
- Marks Heze’s `shouldExtendPayload` **Proved** in `CONSENSUS_PROOF_CANDIDATES.md`.
- Records two write-path follow-ups: proving the payload/verdict pairing established by `onExecutionPayloadEnvelope`, and characterizing the exact update performed by `recordPayloadInclusionListSatisfaction`.
- Updates the Proofs section of `IMPLEMENTATION_NOTES.md`.
## Notes for Reviewers
- This is a local FOCIL read-path theorem, not a complete characterization of `shouldExtendPayload`. The missing record `assert` branch and the later logic shared with Gloas remain outside its scope. The converse is not claimed:
  those other branches may also cause `shouldExtendPayload` to return `false`.
- `hverified` is intentionally retained even though the Boolean conclusion can be derived without it: the hypothesis establishes that ordinary payload verification passed and the FOCIL gate is the rejecting branch.
- Verdict production, execution-engine correctness, and the invariant pairing verified payloads with recorded verdicts remain follow-up work. Together, the planned write characterization and pairing theorem would connect the producer path to this rejection theorem.
- The proof closes with targeted `simp` followed by `rfl`. No Mathlib, `native_decide`, `bv_decide`, `sorry`, or new axioms are introduced.
- The elaborated theorem requires only `[Preset]`, `[HasherTag]`, `[Config]`,
  and `[FcMap map]`; in particular, it has no `[ExecutionEngine]` binder.
  `#print axioms` reports exactly `propext`, `Classical.choice`, and
  `Quot.sound`.
## Test Plan
- [x] `lake build`
- [x] `lake build EthCLSpecs`
- [x] `just ethcl-test`
- [x] `just lint`
- [x] `just check-citations`
- [x] `just test`
- [x] `#print axioms` on `shouldExtendPayload_run_eq_false_of_recorded_unsatisfied`