### PR TITLE
docs: adopt STE + Orwell writing rules, and clear the two worst banned words

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,9 +337,78 @@ sets; Fulu is authored as the accumulated base.
 - Don't bump `lean-toolchain` casually, it cascades through CI and any deps.
 - Don't leave `sorry` in committed code without a `TODO` and a tracking note.
 
-## Writing Style & Structural Constraints for Documentation
+## Writing Style & Structural Constraints
 
-Applies to comments in code and in other documentation files. Also, when writting in github issues and PRs.
+Covers every word you write for this project: comments in code,
+documentation files, commit messages, GitHub issues and PRs, and replies to
+the user in conversation. One standard everywhere, so prose does not change
+register when it moves from a chat reply into a docstring.
+
+### Simplified Technical English
+
+Write Simplified Technical English. The working core of it:
+
+- **One word, one meaning.** Pick a term for a thing and keep it. `container`,
+  `chunk`, `merkleization`, `fork body` mean what the spec and the
+  ARCHITECTURE docs say they mean, in every file. Do not reach for a synonym
+  to avoid repeating a word.
+- **One instruction per sentence.** Split a sentence that carries two
+  independent claims.
+- **Short sentences.** Twenty words is a good limit for a statement, and
+  twenty-five for a description. Longer needs a reason.
+- **Say who acts.** Name the subject that performs the action: "the deriving
+  handler emits the instance", "the driver replays the vector".
+- **Keep the articles.** Write "the cache layer", not "cache layer".
+- **No noun stacks.** Three nouns in a row is the limit. Break "beacon state
+  transition test vector driver" into a phrase with a preposition.
+
+### Orwell's six rules
+
+From *Politics and the English Language*, and they outrank any stylistic
+instinct to the contrary:
+
+1. Never use a metaphor, simile, or other figure of speech which you are
+   used to seeing in print.
+2. Never use a long word where a short one will do.
+3. If it is possible to cut a word out, always cut it out.
+4. Never use the passive where you can use the active.
+5. Never use a foreign phrase, a scientific word, or a jargon word if you
+   can think of an everyday English equivalent.
+6. Break any of these rules sooner than say anything outright barbarous.
+
+Rule 5 does not ban this project's vocabulary. Four domains meet here, and
+each brings terms that no everyday word replaces:
+
+- **Lean and type theory:** `defeq`, `whnf`, `motive`, `elaborator`,
+  `reducible`, `opaque`, `typeclass`, `instance`, `coercion`, `universe`,
+  `olean`, `axiom`, `kernel`, `termination_by`. Metaprogramming `splice`
+  (the `$x` in a syntax quotation) belongs here too.
+- **SSZ:** `merkleization`, `hashTreeRoot`, `chunk`, `zero hash`,
+  `generalized index`, `offset`, `bitlist`, `bitvector`, `container`,
+  `selector`, `mix_in_length`, `fixed-size` / `variable-size`.
+- **Consensus specs:** `slot`, `epoch`, `checkpoint`, `attestation`,
+  `committee`, `validator`, `withdrawal`, `churn limit`, `justification`,
+  `finalization`, `shuffling`, `RANDAO`, `Gwei`, `preset`, `pyspec`, and
+  the fork names.
+- **Crypto and FFI:** `FFI`, `@[extern]`, `shim`, `boxed` / `unboxed`,
+  `endianness`, `blst`, `c-kzg`, `BLS12-381`, `G1` / `G2`, `pairing`,
+  `field element`, `commitment`, `trusted setup`, `TCB`, `hazmat`.
+
+The repo's own terms of art stay as well, and they mean one thing each:
+`seam` (a typeclass the fork body calls out through), `tier`, `pin`,
+`gate`, `fixture`, `conformance`, `differential test`, `oracle`.
+
+Rule 5 bans the jargon that replaces a plain word for no gain. Examples,
+and the list is open: `ride along`, `ride on`, `load-bearing`, `sanctioned`
+(write "allowed"), `verdict` (write "result"), `plumbing`, `baked in`,
+`escape hatch`, `under the hood`, `blast radius`, `paper over`, `canary`.
+It also bans borrowed Latin (`inter alia`, `a priori`, `vice versa`) where
+English does the job.
+
+Rule 6 is the only exemption, and it is narrow. Clarity outranks the other
+five. A passive is right when the actor is unknown or beside the point
+("the block was rejected by the gate" reads worse than "the gate rejected
+the block", but "the `.olean` is rebuilt on every toolchain bump" is fine).
 
 ### Sentence Construction (Hard Enforcement)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,15 @@ is the *why* so edge cases can be judged on principle, not by pattern-matching.
 
   Explain non-obvious *inferences* with the same rigor as non-obvious idioms.
   Lean infers a lot, types, terms, instances, motives, and most of it is
-  unremarkable, but some of it is load-bearing and not recoverable from
+  unremarkable, but some of it decides what the code means and is not
+  recoverable from
   reading the surface code: `let x : ConcreteType := y` coercions that force
   defeq reduction across a mutual-block boundary; dependent pattern
   destructures (`vs.1` / `vs.2` on a `Prod`-chain that came from unfolding
   an `interp` arm); named-argument typeclass synthesis (`(H := H)` when the
   parameter is a phantom tag the methods don't consume); the inferred
   `Fin n` parameter of a `Vector.ofFn` lambda; the synthesised bound proof
-  inside `b[i]'h`. When the inference is the load-bearing thing a reader
+  inside `b[i]'h`. When the inference is the thing a reader
   needs to follow, name what Lean inferred and *why* in a one-line comment,
   don't restate types the RHS already makes obvious. Type-annotate
   intermediate `let` / `have` bindings whose type changes the meaning of
@@ -115,7 +116,7 @@ is the *why* so edge cases can be judged on principle, not by pattern-matching.
   a missed implicit is paid forever.
 - **Stringly-typed is a smell.** Tag SSZ kinds with an inductive
   (`SSZType.uint64 | .vector … | .container …`), not with `String`. If
-  you find yourself comparing strings in load-bearing code, the type is
+  you find yourself comparing strings in code that decides behavior, the type is
   asking to be promoted.
 
 These map onto the usual references: Fowler's *Refactoring* (smells), Hunt &
@@ -400,7 +401,7 @@ The repo's own terms of art stay as well, and they mean one thing each:
 
 Rule 5 bans the jargon that replaces a plain word for no gain. Examples,
 and the list is open: `ride along`, `ride on`, `load-bearing`, `sanctioned`
-(write "allowed"), `verdict` (write "result"), `plumbing`, `baked in`,
+(write "allowed"), `verdict` (write "answer"), `plumbing`, `baked in`,
 `escape hatch`, `under the hood`, `blast radius`, `paper over`, `canary`.
 It also bans borrowed Latin (`inter alia`, `a priori`, `vice versa`) where
 English does the job.

--- a/docs/CODING_STYLE.md
+++ b/docs/CODING_STYLE.md
@@ -330,7 +330,7 @@ Four habits, three to keep and one to drop:
   `-- Validator sweep (Capella).` pair in `getExpectedWithdrawals`
   (`EthCLSpecs/Fulu/Withdrawals.lean:getExpectedWithdrawals`) is the model. Two comments, two
   phases.
-- **Explain a load-bearing inference.** The `sszGetIdx` comments say why an index
+- **Explain an inference that changes the meaning.** The `sszGetIdx` comments say why an index
   read must reject instead of masking. The cache-root comment in `Node.ofSubtrees`
   (`SizzLean/Cache/MerkleTree/Build.lean:Node.ofSubtrees`) says why the root is computed inline.
   Neither fact is recoverable from the surface code. CLAUDE.md asks for exactly
@@ -381,7 +381,7 @@ forkdef advanceStoreTime (store : Store map) (time : UInt64) : Store map :=
 
 The giant fuel argument becomes a named `fuel`, the duplicated `tickSlot` formula
 collapses to one `targetSlot`, and the comment records the invariant that makes the
-dedup safe. That invariant is the kind of load-bearing inference CLAUDE.md asks to
+dedup safe. That invariant is the kind of inference CLAUDE.md asks to
 be spelled out, since a reader cannot tell from the old code that the inner
 recompute was redundant.
 

--- a/hazmat-docs/ARCHITECTURE.md
+++ b/hazmat-docs/ARCHITECTURE.md
@@ -497,11 +497,11 @@ This document is binding on layout and dependencies for the LeanHazmat family.
 CLAUDE.md is binding on style and discipline: imports first; `set_option
 autoImplicit false` per file; PascalCase for types, lowerCamelCase for defs;
 namespacing under `LeanHazmat.<Family>`; no committed `#eval` / `#check` / `#print`
-(`example : … := by …` and `#guard` are the load-bearing alternatives);
+(`example : … := by …` and `#guard` are the alternatives);
 structural recursion or `termination_by` over `partial def`. Where the two
 overlap, CLAUDE.md wins on form and this document wins on architectural substance.
 
-The load-bearing convention is **literate by default**:
+The main convention is **literate by default**:
 
 - Every `*.lean` file opens with a `/-! … -/` module docstring framing it for a
   reader who knows one side of the FFI/crypto divide but not the other.

--- a/hazmat-docs/PLAN.md
+++ b/hazmat-docs/PLAN.md
@@ -29,7 +29,7 @@ Lake `extern_lib` / vendored-C-build toolchain is already familiar.
 
 ## Stage 0: Cross-package linking spike
 
-**Goal.** Settle the one load-bearing unknown before any code moves: does
+**Goal.** Settle the one blocking unknown before any code moves: does
 Lake propagate a package's `extern_lib` / `moreLinkArgs` to a *dependent*
 package's link step? The answer decides whether `LeanHazmatSha256` can be
 the single OpenSSL pkg-config home (with `SizzLean` inheriting the link

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Driver.lean
@@ -13,7 +13,7 @@ and the outcome is classified into one of the error model's buckets.
 The reject-faithfulness audit (`SPECS_ARCHITECTURE.md` §10.2) is encoded in
 `classify`:
 
-| Vector | Result | Verdict |
+| Vector | Outcome | Result |
 |---|---|---|
 | valid (`post` present) | root matches | pass |
 | valid | any error, or wrong root | fail |
@@ -54,7 +54,7 @@ structure CaseRequest where
   caseMeta : CaseMeta
   deriving Inhabited
 
-/-- The driver's verdict for one case. `passed` is whether the outcome matched
+/-- The driver's result for one case. `passed` is whether the outcome matched
 the vector's valid/invalid marking; `bucket` is the reporting bucket (a passing
 case is `passing` or `expectedRejection`; a failure carries its smell); `flagged`
 marks an invalid vector rejected by a bug-smell rather than a clean `assert`. -/

--- a/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
+++ b/packages/EthCLLib/EthCLLib/PySpecTests/Interface.lean
@@ -62,7 +62,7 @@ structure CaseMeta where
   pre-fork block. `none` ⇒ every block is post-fork. -/
   forkBlock : Option Nat := none
   /-- `execution.yaml`'s `execution_valid` for `operations/execution_payload`: the
-  mocked execution-engine verdict. `true` for every other format. -/
+  mocked execution-engine answer. `true` for every other format. -/
   executionValid : Bool := true
   deriving Inhabited, Repr
 

--- a/packages/EthCLLib/EthCLLib/Spec/Arith.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Arith.lean
@@ -210,7 +210,7 @@ where the surviving order then feeds the equivocating-index merge. -/
 `ys`'s order with each candidate tested against the running result. So `xs` is copied as is (its
 own duplicates, if any, preserved) and `ys` contributes each new value once. Names the
 insertion-order-preserving merge `on_attester_slashing` folds new equivocators onto
-`store.equivocating_indices`. The resulting order is load-bearing: it feeds the fork-choice
+`store.equivocating_indices`. The resulting order matters: it feeds the fork-choice
 weight computation, so the fold keeps the first-seen position rather than re-sorting. -/
 @[inline] def arrayUnion {α : Type} [BEq α] (xs ys : Array α) : Array α :=
   ys.foldl (init := xs) fun acc i => if acc.contains i then acc else acc.push i

--- a/packages/EthCLLib/EthCLLib/Spec/Engine.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Engine.lean
@@ -2,7 +2,7 @@
 # `EthCLLib.Spec.Engine`: the `[ExecutionEngine]` seam
 
 The spec's `ExecutionEngine` predicates are Engine-API calls answered by an
-external execution layer (EL), so their verdicts are EL-implementation-defined
+external execution layer (EL), so their answers are EL-implementation-defined
 and cannot be modeled as fixed values without hiding the trust boundary. Like
 `[CryptoBackend]` one file over, this is an injection seam, a typeclass
 boundary where the consumer picks the implementation (`FRAMEWORK_ARCHITECTURE.md`
@@ -24,7 +24,7 @@ One deliberate difference from `CryptoBackend`: that seam ships named backends
 (`ffi` / `verifyOff` / `symbolic`) a consumer must inject, so a forgotten
 injection is a compile error; this one registers the optimistic mock as a
 global instance, so every conformance path works with zero wiring. The cost is
-that a consumer wiring a real EL verdict must remember the local override,
+that a consumer wiring a real EL answer must remember the local override,
 nothing forces it.
 
 ## Two classes, one boundary
@@ -56,7 +56,7 @@ set_option autoImplicit false
 
 namespace EthCLLib.Spec
 
-/-- The execution-layer seam: `ExecutionEngine` predicates whose verdict an
+/-- The execution-layer seam: `ExecutionEngine` predicates whose answer an
 external EL owns. Generic over the fork's payload / transaction / execution-request
 types (they are fork-namespaced or shared types a framework class cannot name
 concretely).
@@ -89,7 +89,7 @@ class ExecutionEngine (Payload : Type) (Tx : Type) (Requests : Type) where
 
 /-- The default engine: the optimistic always-`true` mock, the residual EL trust
 boundary of every engine-gated spec branch. Generic, so it serves every fork; a
-consumer wanting a real (or refuting) verdict overrides `[ExecutionEngine]`
+consumer wanting a real (or refuting) answer overrides `[ExecutionEngine]`
 locally with a `letI` at the concrete fork types. -/
 instance instExecutionEngineOptimistic {Payload Tx Requests : Type} :
     ExecutionEngine Payload Tx Requests where

--- a/packages/EthCLLib/EthCLLib/Spec/Forms.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Forms.lean
@@ -89,7 +89,7 @@ def elabForkdef : CommandElab := fun stx => do
 /-- `forkabbrev name … := …`, shaped exactly like `abbrev`. Used for the fork's
 type aliases (`Slot`, `Gwei`, `Root`, …) and for every `Const` entry.
 
-The abbrev-ness is load-bearing, not cosmetic: `@[reducible]` is what lets
+The abbrev-ness does real work here: `@[reducible]` is what lets
 SSZRepr instance synthesis see through `Root` to `Vector UInt8 32`, and what lets
 a symbolic list cap `Const.validatorRegistryLimit` reduce to a literal once a
 concrete `Preset` is injected. Replay re-emits an `abbrev` for the same reason. -/

--- a/packages/EthCLLib/EthCLLib/Spec/Loop.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/Loop.lean
@@ -74,7 +74,7 @@ spec text, so exhausting it is a work-queue item, and `todo` is the class that r
 fuel-out on a `valid: false` step would pass green on a bound we know is wrong. That is the
 same reason `decodeFailure` stays out of `StoreTransitionError.isExpectedRejection`. Both
 current call sites are `on_tick`, whose steps carry no `valid` flag and always run
-`expectedValid := true`, so no verdict rides on this today. The class keeps it that way for
+`expectedValid := true`, so nothing depends on this today. The class keeps it that way for
 the next caller. -/
 def fuelIterateM! {α : Type} {m : Type → Type u} {E : Type} [Monad m] [MonadExcept E m]
     [SpecReject E] (fuel : Nat) (a : α) (what : String) (step : α → m (Step α α)) : m α := do

--- a/packages/EthCLLib/EthCLLib/Tests/InheritanceReplay.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/InheritanceReplay.lean
@@ -4,7 +4,7 @@ import EthCLLib.Spec.Forms
 # `EthCLLib.Tests.InheritanceReplay`: the inheritance-replay self-test
 
 Graduates the Phase 0.2 spike into `EthCLLib` (`PLAN.md` §0.2, §1.1 acceptance).
-It confirms the one load-bearing property of *the inheritance mechanism*: an
+It confirms the one essential property of *the inheritance mechanism*: an
 inherited caller late-binds to the **child's** override of a sibling, the
 open-recursion case a symbol-level copy or alias gets wrong.
 

--- a/packages/EthCLLib/EthCLLib/Tests/TierMerge.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/TierMerge.lean
@@ -12,7 +12,7 @@ three things the per-fork tier split needs (`FRAMEWORK_ARCHITECTURE.md` §4):
 2. **Proof fields ride along.** A well-formedness field replays into the child's
    class, and its `by decide` assignment re-proves against the *child's* value,
    so an overridden number gets a fresh proof with nothing restated.
-3. **Symbolic cap defeq across the bridge.** This is the load-bearing one. With
+3. **Symbolic cap defeq across the bridge.** This is the one that matters most. With
    the preset still a variable, a vector width computed through the parent's
    class must be definitionally the width computed through the child's, or the
    fork upgrade (which copies parent-shaped fields into child-shaped ones before

--- a/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Fulu/Interface.lean
@@ -140,7 +140,7 @@ private def runOperationImpl (P : Preset) (C : Config) (kind : OpKind)
     | .syncAggregate         => (decodeOp (@SyncAggregate P) opBytes).map processSyncAggregate
     | .withdrawals           => (decodeOp (@ExecutionPayload P) opBytes).map processWithdrawals
     -- The standalone execution_payload op runs the in-block handler, gated on the
-    -- mocked execution-engine verdict (`execution.yaml`): a `false` verdict is the
+    -- mocked execution-engine answer (`execution.yaml`): a `false` answer is the
     -- spec's `assert verify_and_notify_new_payload(...)` failing, so the op rejects.
     | .executionPayload      => (decodeOp (@BeaconBlockBody P) opBytes).map (fun body => do
         assert cmeta.executionValid

--- a/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Gloas/ForkChoice.lean
@@ -832,7 +832,7 @@ forkdef verifyExecutionPayloadEnvelopeSignature (state : State) (signedEnv : Sig
   pure (blsVerify pubkey signingRoot signedEnv.signature)
 
 -- The envelope path crosses the execution layer twice: `verify_and_notify_new_payload`
--- inside the verification, and `is_data_available` at the handler. Both verdicts belong to
+-- inside the verification, and `is_data_available` at the handler. Both answers belong to
 -- something outside the vector, so both enter through the framework seams in
 -- `EthCLLib.Spec.Engine` (which carries the optimistic-default rationale for each) rather
 -- than being written as constants here. Scoped to the two declarations that need them; at
@@ -841,7 +841,7 @@ section EngineSeam
 variable [ExecutionEngine ExecutionPayload Transaction ExecutionRequests] [DataAvailability]
 
 /-- `verify_and_notify_new_payload(new_payload_request)` (`gloas/fork-choice.md:657-666`):
-the EL's verdict on the revealed payload. Reads the `[ExecutionEngine]` seam; the trust
+the EL's answer on the revealed payload. Reads the `[ExecutionEngine]` seam; the trust
 boundary and the always-`true` default are documented on `EthCLLib.Spec.ExecutionEngine`,
 including why the commitments reach it unmapped by
 `kzg_commitment_to_versioned_hash`. -/
@@ -859,14 +859,14 @@ forkdef verifyAndNotifyNewPayload (payload : ExecutionPayload)
 /-- `is_data_available(beacon_block_root)` (`gloas/fork-choice.md:243-257`): whether the
 block's column sidecars retrieve and verify. Gloas modified the Fulu signature to take a
 root and retrieve the sidecars itself, through a function the spec marks implementation
-and context dependent, so the verdict reads the `[DataAvailability]` seam. Fulu's own
+and context dependent, so the answer reads the `[DataAvailability]` seam. Fulu's own
 `isDataAvailable` is unaffected: it is handed the columns the step lists and checks them
 for real. -/
 forkdef isDataAvailable (beaconBlockRoot : Root) : Bool :=
   DataAvailability.isDataAvailable beaconBlockRoot
 
 /-- `verify_execution_payload_envelope`: the consensus-side envelope checks, closing with
-the EL's `verify_and_notify_new_payload` verdict. Returns the cache-warmed
+the EL's `verify_and_notify_new_payload` answer. Returns the cache-warmed
 state (the `hashTreeRoot` computed for the block-root check) in
 `Except StoreTransitionError`; the handler stores it back so the warm tree is kept
 rather than thrown away. -/
@@ -900,7 +900,7 @@ forkdef verifyExecutionPayloadEnvelope (state : State) (signedEnv : SignedExecut
   assert (payload.timestamp == expectedTime)
   assert (htr payload.withdrawals == htr (sszGet state payloadExpectedWithdrawals))
 
-  -- The EL verdict, last as in the spec. `bid.blobKzgCommitments` supplies the request's
+  -- The EL answer, last as in the spec. `bid.blobKzgCommitments` supplies the request's
   -- versioned hashes (unmapped, see the seam's docstring); the parent root and the
   -- execution requests come off the envelope.
   assert (verifyAndNotifyNewPayload payload bid.blobKzgCommitments.toArray

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/ForkChoice.lean
@@ -368,7 +368,7 @@ inherit notifyPtcMessages
 inherit onBlock
 inherit verifyExecutionPayloadEnvelopeSignature
 
--- Three verdicts on this fork's paths belong to something outside the vector: the EL's
+-- Three answers on this fork's paths belong to something outside the vector: the EL's
 -- `is_inclusion_list_satisfied` (`heze/fork-choice.md:54-62`) and
 -- `verify_and_notify_new_payload`, plus `is_data_available`'s sidecar retrieval. All three
 -- enter through the framework seams in `EthCLLib.Spec.Engine`, which is where the
@@ -386,7 +386,7 @@ inherit verifyExecutionPayloadEnvelope
 
 /-- `is_inclusion_list_satisfied(execution_payload, inclusion_list_transactions)`
 (`consensus-specs/specs/heze/fork-choice.md:54-62`): the `ExecutionEngine` predicate deciding
-whether a payload includes the required inclusion-list transactions. Its verdict is
+whether a payload includes the required inclusion-list transactions. Its answer is
 EL-implementation-defined (the Engine API answers it against an external EL), so it reads the
 `[ExecutionEngine]` seam rather than a fixed value; the default and the trust boundary are
 documented on `EthCLLib.Spec.ExecutionEngine`. -/
@@ -401,7 +401,7 @@ forkdef isInclusionListSatisfied (payload : ExecutionPayload) (ilTxs : Array Tra
 inclusion-list constraints for `root`. Pure here (returns the updated store); the spec mutates
 in place. `get_inclusion_list_store()` is `store.inclusionListStore`; the required
 transactions are read for the previous slot (`state.slot - 1`) at the default `only_timely =
-True`, and the EL verdict comes from `isInclusionListSatisfied`, which reads the
+True`, and the EL answer comes from `isInclusionListSatisfied`, which reads the
 `[ExecutionEngine]` seam (the spec's `execution_engine` argument, modeled injectably). -/
 forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : State) (root : Root)
     (payload : ExecutionPayload) : StoreTransition (Store map) := do
@@ -421,7 +421,7 @@ forkdef recordPayloadInclusionListSatisfaction (store : Store map) (state : Stat
 `consensus-specs/specs/heze/fork-choice.md:273-300`): the Gloas body with one added step,
 `record_payload_inclusion_list_satisfaction` is called on the verified envelope *before* the
 payload is stored (`fork-choice.md:295`), so `should_extend_payload` can later read the
-recorded verdict. `state` is the pre-verify `block_states[root]`, as in the spec; the warm
+recorded answer. `state` is the pre-verify `block_states[root]`, as in the spec; the warm
 state from `verify_execution_payload_envelope` is kept only for `blockStates`. -/
 forkdef onExecutionPayloadEnvelope (signedEnv : SignedExecutionPayloadEnvelope) : StoreTransition Unit := do
   let store ← get

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/Signing.lean
@@ -12,7 +12,7 @@ signature under `DOMAIN_INCLUSION_LIST_COMMITTEE`. `blsVerifySigned` is the resi
 boundary (the `[CryptoBackend]` seam), as for every other signature predicate; no pure assertion
 pins it. FOCIL adds no state transition, so this is a predicate rather than a transition step,
 though it throws on an out-of-range `validator_index` (the spec's `state.validators[index]`
-`IndexError`) rather than returning a verdict there.
+`IndexError`) rather than returning an answer there.
 -/
 
 set_option autoImplicit false
@@ -30,7 +30,7 @@ message's epoch. Mirrors the Python step-for-step: read `message`, the validator
 `validator_index`, the domain, `compute_signing_root(message, domain)`, then `bls.Verify`.
 
 The signature check itself, `blsVerifySigned`, goes through the `[CryptoBackend]` seam
-(`FRAMEWORK_ARCHITECTURE.md` §1), and no build-enforced pin fixes its verdict. That is the
+(`FRAMEWORK_ARCHITECTURE.md` §1), and no build-enforced pin fixes its answer. That is the
 same trust boundary every signature predicate keeps (Gloas's bid and builder-deposit
 signatures included).
 
@@ -49,7 +49,7 @@ forkdef isValidInclusionListSignature (state : State) (signed : SignedInclusionL
   let message := signed.message
   let index := message.validatorIndex
   -- `validator_index` arrives off the wire, so the spec's `state.validators[index]` raises
-  -- `IndexError` for an out-of-range index rather than yielding a verdict: `sszGetIdx`
+  -- `IndexError` for an out-of-range index rather than yielding an answer: `sszGetIdx`
   -- (→ `outOfBounds`), the monadic safe read, in place of an `if index < size` guard that would
   -- mask the raise as a `false` and read the `Inhabited` default (zero-pubkey) validator.
   let validator ← sszGetIdx (sszGet state validators) index.toNat

--- a/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Heze/State.lean
@@ -7,7 +7,7 @@ At alpha.11 Heze does not change `BeaconState`, so `inherit BeaconState` replays
 field block here unchanged. `state_preamble` declares the boxed `State` and `modifyState`.
 The `Containers.InclusionList` import is the load-order entry: it transitively pulls
 `Heze.Inherited` (the inherited containers) and the `fork Heze from Gloas` lineage that
-`inherit` resolves against. It is load-bearing; do not drop it.
+`inherit` resolves against. It is required; do not drop it.
 -/
 
 set_option autoImplicit false

--- a/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Proofs/UpdateCheckpoints.lean
@@ -21,7 +21,7 @@ namespace the subject itself sits in, leaving `EthCLSpecs.Proofs.Fulu` free.
 ## The shared proof shape
 
 Every proof here decides both of the definition's guards with `by_cases`, then lets
-`simp` reduce the resulting nested record updates. The second guard is load-bearing
+`simp` reduce the resulting nested record updates. The second guard still matters
 even where the statement never mentions it: the definition's outer `if` tests the
 finalized epoch of the store the *inner* `if` already produced, so `simp` cannot
 project either checkpoint field until both branches are settled. Dropping either

--- a/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/PySpecTests/Server.lean
@@ -73,7 +73,7 @@ private def buildRequest (fields : Array String) : IO CaseRequest := do
   let inputPaths  := if fields[7]!.isEmpty then #[] else (fields[7]!.splitOn ",").toArray
   let forkBlock   := (dashToNone fields[8]!).map (·.toNat!)
   -- Optional 10th field: `execution_valid` for `operations/execution_payload` (the
-  -- mocked EL verdict); absent ⇒ `true`.
+  -- mocked EL answer); absent ⇒ `true`.
   let executionValid := (fields[9]?.getD "1") == "1"
 
   let mut inputs : Array ByteArray := #[]
@@ -191,7 +191,7 @@ private def handleForkChoice (iface : ForkInterface) (fields : Array String) : I
       | .spec (.missingKey _)    => "missing store key"
       | .spec (.decodeFailure d) => d
       | .spec (.transition te)   => reprStr te).replace "\t" " " |>.replace "\n" " "
-    -- Route the verdict through `RunError.classify` (which recurses into `.transition`), so a
+    -- Route the answer through `RunError.classify` (which recurses into `.transition`), so a
     -- nested state-transition `.todo` / `.outOfScope` reached on a fork-choice step reports as
     -- xfail / skip rather than a bug. Everything else (decode/container bug, unexpected assert,
     -- missing key, uncaught fault) is a bug on the fork-choice path; per-step `valid:false`

--- a/packages/EthCLSpecs/EthCLSpecs/Tests/GloasForkChoicePins.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Tests/GloasForkChoicePins.lean
@@ -177,8 +177,8 @@ example : pinEnvelopeSigBuilderOob = true := by native_decide
 
 /-! ### The execution-layer seams, refuted
 
-Both verdicts default to `true`, so every conformance vector runs the accepting branch and
-the refuting one is dead to the suite. These pin that the branch exists and that the verdict
+Both answers default to `true`, so every conformance vector runs the accepting branch and
+the refuting one is dead to the suite. These pin that the branch exists and that the answer
 comes from the seam: the same call under the two instances, once each way. `pinRecordRefuted`
 does this for Heze's FOCIL gate; this is the pair for Gloas's two.
 
@@ -187,7 +187,7 @@ every other assert on the envelope path, so a handler-level pin would match on a
 shares with the asserts around it and pass whether or not the seam was consulted. The
 handler wiring is a one-line `assert` over the wrapper each pin drives. -/
 
-/-- The pair of engine verdicts under the optimistic default. Pure `Bool`s off the seam, no
+/-- The pair of engine answers under the optimistic default. Pure `Bool`s off the seam, no
 hashing, so kernel `#guard` closes them. -/
 private def pinEngineOptimistic : Bool × Bool :=
   letI : Preset := minimal

--- a/packages/EthCLSpecs/EthCLSpecs/Tests/HezeForkChoicePins.lean
+++ b/packages/EthCLSpecs/EthCLSpecs/Tests/HezeForkChoicePins.lean
@@ -45,11 +45,11 @@ exercises it, and the pyspec conformance runs answer every engine call through t
 `is_inclusion_list_satisfied = true` default, so the discriminating `false` branch is
 otherwise dead code. This pin drives the predicate on a minimal `Store` directly; the four
 verified/recorded combinations are enumerated one per `#guard` below, each with its expected
-verdict beside it. Everything is hash-free (`is_payload_verified` is a `payloads` membership
+answer beside it. Everything is hash-free (`is_payload_verified` is a `payloads` membership
 test, no `htr`), so kernel `#guard` per the hash-tactic rule.
 
 The pin fixes the recorded bit by hand rather than through the engine, so the
-`isInclusionListSatisfied` verdict itself is out of its reach; `pinRecordRefuted` below
+`isInclusionListSatisfied` answer itself is out of its reach; `pinRecordRefuted` below
 drives that refuting branch through the record path into this gate. -/
 
 /-- The pins' concrete fork-choice monad: the minimal preset over the deterministic
@@ -88,42 +88,42 @@ private def pinPilsStore (payloadPresent : Bool) (recorded : Option Bool) :
       | none   => FcMap.empty
     inclusionListStore := InclusionListStore.empty }
 
-/-- What `pinPils` observed: the predicate's verdict, or which class of throw rejected it.
+/-- What `pinPils` observed: the predicate's answer, or which class of throw rejected it.
 
 Naming the class is the point. Folding every `.error` to a single marker pins only *that* a
 throw happened, so a regression from the spec's `assert` to an uncaught `.missingKey` would
 still satisfy the pin, and that swap is exactly the difference between a faithful rejection and
 a bug. `pinCommitteeThrows` below holds the same line from the other side, asserting a reject is
 *not* an expected rejection. -/
-private inductive PilsVerdict where
+private inductive PilsAnswer where
   /-- The predicate ran clean and answered `b`. -/
-  | verdict (b : Bool)
+  | answer (b : Bool)
   /-- The spec's `assert root ∈ payload_inclusion_list_satisfaction` fired: the expected reject. -/
   | assertReject
   /-- Any other throw (a bare `.missingKey` read, a decode miss). Never expected at this gate. -/
   | otherReject
   deriving DecidableEq
 
-/-- The predicate's verdict on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
+/-- The predicate's answer on `pinPilsStore payloadPresent recorded`. The `letI`s re-supply the
 preset / hasher the `forkdef` parameters want (Lean re-synthesizes them rather than reading the
 store's fixed type), the same pattern the `InclusionListStore` pins in this file use. -/
-private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : PilsVerdict :=
+private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : PilsAnswer :=
   letI : Preset := minimal
   letI : HasherTag := fastHasherTag
   let store := pinPilsStore payloadPresent recorded
   -- Run the predicate concretely and match on *which* reject fired: `.assert` is the spec's
   -- own guard, anything else is our bug.
   match (isPayloadInclusionListSatisfied (map := treeMap) store pinPilsRoot : PinM Bool).run store with
-  | .ok b _              => .verdict b
+  | .ok b _              => .answer b
   | .error (.assert _) _ => .assertReject
   | .error _ _           => .otherReject
 
 -- verified + recorded `false` ⇒ `false` (do not extend this payload).
-#guard pinPils true (some false) = .verdict false
+#guard pinPils true (some false) = .answer false
 -- verified + recorded `true` ⇒ `true`.
-#guard pinPils true (some true) = .verdict true
+#guard pinPils true (some true) = .answer true
 -- unverified (root ∉ payloads) ⇒ `false`, even with the satisfaction bit recorded `true`.
-#guard pinPils false (some true) = .verdict false
+#guard pinPils false (some true) = .answer false
 -- verified but no recorded entry ⇒ the spec's `assert root ∈ payload_inclusion_list_satisfaction`
 -- now *rejects* (a state the invariant rules out) rather than reading a `lookupD` default. The
 -- `.assertReject` (over a bare "it threw") is what a regression to `.missingKey` would break.
@@ -131,14 +131,14 @@ private def pinPils (payloadPresent : Bool) (recorded : Option Bool) : PilsVerdi
 -- unverified AND no recorded entry ⇒ still the spec's assert, because
 -- `assert root in store.payload_inclusion_list_satisfaction` precedes the verified check
 -- (`heze/fork-choice.md:199-212`). A model that tested `is_payload_verified` first would answer
--- `.verdict false` here, and the other three quadrants could not tell the difference.
+-- `.answer false` here, and the other three quadrants could not tell the difference.
 #guard pinPils false none = .assertReject
 
 /-! ### Build-enforced pins (vectorless): the FOCIL fork-choice helpers
 
 `get_inclusion_list_due_ms`, `record_payload_inclusion_list_satisfaction`, and `on_inclusion_list`
 ship no conformance vector either. These drive them end-to-end so a future edit can't regress them
-silently: the deadline constant, the recorded EL verdict, and the timeliness bit `on_inclusion_list`
+silently: the deadline constant, the recorded EL answer, and the timeliness bit `on_inclusion_list`
 threads into `process_inclusion_list`. -/
 
 /-- `get_inclusion_list_due_ms = INCLUSION_LIST_DUE_BPS * SLOT_DURATION_MS // BASIS_POINTS`. Under
@@ -189,13 +189,13 @@ private def pinPopulatedState : @EthCLSpecs.Heze.BeaconState minimal :=
   let vals := (Array.replicate Const.slotsPerEpoch activeValidator).foldl (·.push ·) base.validators
   { base with slot := 1, validators := vals }
 
-/-- `record_payload_inclusion_list_satisfaction` records the engine verdict at `root`: with
+/-- `record_payload_inclusion_list_satisfaction` records the engine answer at `root`: with
 the optimistic default (`isInclusionListSatisfied = true`) it writes `true`. `slot := 1` clears the
 `state.slot != 0` underflow throw, and the populated validator set (`pinPopulatedState`)
 gives `slot - 1` a non-empty beacon committee, so the record path runs end-to-end through
-`getInclusionListCommittee` without hitting its empty-committee throw. The recorded verdict is
+`getInclusionListCommittee` without hitting its empty-committee throw. The recorded answer is
 `true` regardless of the required transactions (the optimistic oracle ignores `ilTxs`), so what
-this pin fixes is the record path writing the verdict at the right key.
+this pin fixes is the record path writing the answer at the right key.
 
 Lean mechanics: the forkdef wants the boxed `State` (`State = SSZ.Box HasherTag.H
 BeaconState`), so `state` is a `FastBox` of `pinPopulatedState`. `FastBox` is
@@ -212,13 +212,13 @@ private def pinRecordSatisfied : Option Bool :=
   | .error _ _  => none
 example : pinRecordSatisfied = some true := by native_decide
 
-/-- The recorded verdict and the gate's answer, or the reject that fired. Keeping `threw`
+/-- The recorded bit and the gate's answer, or the reject that fired. Keeping `threw`
 separate is the whole point: the *gate* arm is where a tuple collapses, since a throw from
 `isPayloadInclusionListSatisfied` would hand back `(some false, false)`, byte-identical to the
 legitimate refusal this pin exists to check. The record-path arm was already distinguishable
 (`(none, false)`); this makes both so. -/
-private inductive RecordVerdict where
-  /-- The record path completed: the stored bit and the gate's verdict. -/
+private inductive RecordAnswer where
+  /-- The record path completed: the stored bit and the gate's answer. -/
   | recorded (value : Option Bool) (gate : Bool)
   /-- Either the record path or the gate rejected. -/
   | threw
@@ -229,10 +229,10 @@ private inductive RecordVerdict where
 default (`EthCLLib.Spec.Engine` documents the design). The record path writes `false` at a
 *verified* `root`, and `isPayloadInclusionListSatisfied` then refuses to extend it. That
 covers the branch every conformance vector leaves dead, end-to-end: oracle → recorded
-verdict → gate. `pinPilsStore true none` puts `root ∈ payloads`, so the membership check
+answer → gate. `pinPilsStore true none` puts `root ∈ payloads`, so the membership check
 passes and the recorded bit is what decides. `State` is FFI-backed (`FastBox`), so
 `native_decide`. -/
-private def pinRecordRefuted : RecordVerdict :=
+private def pinRecordRefuted : RecordAnswer :=
   letI : Preset := minimal
   letI : Config := minimalConfig
   letI : HasherTag := fastHasherTag

--- a/packages/EthCLSpecs/PySpecTests/README.md
+++ b/packages/EthCLSpecs/PySpecTests/README.md
@@ -12,7 +12,7 @@ cache stays warm (`FRAMEWORK_ARCHITECTURE.md` §13.3).
   and `ServerClient` (the long-lived server with re-spawn on death).
 - `conftest.py` — the `server` session fixture and the `case` parametrization;
   options `--preset`, `--fork`, `--subset`, `--tag`, `--no-crypto-cache`.
-- `test_pyspec.py` — one test per case; the reject-faithfulness verdict
+- `test_pyspec.py` — one test per case; the reject-faithfulness check
   (`bug` fails hard, `todo` is `xfail` the Phase-2 work-queue, otherwise the case
   must pass).
 

--- a/packages/EthCLSpecs/PySpecTests/harness.py
+++ b/packages/EthCLSpecs/PySpecTests/harness.py
@@ -310,7 +310,7 @@ def build_request(case: Case, tmpdir: Path) -> str:
     blocks_count = int(meta.get("blocks_count", len(blocks)))
     fork_epoch = meta.get("fork_epoch", None)
     fork_block = meta.get("fork_block", None)
-    # operations/execution_payload carries the execution-engine verdict in execution.yaml.
+    # operations/execution_payload carries the execution-engine answer in execution.yaml.
     execution_valid = 1
     if case.runner == "operations" and case.handler == "execution_payload":
         ev_path = case.path / "execution.yaml"

--- a/packages/EthCLSpecs/PySpecTests/test_pyspec.py
+++ b/packages/EthCLSpecs/PySpecTests/test_pyspec.py
@@ -1,7 +1,7 @@
 """The pyspec test: one parametrized test per vector case.
 
 The harness builds a request from the case on disk and submits it to the
-worker's Lean server; the server returns the driver's classify verdict. The
+worker's Lean server; the server returns the driver's classify result. The
 assertion follows the reject-faithfulness audit (`SPECS_ARCHITECTURE.md` §10.2):
 
 - `bug` (`outOfBounds` / `missingKey` on well-formed input, or a server crash) is

--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -95,7 +95,7 @@ the lineage edge.
 
 **Validated against the real vectors.** The full in-scope suite passes at both
 the `minimal` and `mainnet` presets, for all three forks (Fulu, Gloas, Heze),
-pinned to release `v1.7.0-alpha.11`. The verdict model is honest. An out-of-range read or a crash
+pinned to release `v1.7.0-alpha.11`. The error model is honest. An out-of-range read or a crash
 is a hard failure, and an unimplemented branch is a visible `xfail`. Every
 passing vector reflects a real match or a faithful rejection.
 

--- a/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/FRAMEWORK_ARCHITECTURE.md
@@ -13,7 +13,7 @@ author's side.
 A consensus spec sits at a small intersection. A reader fluent in the Python
 `pyspec` may not have written a Lean macro; a reader fluent in Lean may not know
 what a hash-tree-root is. This document teaches both sides as it goes. Where a
-Lean idiom is load-bearing, it gets a sentence the first time it appears; where
+Lean idiom carries the meaning, it gets a sentence the first time it appears; where
 a spec term needs grounding, it gets one too.
 
 The framework owns the plumbing. It owns the arithmetic, the SSZ machinery, the
@@ -272,8 +272,8 @@ pipeline can `inherit` it.
 
 Containers and structures follow the same two cases as functions. An unchanged one
 is `inherit`ed; a changed or new one is declared in full. There is no field-merge
-form, no append form, and no macro-level `extends`. SSZ field order is
-load-bearing for serialization and Merkleization, so a fork that changes a
+form, no append form, and no macro-level `extends`. SSZ field order decides
+the serialization and the Merkleization, so a fork that changes a
 container restates its complete field list. The order stays explicit on the page
 and checked by conformance, rather than computed from a parent by some merge rule
 the reader cannot see. A full declaration regenerates the SSZ instances over its
@@ -528,7 +528,7 @@ keeping with the project's stringly-typed-is-a-smell principle. The two exceptio
 are `assert`'s `descr` (rendered from the asserted expression's syntax) and
 `todo`'s `what`. Both are diagnostic strings, printed only on a vector mismatch and
 never branched on, since the vectors record valid-or-invalid and never a reason.
-The error *constructor* is what is load-bearing, and the pyspec harness reads
+The error *constructor* is what counts, and the pyspec harness reads
 it in its classify mode:
 
 | Constructor | Classify-mode meaning |
@@ -789,7 +789,7 @@ The access primitives are SizzLean's generic macros, used directly.
 | `sszModify state field[i]! := g` / `… as x => body` | `state.field[i] = g(state.field[i])` | read-modify-write of one path, named once; `:= g` applies a function, `as x => body` binds the current value (`fun`-free, for `{ x with … }`); sugar over `sszUpdate … := … (sszGet …)` |
 | `modifyState fun state => …` | several `state.field = …` lines | updates several fields of the threaded state at once |
 | `getStateRoot` | `hash_tree_root(state)` | the Merkle root of the threaded state, keeping the cache-warmed box (`stateRoot` returns the root with the box for a non-monadic context, `stateRoot!` discards it, terminal-only) |
-| `sszGetIdx (sszGet state F) i` / `xs[i]!` | `xs[i]` | element read; a load-bearing (data-derived) index uses `sszGetIdx`, surfacing `outOfBounds idx bound`, never a crash; a statically-bounded or `assert`-guarded index uses the total `xs[i]!` |
+| `sszGetIdx (sszGet state F) i` / `xs[i]!` | `xs[i]` | element read; a data-derived index uses `sszGetIdx`, surfacing `outOfBounds idx bound`, never a crash; a statically-bounded or `assert`-guarded index uses the total `xs[i]!` |
 
 ```lean
 def incrementSlot : StateTransition Unit := do
@@ -800,7 +800,7 @@ def checkSlot (expected : Slot) : StateTransition Unit := do
   assert (sszGet state slot == expected)
 ```
 
-Indexed access carries a deliberate split. A field projection stays pure. A load-bearing
+Indexed access carries a deliberate split. A field projection stays pure. A data-derived
 index, one a data field supplies with no structural bound, reads through `sszGetIdx` (or
 `bitlistGetIdx` for a `Bitlist`) and returns through the error channel, surfacing
 `outOfBounds idx bound` rather than a panic, with a single `liftErr` adapter joining the two
@@ -1250,7 +1250,7 @@ Seven anti-patterns the framework avoids in every definition, in order of severi
    equivalence axioms are only the concrete-bytes fallback. A spec function that
    itself calls some other extern-opaque primitive would force compiler axioms into
    every proof above it.
-5. **A load-bearing `arr[i]!` in a monadic step.** A data-derived index (a validator /
+5. **A data-derived `arr[i]!` in a monadic step.** A data-derived index (a validator /
    committee / queue index an operation supplies) with no structural bound reads through
    `sszGetIdx`, surfacing `outOfBounds idx bound` (§7), so a bad index lands in the
    `likelyBug` bucket and a proof need not unfold through the `Inhabited` default. Total

--- a/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
+++ b/packages/EthCLSpecs/docs/IMPLEMENTATION_NOTES.md
@@ -209,7 +209,7 @@ with no G1 add/neg and no precomputed-aggregate dependency.
 ## Engine seam
 
 `EthCLLib.Spec.Engine` is the execution-layer sibling of the crypto seam: a spec
-function whose verdict belongs to an external execution client routes through a
+function whose answer belongs to an external execution client routes through a
 typeclass. Unlike `CryptoBackend` these ship a global default, the optimistic instance
 answering the constant `true` (the seam table in `FRAMEWORK_ARCHITECTURE.md` §1). A
 local `letI` overrides it.
@@ -256,7 +256,7 @@ runner selects fork × preset (`pyspec_server [fork] [preset]`).
 ## State access, indexing, and the error model
 
 Reads and writes go through `sszGet` / `sszUpdate`. The index accessor is chosen by three
-questions: is the index _load-bearing_ (data-derived and not otherwise bounded), has a
+questions: is the index _data-derived_ (supplied by a data field and not otherwise bounded), has a
 validation already proved it in range, and is a reject channel in scope (a monadic step or
 an `Except` query) at the read.
 
@@ -577,15 +577,15 @@ MIN_VALIDATOR_WITHDRAWABILITY_DELAY < 2^64` before the write, so an over-range c
   `sanity/blocks`. The timestamp is `compute_time_at_slot(state, state.slot)`, the
   millisecond form every other clock site in the tree reads, and the standalone
   `operations/execution_payload` format threads the
-  test's `execution.yaml` engine verdict via `CaseMeta.executionValid` to model an
+  test's `execution.yaml` engine answer via `CaseMeta.executionValid` to model an
   engine rejection. The blob-parameter bound is enforced where the operation format
   supplies it. The skip is safe for the in-scope corpus by audit, not just by
   assumption: every invalid `sanity/blocks` / `finality` / `random` case (82, across
   both presets and both forks) rejects through a consensus `assert` the in-block
   pipeline models, signatures, blob-count limits, payload-attestation checks, the
   execution-requests root, slot / parent consistency, duplicate operations, the state
-  root, so none reaches a clean run that an engine verdict alone would have rejected.
-  An invalid block that depended on the engine verdict would run clean and surface as a
+  root, so none reaches a clean run that an engine answer alone would have rejected.
+  An invalid block that depended on the engine answer would run clean and surface as a
   `likelyBug` "expected a rejection but ran clean", not a silent pass.
 
 `CryptoBackend.aggregatePubkeys` exists because `get_next_sync_committee` needs BLS
@@ -665,7 +665,7 @@ and the diff is confined to the fork-choice inclusion-list layer. FOCIL ships no
 behavioral conformance vector at the alpha.11 pin, so the divergences below are anchored
 to the pinned spec text and the `EthCLSpecs/Heze/ForkChoice.lean` pins.
 
-- **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its verdict to
+- **`is_inclusion_list_satisfied`** (`heze/fork-choice.md:54-62`) defers its answer to
   `ExecutionEngine.is_inclusion_list_satisfied`, an Engine-API call against an external
   execution client. This harness has no execution layer, so the call goes through the
   `[ExecutionEngine]` typeclass (the Engine seam above), whose default instance answers
@@ -756,7 +756,7 @@ was a real reject-faithfulness gap until set per preset:
 `pyspec_server` is a long-lived, crash-tolerant loop (a malformed request reports failed
 and the loop continues), one per `pytest-xdist` worker via the `conftest.py` session
 fixture (re-spawn on death). `harness.py` does acquisition / walk / snappy / request
-encoding; `test_pyspec.py` is the reject-faithfulness verdict. The server emits one
+encoding; `test_pyspec.py` is the reject-faithfulness check. The server emits one
 tab-separated line per case, so two detail sources that could embed a newline and
 desync the worker are flattened at the chokepoint: `EthCLLib.Spec.sanitizeDescr` takes
 the first trimmed line of an `assert` descriptor, and `CaseResult.render` flattens any

--- a/packages/EthCLSpecs/docs/PLAN.md
+++ b/packages/EthCLSpecs/docs/PLAN.md
@@ -129,7 +129,7 @@ reference them rather than re-deriving them.
 | Dependency | Why | Gates |
 |---|---|---|
 | The SizzLean preset-resolved symbolic-cap derive blocks `forkcontainer` | a container is `[Preset]`-parameterized and its field widths are `Const.*` projections that stay symbolic until the preset resolves; `SSZRepr` has to derive over those caps and reduce once `[Preset]` is concrete | the container front-end (Phase 1) |
-| The three spikes gate building on the mechanisms they confirm | the fork-inheritance replay, the `[CryptoBackend]` instance, and vector acquisition plus SSZ decode are load-bearing pieces chosen but not yet exercised; a wrong assumption found after the framework is built is expensive to unwind | `forkdef` / `forkcontainer` / `inherit`, every crypto-gated step, and the whole harness input edge (Phase 1 onward) |
+| The three spikes gate building on the mechanisms they confirm | the fork-inheritance replay, the `[CryptoBackend]` instance, and vector acquisition plus SSZ decode are essential pieces chosen but not yet exercised; a wrong assumption found after the framework is built is expensive to unwind | `forkdef` / `forkcontainer` / `inherit`, every crypto-gated step, and the whole harness input edge (Phase 1 onward) |
 | The walking skeleton must be green before Fulu broadens | one green format end-to-end through the per-worker Lean server proves the framework, the harness, the crypto seam, and the inheritance on the smallest surface; broadening onto unproven plumbing multiplies debugging cost | the full Fulu port (Phase 2) |
 | Mainnet performance is smoke-tested once the core transition is green | "both presets from day one" is true at the type level; performance is not, mainnet states are far larger and exercise the cache and FFI hasher on bigger trees | the mainnet hardening (Phase 4) |
 
@@ -247,7 +247,7 @@ works.
 
 ### 1.1 The framework skeleton (`EthCLLib`)
 
-**Goal.** Stand up the framework's load-bearing core: the parts every later step and
+**Goal.** Stand up the framework's core: the parts every later step and
 container depend on, and nothing more.
 
 **Deliverables.**

--- a/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
+++ b/packages/EthCLSpecs/docs/SPECS_ARCHITECTURE.md
@@ -15,7 +15,7 @@ siblings by section title so the links resolve.
 A consensus spec sits at a small intersection. A reader fluent in the Python
 `pyspec` may not have written Lean; a reader fluent in Lean may not know what
 `process_epoch` does. This document teaches both sides as it goes. Where a spec
-term needs grounding it gets a sentence; where a Lean idiom is load-bearing it
+term needs grounding it gets a sentence; where a Lean idiom carries the meaning it
 gets one too.
 
 The thesis it earns: the spec author writes consensus logic and nothing else.
@@ -424,8 +424,8 @@ container front-end owns why these stay non-SSZ.
 
 Fork-incremental declaration follows two cases, the same two that functions follow.
 An unchanged container is `inherit`ed, not rewritten in the fork. A changed or new
-one is declared in full. There is no append form. SSZ field order is load-bearing
-for serialization and Merkleization, so a fork that changes a container restates
+one is declared in full. There is no append form. SSZ field order decides the serialization
+and the Merkleization, so a fork that changes a container restates
 its complete field list explicitly on the page, checked by conformance, rather
 than merging onto a parent by a rule the reader cannot see.
 
@@ -904,7 +904,7 @@ not built. Both presets run; mainnet runs on demand rather than on every CI pass
 
 The audit reads the classify-mode bucket of the error model against each vector's
 valid-or-invalid marking. The vectors are the operational reference, so matching the
-verdict is necessary but not sufficient; the audit checks that the spec rejects at
+answer is necessary but not sufficient; the audit checks that the spec rejects at
 the same point and for the same reason the upstream pyspec does.
 
 | Vector marking | Faithful result | A failure |

--- a/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
+++ b/packages/EthCLSpecs/docs/SPEC_AUTHORING_MODEL.md
@@ -583,7 +583,7 @@ overridden constant, must resolve to the child fork's version.
 
 Containers and structures follow the same two cases as functions. An unchanged
 one is `inherit`ed; a changed or new one is declared in full. There is no
-field-merge or append form. SSZ field order is load-bearing, so a fork that
+field-merge or append form. SSZ field order decides the encoding, so a fork that
 changes a container restates its complete field list, explicit on the page and
 checked by conformance, rather than computing the order from a parent. A full
 declaration regenerates the SSZ instances over its field list.

--- a/packages/LeanHazmatSha256/lakefile.lean
+++ b/packages/LeanHazmatSha256/lakefile.lean
@@ -66,7 +66,7 @@ unsafe def opensslLinkArgs : Array String :=
 appended to `cShimFlags` so the C shims find `<openssl/evp.h>`. On
 Debian / Ubuntu the headers live at `/usr/include` and no explicit
 `-I` is needed; on macOS Homebrew openssl@3 is keg-only and the `.pc`
-file's `-I/opt/homebrew/opt/openssl@3/include` is load-bearing. Empty
+file's `-I/opt/homebrew/opt/openssl@3/include` is required. Empty
 fallback keeps Debian working when pkg-config is missing. -/
 unsafe def opensslCFlags : Array String :=
   runPkgConfig #["--cflags", "libcrypto"] #[]

--- a/packages/LeanPoseidon/docs/ARCHITECTURE.md
+++ b/packages/LeanPoseidon/docs/ARCHITECTURE.md
@@ -759,7 +759,7 @@ This document is binding on layout and dependencies. CLAUDE.md is binding
 on style and discipline: imports first; `set_option autoImplicit false`
 per file; PascalCase for types, lowerCamelCase for defs; namespacing under
 `LeanPoseidon.*` (and `LeanPoseidonProofs.*`); no committed `#eval` / `#check` /
-`#print` (`example : … := by …` and `#guard` are the load-bearing
+`#print` (`example : … := by …` and `#guard` are the
 alternatives); structural recursion or `termination_by` over `partial def`.
 
 **Literate by default.** Every `*.lean` file opens with a `/-! … -/`

--- a/packages/LeanPoseidonProofs/LeanPoseidonProofs/Padding.lean
+++ b/packages/LeanPoseidonProofs/LeanPoseidonProofs/Padding.lean
@@ -15,7 +15,7 @@ The argument (mapped to `List` via `Array.toList_inj`): `pad xs` is
 element** is the marker `1` (if `k = 0`) or a pad `0` (if `k = 1`); since
 `1 ≠ 0`, equal outputs force equal `k`, and with the equal total length this
 forces `|xs| = |ys|`. Equal prefix lengths then strip the shared suffix
-(`List.append_inj_left`). `1 ≠ 0` is the load-bearing field fact.
+(`List.append_inj_left`). `1 ≠ 0` is the field fact the argument turns on.
 -/
 
 set_option autoImplicit false

--- a/packages/SizzLean/PySpecTests/test_pyspec.py
+++ b/packages/SizzLean/PySpecTests/test_pyspec.py
@@ -1,7 +1,7 @@
 """The ssz_generic pyspec test: one parametrized test per vector case.
 
 The harness builds a request from the case on disk and submits it to the worker's
-`ssz_generic_runner`; the runner returns its classify verdict. The assertion
+`ssz_generic_runner`; the runner returns its classify result. The assertion
 follows the same model as the EthCLSpecs harness:
 
 - a shape outside SizzLean's `SSZType` universe (the progressive / stable /

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Node.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Node.lean
@@ -29,7 +29,7 @@ fraction of slot time on hashing.
 The Tree layer is the cache. Each `pair` node remembers its root; an
 incremental `setAt` only invalidates the spine, leaving the rest of
 the tree's roots intact. The contract, that the cached root equals
-the spec root, is the load-bearing property tested by the
+the spec root, is the property tested by the
 `TreeBackedCoherence` and `TreeBackedSetField` gates.
 
 ## Lean idioms used here

--- a/packages/SizzLean/SizzLean/Hasher/Class.lean
+++ b/packages/SizzLean/SizzLean/Hasher/Class.lean
@@ -55,7 +55,7 @@ even before any instance is defined. The class opens as an instance
 binder and both fields project cleanly.
 
 The `(H := H)` named-argument form on `Hasher.combine` and
-`Hasher.hash` is *load-bearing*: because `H` is a
+`Hasher.hash` is *required*: because `H` is a
 phantom tag (it doesn't appear in either method's argument or
 result types), instance synthesis can't recover it from `b₁ b₂`.
 Naming it explicitly resolves the ambiguity. Downstream files

--- a/packages/SizzLean/SizzLean/Repr/Deriving.lean
+++ b/packages/SizzLean/SizzLean/Repr/Deriving.lean
@@ -237,7 +237,7 @@ parameterised exactly like the structure. The binder name is the
 parameter's `userName`, which is also how the field-type Syntax below
 refers to it (delaboration renders an fvar by its `userName`), so the
 two line up by name on re-elaboration. Preserving `[]` for an instance
-parameter (e.g. `[Preset]`) is load-bearing: it keeps that parameter a
+parameter (e.g. `[Preset]`) is required: it keeps that parameter a
 *local instance* so the field shapes' preset-resolved projections and
 any nested `SSZRepr` synthesis still find it.
 

--- a/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
+++ b/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
@@ -224,7 +224,7 @@ private def zeroHashAtDepth (H : Type) [Hasher H] (d : Nat) : ByteArray :=
 
 /-- Pair adjacent chunks at tree level `lvl`, using `ZERO_HASHES[lvl]`
 as the right sibling for an odd-length tail. The level argument is
-load-bearing for correctness: at level `k`, the phantom right
+required for correctness: at level `k`, the phantom right
 sibling of a lone-tail interior node is an all-zero subtree of
 depth `k`, whose root is `ZERO_HASHES[k]`, *not* `zero32` (which
 would be wrong for `k > 0`).

--- a/packages/SizzLean/SizzLean/Spec/Interp.lean
+++ b/packages/SizzLean/SizzLean/Spec/Interp.lean
@@ -115,7 +115,7 @@ the two sides are definitionally equal; `rfl` is rejected by
 elaboration otherwise. Type equality is propositional (not
 `Decidable`) in Lean 4, so the `example := rfl` form is the
 correct idiom here; CLAUDE.md explicitly lists it as the
-load-bearing alternative to forbidden
+alternative to forbidden
 `#eval` / `#check` / `#print`.
 
 Under the hood, `rfl` here is `@rfl Type (SSZType.interp …)`. Lean

--- a/packages/SizzLean/SizzLean/Spec/Serialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Serialize.lean
@@ -16,7 +16,7 @@ Per spec *§Serialization, Basic types*, every multi-byte integer
 carries the eight least-significant bits. `uint16LE`, `uint32LE`,
 `uint64LE` below emit exactly this layout.
 
-## Container offset arithmetic: the load-bearing fiddly bit
+## Container offset arithmetic: the fiddly bit
 
 A container with fields `f₁..fₖ` is encoded as a *fixed-size prefix*
 followed by a *variable-size body region*. Each fixed-size field

--- a/packages/SizzLean/SizzLeanTests/ElementSurface.lean
+++ b/packages/SizzLean/SizzLeanTests/ElementSurface.lean
@@ -13,7 +13,7 @@ Two groups:
   so the three reads behave like `Array`'s: `xs[i]'h` reads with an in-bounds
   proof, `xs[i]?` is a real bounds check (`none` past the end), and `xs[i]!`
   returns the element type's `default` past the end. The `?` / proof forms are
-  the load-bearing gate here: the previous `fun _ _ => True` predicate made
+  the real gate here: the previous `fun _ _ => True` predicate made
   `xs[i]?` *always* `some`, so a past-the-end read never reported `none`.
 * **Collection surface.** `toArray` / `toList` / `foldl` / `map` / `mapCap` / `push` /
   `any` / `all` / `findIdx?` / `contains` and the `for x in xs` (`ForIn`) loop on

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -718,8 +718,8 @@ common case of "fix one hasher across many content types" becomes
 
 The two type names are *the same type* (`CachedSSZ` is an `abbrev`
 over `TreeBacked`). `TreeBacked` is the *internal* spelling used
-inside `packages/SizzLean/SizzLean/Cache/TreeBacked.lean` where the Merkle tree is
-load-bearing (gindex paths, `setManyAt` walker, cache slots);
+inside `packages/SizzLean/SizzLean/Cache/TreeBacked.lean` where the Merkle tree does
+the work (gindex paths, `setManyAt` walker, cache slots);
 `CachedSSZ` is the *external* spelling the library presents to
 users who care about "a cached SSZ value" and not the underlying
 tree. The update surface `sszUpdate` lives under `packages/SizzLean/SizzLean/Cache/`
@@ -1304,7 +1304,7 @@ graph LR
   invariant maintained by smart constructors, not a kernel-checked
   proposition).
 - The deriving handler's emitted iso (it produces `rfl` proofs, which
-  *are* kernel-checked; the metaprogramming itself is not load-bearing).
+  *are* kernel-checked; the metaprogramming itself is not trusted).
 - Eth-types instances (just `deriving SSZRepr` on plain structures).
 - Conformance vectors (test data; their results funnel through
   `native_decide` so each *axiom* is in TCB, but the vectors themselves
@@ -1456,10 +1456,10 @@ This document is binding on layout and dependencies. CLAUDE.md is binding
 on style and discipline: imports first; `set_option autoImplicit false`
 per file; PascalCase for types, lowerCamelCase for defs; namespacing
 under `SizzLean.*`; no committed `#eval` / `#check` / `#print`
-(`example : … := by …` and `#guard` are the load-bearing alternatives);
+(`example : … := by …` and `#guard` are the alternatives);
 structural recursion or `termination_by` over `partial def`.
 
-The load-bearing convention specific to this library is **literate by
+The main convention specific to this library is **literate by
 default**:
 
 - Every `*.lean` file under `SizzLean/` opens with a `/-! … -/` module

--- a/packages/SizzLean/docs/OPTIMISATION.md
+++ b/packages/SizzLean/docs/OPTIMISATION.md
@@ -346,7 +346,7 @@ element.
 
 ### Coherence invariant and its safety net
 
-The single load-bearing invariant on the cache layer:
+The single invariant on the cache layer:
 
 > For every `t : TreeBacked H T`, `t.hashTreeRootCached =
 > SSZ.hashTreeRoot H t.view`.

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -247,7 +247,7 @@ spec functions in Phase 3.
 The cached Merkle-tree work (`Tree`, `TreeBacked`) that originally
 lived here as the "production-primitives track" has moved to
 Phase 4. It's a *performance* layer, asserted equivalent to the
-spec rather than load-bearing for correctness, so it earns its
+spec rather than required for correctness, so it earns its
 keep after empirical conformance validates the spec it sits on
 top of. Same "validate first, then build" principle the proof
 work in Stage 18 follows.
@@ -438,7 +438,7 @@ several independent satellites:
   serialise. `Node` is the library; `setAt` works on it; `TreeBacked`
   is the user-facing scaffold (14a); `Node.ofShape` makes the cache
   *useful* (14b); cached `setField` / `setIndex` (14c) is the
-  load-bearing operation; **`sszUpdate t with f := v, g := w`
+  central operation; **`sszUpdate t with f := v, g := w`
   syntax (14d)** ships the ergonomic surface plus a per-statement
   batched walker (`setManyAt`). This whole chain lands before any
   perf work because the perf optimisations in Stage 17 all assume
@@ -964,7 +964,7 @@ gates moved from `packages/SizzLean/SizzLeanTests/` to a *separate*
 `lean_lib SizzLeanTests` at namespace `Tests.*`.
 Default `lake build` builds only the library proper (the
 in-file NIST §B gates in `Hasher/Sha256Spec.lean` plus structural
-lemmas stay there, they're load-bearing for the spec's
+lemmas stay there, they're required for the spec's
 correctness at definition time). `lake build SizzLeanTests`
 runs the full empirical suite (CAVP, randomised property tests,
 `TreeBacked` coherence sweeps). Lets day-to-day iteration stay

--- a/packages/SizzLean/lakefile.lean
+++ b/packages/SizzLean/lakefile.lean
@@ -149,7 +149,7 @@ lean_lib SizzLeanTests where
 -- Each scenario's measurement column lives in its own
 -- `SizzLeanBench/Scenarios/<Name>.lean` file.
 --
--- `precompileModules := true` is load-bearing for the bench: without
+-- `precompileModules := true` is required for the bench: without
 -- it, the scenario for-loops and the `runBench` driver run as
 -- bytecode through Lean's interpreter even though `ssz_bench` is a
 -- native binary, measuring the interpreter, not the library. With


### PR DESCRIPTION
## Summary

Brings the writing-style section in line with the one in the sibling
`phisut` project: Simplified Technical English plus Orwell's six rules,
applied to every word written for this repo. Then removes the two banned
words that were most common in the existing prose, `load-bearing` and
`verdict`.

## What changed

**`CLAUDE.md`** (commit 1)

- The section covers code comments, documentation, commit messages,
  GitHub issues and PRs, and replies in conversation. One standard, so
  prose keeps its register when it moves from a chat reply into a
  docstring.
- New: the Simplified Technical English core. One word one meaning, one
  instruction per sentence, short sentences, name the actor, keep the
  articles, no noun stacks.
- New: Orwell's six rules, with the narrow rule 6 exemption for clarity.
- Rule 5's carve-out lists the vocabulary this repo actually uses,
  surveyed from every `.lean` comment and `.md` file, split across Lean
  and type theory, SSZ, the consensus specs, and crypto / FFI. A second
  paragraph names the house terms of art (`seam`, `tier`, `pin`, `gate`,
  `fixture`, `conformance`, `differential test`, `oracle`), which the
  guide was silent on before.

**Repo prose** (commit 2, 45 files)

- `load-bearing`, 43 sites, each taking the word that fits: `required`
  for something that must be present, `data-derived` for an index a data
  field supplies, `decides the encoding` for SSZ field order, plus
  `matters`, `essential`, `the real gate`, `does the work`.
- `verdict`, 49 sites. `answer` where a predicate or the execution layer
  decides something, `result` where the pyspec driver classifies a case.
- Three test-only identifiers rename with it in
  `EthCLSpecs/Tests/HezeForkChoicePins.lean`: `PilsVerdict` →
  `PilsAnswer`, `RecordVerdict` → `RecordAnswer`, and the `.verdict`
  constructor → `.answer`.

No behavior changes. The only non-comment edits are those three
identifiers.

## Test plan

- [x] `lake build` (full monorepo, on the pinned toolchain) is green.
- [x] Per-package test suites pass:
  - [ ] `lake build LeanSha256Tests`
  - [ ] `lake build SizzLeanTests`
  - [ ] `lake build EthCLSpecs.Tests`, green at 491 modules. This is the
        module holding the renamed inductives, and its `#guard` pins
        exercise the `.answer` constructor.
- [ ] If this touches spec types or cache behaviour:
      `just ethcl-pyspec` is green.

Not run: the pyspec sweep and the other package suites. This PR touches
no spec type, no cache path, and no executable code beyond three
private test identifiers in a module that builds green.

## Risk / trust footprint

None. No axiom, `sorry`, `partial def`, `native_decide`, `unsafe` block,
or `@[extern]` declaration is added or removed.

## Notes for reviewers

One judgment call worth a look: `splice` stays permitted, off the ban
list this repo inherited. It appears 24 times in `Repr/Deriving.lean`,
`Cache/Update.lean`, and `PresetSymbolicCap.lean`, always meaning the
`$x` in a Lean syntax quotation. That is standard metaprogramming
vocabulary, so rule 5 protects it.

The survey also turned up smaller offenders left for a follow-up:
`plumbing` (23), `baked in` (11), `escape hatch`, `under the hood`,
`blast radius`, `paper over`, `sanctioned` (16). All are now named in
the ban list, so new prose will avoid them; the existing sites are
untouched.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
