### PR TITLE
feat(sizzlean): hash_tree_root agreement, and the gindex results over spec roots

### DIFF
--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -1,4 +1,5 @@
 import EthCLLib.Proofs.MerkleOpening
+import EthCLLib.Proofs.MerkleShape
 import EthCLLib.Proofs.MerkleBranch
 import EthCLLib.Proofs.GeneralizedIndexBranch
 

--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -1,3 +1,4 @@
+import EthCLLib.Proofs.MerkleOpening
 import EthCLLib.Proofs.MerkleBranch
 
 /-!

--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -1,5 +1,6 @@
 import EthCLLib.Proofs.MerkleOpening
 import EthCLLib.Proofs.MerkleBranch
+import EthCLLib.Proofs.GeneralizedIndexBranch
 
 /-!
 # `EthCLLib.Proofs`: framework proof modules

--- a/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
@@ -2,6 +2,7 @@ import EthCLLib.Proofs.MerkleBranch
 import EthCLLib.Proofs.MerkleShape
 import SizzLean.Spec.GeneralizedIndex
 import SizzLean.Proofs.ShapeWidth
+import SizzLean.Proofs.ShapeAgreement
 
 /-!
 # `EthCLLib.Proofs.GeneralizedIndexBranch`: completeness at a generalized index
@@ -16,6 +17,10 @@ addresses, a container field.
 
 Completeness only: the check accepts every honest opening. Rejecting a forged
 branch is binding, which has no sound statement under a real 64-to-32 `combine`.
+
+Statements come in two spellings: over `Node.merkleRoot` of the built tree, and
+over `SSZType.hashTreeRoot`. `merkleRoot_ofShape_eq_hashTreeRoot`
+(`SizzLean/Proofs/ShapeAgreement.lean`) is the step between them.
 
 ## The zero-table hypothesis
 
@@ -119,13 +124,12 @@ theorem ofShape_container_isOpenable [HasherTag] [CombineWidth32 HasherTag.H]
 
 /-- **Completeness at a container field's generalized index.** Opening
 `Node.ofShape` for a container at the gindex `get_generalized_index` assigns
-field `k`, and the check accepts. The leaf there is field `k`'s own sub-tree
-root, which is what `hash_tree_root` of that field is.
+field `k`, and the check accepts.
 
-Three spec call sites verify this shape directly:
-`verify_data_column_sidecar_inclusion_proof` (leaf
-`hash_tree_root(sidecar.kzg_commitments)`, a composite list field's root),
-`EXECUTION_PAYLOAD_GINDEX`, and the two sync-committee gindices. -/
+This theorem states the leaf with `honestLeaf`, a tree-vocabulary opener.
+`isValidMerkleBranch_complete_containerField_specLeaf` below restates that leaf
+as field `k`'s `hash_tree_root`. A spec call site holds it in that second
+form. -/
 theorem isValidMerkleBranch_complete_containerField
     [HasherTag] [CombineWidth32 HasherTag.H]
     (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
@@ -179,28 +183,39 @@ holds a container sub-tree. Opening that sub-tree at its own field `k₂` compos
 with the outer path by `IsOpenable.trans`, at the concatenated index
 `k₁ * 2 ^ d₂ + k₂` the gindex builder produces.
 
-**`hsub` is the one unproven step here.** It says the outer tree's field-`k₁`
-sub-tree is the inner value's own `ofShape` tree. Stating it generically is the
-obstacle. `SSZType.interpFields` is a bare right-nested `Prod` chain with no
-accessor. "Field `k₁` of `vs`" therefore needs a dependent projection at type
-`(fs.getD k₁ .bool).interp`. That is new API, and not a lemma. A caller at a
-concrete container discharges `hsub` by `rfl`.
+`nodeAt_ofShape_container` supplies the tree step. The outer tree's field-`k₁`
+sub-tree *is* the field value's own `ofShape` tree.
 
-`k₁` needs no range bound, since `ofSubtrees` pads every position. -/
+The caller owes two facts about the schema, and none about the tree. Field
+`k₁`'s type is the container `gs` (`hfield`), and its value is `ws` (`hval`).
+Both are `rfl` / `HEq.refl` at any concrete container, and neither mentions
+`nodeAt`.
+
+`hval` is a `HEq` because `SSZType.fieldAt fs vs k₁ hk₁` has type
+`(fs[k₁]).interp`. That becomes `interpFields gs` only once `hfield` applies, so
+`congr` on `Node.ofShape` relates the two, and `Eq` does not.
+
+`hk₁ : k₁ < fs.length` is what lets the statement name field `k₁` at all. The
+one-step witness needs no such bound, since `ofSubtrees` pads every position. -/
 theorem ofShape_container_isOpenable₂ [HasherTag] [CombineWidth32 HasherTag.H]
     (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
-    (fs : List SSZType) (vs : SSZType.interpFields fs) (k₁ : Nat)
+    (fs : List SSZType) (vs : SSZType.interpFields fs)
+    (k₁ : Nat) (hk₁ : k₁ < fs.length)
     (gs : List SSZType) (ws : SSZType.interpFields gs) (k₂ : Nat)
     (hk₂ : k₂ < gs.length)
-    (hsub : nodeAt (Node.ofShape HasherTag.H (.container fs) vs)
-              (chunkDepth fs.length) k₁
-            = Node.ofShape HasherTag.H (.container gs) ws) :
+    (hfield : fs[k₁] = .container gs)
+    (hval : HEq (SSZType.fieldAt fs vs k₁ hk₁) ws) :
     IsOpenable HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
       (chunkDepth fs.length + chunkDepth gs.length)
       (k₁ * 2 ^ chunkDepth gs.length + k₂) := by
   refine IsOpenable.trans
     (ofShape_container_isOpenable' hzero fs vs k₁) ?_
     (Nat.lt_of_lt_of_le hk₂ (le_two_pow_chunkDepth gs.length))
+  have hsub : nodeAt (Node.ofShape HasherTag.H (.container fs) vs)
+        (chunkDepth fs.length) k₁
+      = Node.ofShape HasherTag.H (.container gs) ws := by
+    rw [nodeAt_ofShape_container HasherTag.H fs vs k₁ hk₁]
+    congr 1
   rw [hsub]
   exact ofShape_container_isOpenable' hzero gs ws k₂
 
@@ -251,16 +266,16 @@ Stated at the raw `(depth, index)` pair. `getGeneralizedIndex_container_field₂
 above is the arithmetic half. It shows the gindex those constants carry composes
 to exactly this depth and index. Neither constant appears here, and the concrete
 field lists never appear either, so the `#guard`ed arithmetic below is what ties
-the two together. Inherits `hsub` from the witness. -/
+the two together. Inherits the two schema facts from the witness. -/
 theorem isValidMerkleBranch_complete_containerField₂
     [HasherTag] [CombineWidth32 HasherTag.H]
     (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
-    (fs : List SSZType) (vs : SSZType.interpFields fs) (k₁ : Nat)
+    (fs : List SSZType) (vs : SSZType.interpFields fs)
+    (k₁ : Nat) (hk₁ : k₁ < fs.length)
     (gs : List SSZType) (ws : SSZType.interpFields gs) (k₂ : Nat)
     (hk₂ : k₂ < gs.length)
-    (hsub : nodeAt (Node.ofShape HasherTag.H (.container fs) vs)
-              (chunkDepth fs.length) k₁
-            = Node.ofShape HasherTag.H (.container gs) ws) :
+    (hfield : fs[k₁] = .container gs)
+    (hval : HEq (SSZType.fieldAt fs vs k₁ hk₁) ws) :
     isValidMerkleBranch
         (honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
           (chunkDepth fs.length + chunkDepth gs.length)
@@ -274,7 +289,133 @@ theorem isValidMerkleBranch_complete_containerField₂
           (Node.ofShape HasherTag.H (.container fs) vs)))
       = true :=
   isValidMerkleBranch_complete
-    (ofShape_container_isOpenable₂ hzero fs vs k₁ gs ws k₂ hk₂ hsub)
+    (ofShape_container_isOpenable₂ hzero fs vs k₁ hk₁ gs ws k₂ hk₂
+      hfield hval)
+
+/-- **The same, at the gindex a caller holds.** The statement quantifies over the
+`g` that `get_generalized_index` produced. `gindexSplit_container_field₂` supplies
+the depth and the index.
+
+`isValidMerkleBranch_complete_containerField` is the one-step form. -/
+theorem isValidMerkleBranch_complete_containerField₂_gindex
+    [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs)
+    (k₁ : Nat) (hk₁ : k₁ < fs.length)
+    (gs : List SSZType) (ws : SSZType.interpFields gs) (k₂ : Nat)
+    (hk₂ : k₂ < gs.length)
+    (hfield : fs[k₁] = .container gs)
+    (hval : HEq (SSZType.fieldAt fs vs k₁ hk₁) ws)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k₁, .field k₂] = .ok g) :
+    isValidMerkleBranch
+        (honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (honestBranch HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (Node.merkleRoot HasherTag.H
+          (Node.ofShape HasherTag.H (.container fs) vs)))
+      = true := by
+  obtain ⟨hdep, hidx⟩ := gindexSplit_container_field₂ hk₁ hk₂ hfield hg
+  rw [hdep, hidx]
+  exact isValidMerkleBranch_complete_containerField₂ hzero fs vs k₁ hk₁ gs ws k₂ hk₂
+    hfield hval
+
+/-! ### Restated over the spec's roots
+
+Everything above concludes about `Node.merkleRoot` of a built tree, which is our
+construction rather than the spec's. `merkleRoot_ofShape_eq_hashTreeRoot` says
+that root *is* the container's `hash_tree_root`, so the same theorems restate
+against the spec function, which is what a client computes. -/
+
+/-- **The verified root is the container's own `hash_tree_root`.** -/
+theorem isValidMerkleBranch_complete_containerField_specRoot
+    [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzt : ∀ d, Node.rootOf HasherTag.H (zeroLeaf HasherTag.H d)
+            = zeroHashAtDepth HasherTag.H d)
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g)
+    (hk : k < fs.length) :
+    isValidMerkleBranch
+        (honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (honestBranch HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (SSZType.hashTreeRoot HasherTag.H (.container fs) vs))
+      = true := by
+  rw [← merkleRoot_ofShape_eq_hashTreeRoot HasherTag.H hzt (.container fs) vs]
+  exact isValidMerkleBranch_complete_containerField hzero fs vs k g hg hk
+
+/-- **The opened leaf is the field's own `hash_tree_root`.**
+
+* `leafAt_eq_rootOf_nodeAt` moves from the leaf opener to the node opener.
+* `nodeAt_ofShape_container` identifies that node as field `k`'s tree.
+* `rootOf_ofShape_eq_hashTreeRoot` turns its root into the spec function. -/
+theorem honestLeaf_ofShape_container [HasherTag]
+    (hzt : ∀ d, Node.rootOf HasherTag.H (zeroLeaf HasherTag.H d)
+            = zeroHashAtDepth HasherTag.H d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat) (hk : k < fs.length) :
+    honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+        (chunkDepth fs.length) k
+      = bytesToRoot (SSZType.hashTreeRoot HasherTag.H fs[k] (SSZType.fieldAt fs vs k hk)) := by
+  unfold honestLeaf
+  rw [leafAt_eq_rootOf_nodeAt, nodeAt_ofShape_container HasherTag.H fs vs k hk,
+    rootOf_ofShape_eq_hashTreeRoot HasherTag.H hzt]
+
+/-- **Completeness with both sides in the spec's vocabulary.** The leaf is field
+`k`'s `hash_tree_root`. The root is the container's `hash_tree_root`.
+
+Spec call sites carry this shape. `verify_data_column_sidecar_inclusion_proof`
+passes `hash_tree_root(sidecar.kzg_commitments)` against `body_root`. The
+light-client `EXECUTION_PAYLOAD` and sync-committee proofs pass a field root
+against the body or state root. -/
+theorem isValidMerkleBranch_complete_containerField_specLeaf
+    [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzt : ∀ d, Node.rootOf HasherTag.H (zeroLeaf HasherTag.H d)
+            = zeroHashAtDepth HasherTag.H d)
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g)
+    (hk : k < fs.length) :
+    isValidMerkleBranch
+        (bytesToRoot (SSZType.hashTreeRoot HasherTag.H fs[k] (SSZType.fieldAt fs vs k hk)))
+        (honestBranch HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (SSZType.hashTreeRoot HasherTag.H (.container fs) vs))
+      = true := by
+  obtain ⟨hdep, hidx⟩ := gindexSplit_container_field hk hg
+  rw [← honestLeaf_ofShape_container hzt fs vs k hk, ← hdep, ← hidx]
+  exact isValidMerkleBranch_complete_containerField_specRoot hzt hzero fs vs k g hg hk
+
+/-- **The same statement at the shipped hasher, with no hypotheses left.**
+`rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256` closes `hzt`, and
+`zeroLeaf_isPerfect_sha256` closes `hzero`.
+
+**Axiom use**: `sha256Combine_eq_spec` (`Hasher/Sha256Equiv.lean`), through both
+dischargers. The zero tower is memoised from the FFI `sha256Combine`. -/
+theorem isValidMerkleBranch_complete_containerField_specRoot_sha256
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g)
+    (hk : k < fs.length) :
+    @isValidMerkleBranch fastHasherTag
+        (honestLeaf Sha256 (Node.ofShape Sha256 (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (honestBranch Sha256 (Node.ofShape Sha256 (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (SSZType.hashTreeRoot Sha256 (.container fs) vs))
+      = true := by
+  haveI : CombineWidth32 fastHasherTag.H := inferInstanceAs (CombineWidth32 Sha256)
+  exact @isValidMerkleBranch_complete_containerField_specRoot fastHasherTag _
+    rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256 zeroLeaf_isPerfect_sha256
+    fs vs k g hg hk
 
 /-! **Pin: the light-client gindices decompose as the spec says.** Values from
 `consensus-specs` (`altair/`, `capella/` and `electra/light-client/sync-protocol.md`).

--- a/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
@@ -1,0 +1,315 @@
+import EthCLLib.Proofs.MerkleBranch
+import SizzLean.Spec.GeneralizedIndex
+import SizzLean.Proofs.ShapeWidth
+
+/-!
+# `EthCLLib.Proofs.GeneralizedIndexBranch`: completeness at a generalized index
+
+`isValidMerkleBranch` takes a `(depth, index)` pair. The spec's call sites carry
+a *generalized index* and split it with `floorlog2` / `get_subtree_index`. This
+module runs that split (`SizzLean.Spec.GeneralizedIndex`) and lands in the
+completeness kit. It then instantiates the result at the shape the spec
+addresses, a container field.
+
+## What is proved
+
+Completeness only: the check accepts every honest opening. Rejecting a forged
+branch is binding, which has no sound statement under a real 64-to-32 `combine`.
+
+## The zero-table hypothesis
+
+`hzero` (pad perfection) arrives as a hypothesis, the way `ofSubtrees_isOpenable`
+takes it. Reading the memo's bytes goes through `sha256Combine_eq_spec`. Keeping
+`hzero` a parameter therefore leaves every theorem below axiom-free, and puts the
+commitment at the instantiating call site (`zeroLeaf_isPerfect_sha256`).
+
+The pad's root width follows from `hzero` through
+`rootOf_zeroLeaf_size_of_isPerfect`, so it needs no second hypothesis.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Proofs
+
+open SizzLean
+open SizzLean.Hasher
+open SizzLean.Spec
+open SizzLean.Cache.MerkleTree
+open EthCLLib.Spec
+
+/-- **Completeness at a generalized index.** Take a path witness at the
+`(depth, index)` a gindex decomposes to. The check then accepts the honest
+opening run at that same pair. This restates `isValidMerkleBranch_complete` in
+the vocabulary call sites use, so no caller re-derives the split.
+
+Nothing consumes `1 ≤ g`, since the check takes any index. It stays in the
+statement to record the valid-gindex range. -/
+theorem isValidMerkleBranch_complete_gindex [HasherTag]
+    {n : Node} {g : GeneralizedIndex} (_hg : 1 ≤ g)
+    (ho : IsOpenable HasherTag.H n (floorLog2 g) (getSubtreeIndex g)) :
+    isValidMerkleBranch
+        (honestLeaf HasherTag.H n (floorLog2 g) (getSubtreeIndex g))
+        (honestBranch HasherTag.H n (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (Node.merkleRoot HasherTag.H n))
+      = true :=
+  isValidMerkleBranch_complete ho
+
+/-- **A container's tree is openable at every field slot**, stated at the raw
+`(depth, index)` pair rather than at a gindex. `Node.ofShape` builds
+`.container fs` as `ofSubtrees` over the field sub-trees at depth
+`chunkDepth fs.length` (`Build.lean:186-188`), and `ofSubtrees_isOpenable` opens
+that at any position. `rootOf_subtreesForFields_size` is the sub-tree width side
+condition.
+
+The single witness: the gindex spelling below rewrites into it and the two-step
+theorem composes two copies of it.
+
+No bound on `k`: `ofSubtrees` pads, so a position past the field count is still
+openable and opens onto padding. The in-range hypothesis appears only where the
+*gindex* arithmetic needs it. -/
+theorem ofShape_container_isOpenable' [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat) :
+    IsOpenable HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+      (chunkDepth fs.length) k := by
+  -- `brecOn` compiles `ofShape`, so it does not reduce by `rfl`. The equation
+  -- lemma exposes the `ofSubtrees` form underneath.
+  simp only [Node.ofShape]
+  -- The capacity side condition: a container places one sub-tree per field, and
+  -- `chunkDepth` is chosen to hold that many leaves.
+  exact ofSubtrees_isOpenable HasherTag.H hzero (chunkDepth fs.length) _
+    (by rw [subtreesForFields_length]; exact le_two_pow_chunkDepth fs.length)
+    (rootOf_subtreesForFields_size HasherTag.H
+      (rootOf_zeroLeaf_size_of_isPerfect HasherTag.H hzero) fs vs) k
+
+/-- **A container field's gindex decomposes to its `(depth, index)` pair.** The
+gindex arrives as `hg`, the success case of `get_generalized_index`. The
+statements below therefore quantify over the `g` it produced, and not over the
+`Except` that produced it.
+
+`k < fs.length` puts the field inside the tree's capacity through
+`le_two_pow_chunkDepth`, which is what the converse-decomposition lemmas need. -/
+theorem gindexSplit_container_field {fs : List SSZType} {k : Nat}
+    {g : GeneralizedIndex} (hk : k < fs.length)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g) :
+    floorLog2 g = chunkDepth fs.length ∧ getSubtreeIndex g = k := by
+  have hrange : k < 2 ^ chunkDepth fs.length :=
+    Nat.lt_of_lt_of_le hk (le_two_pow_chunkDepth fs.length)
+  rw [getGeneralizedIndex_container_field hk] at hg
+  -- `hg` is now `.ok (2 ^ d + k) = .ok g`. Strip the constructor to name `g`.
+  have hgv : g = 2 ^ chunkDepth fs.length + k := by injection hg with h; exact h.symm
+  subst hgv
+  exact ⟨floorLog2_two_pow_add hrange, getSubtreeIndex_two_pow_add hrange⟩
+
+/-- **A container field's gindex position is openable.** The same witness, read
+at the `(depth, index)` pair `get_generalized_index` produces for field `k`. -/
+theorem ofShape_container_isOpenable [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g)
+    (hk : k < fs.length) :
+    IsOpenable HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+      (floorLog2 g) (getSubtreeIndex g) := by
+  obtain ⟨hdep, hidx⟩ := gindexSplit_container_field hk hg
+  rw [hdep, hidx]
+  exact ofShape_container_isOpenable' hzero fs vs k
+
+/-- **Completeness at a container field's generalized index.** Opening
+`Node.ofShape` for a container at the gindex `get_generalized_index` assigns
+field `k`, and the check accepts. The leaf there is field `k`'s own sub-tree
+root, which is what `hash_tree_root` of that field is.
+
+Three spec call sites verify this shape directly:
+`verify_data_column_sidecar_inclusion_proof` (leaf
+`hash_tree_root(sidecar.kzg_commitments)`, a composite list field's root),
+`EXECUTION_PAYLOAD_GINDEX`, and the two sync-committee gindices. -/
+theorem isValidMerkleBranch_complete_containerField
+    [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat)
+    (g : GeneralizedIndex)
+    (hg : getGeneralizedIndex (.container fs) [.field k] = .ok g)
+    (hk : k < fs.length) :
+    isValidMerkleBranch
+        (honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (honestBranch HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (floorLog2 g) (getSubtreeIndex g))
+        (floorLog2 g) (getSubtreeIndex g)
+        (bytesToRoot (Node.merkleRoot HasherTag.H
+          (Node.ofShape HasherTag.H (.container fs) vs)))
+      = true :=
+  isValidMerkleBranch_complete
+    (ofShape_container_isOpenable hzero fs vs k g hg hk)
+
+/-- A two-step container path composes the two field gindices. The builder
+threads its accumulator, so the outer gindex multiplies through the inner
+container's width, which is the `2 ^ d₁ * 2 ^ d₂` split `IsOpenable.trans`
+consumes.
+
+`hfield` tells the builder the second step lands in a container. Without it
+`elemType` cannot reduce. Both steps land on containers, the one shape whose
+`itemPosition` is the plain index, so no packing correction survives into the
+statement.
+
+`hk₁` and `hk₂` discharge the two range checks. `hk₁` also lets `hfield` name the
+field with `fs[k₁]`, the spelling the openability theorems below use, instead of
+the `getD` default this proof needs internally. -/
+theorem getGeneralizedIndex_container_field₂
+    {fs : List SSZType} {k₁ : Nat} {gs : List SSZType} {k₂ : Nat}
+    (hk₁ : k₁ < fs.length) (hk₂ : k₂ < gs.length)
+    (hfield : fs[k₁] = .container gs) :
+    getGeneralizedIndex (.container fs) [.field k₁, .field k₂]
+      = .ok ((2 ^ chunkDepth fs.length + k₁) * 2 ^ chunkDepth gs.length + k₂) := by
+  -- `elemType` reads the field with `getD`, and `simp` normalises that to the
+  -- `getElem?` spelling. Restate `hfield` in that form or it stops matching the
+  -- rewritten goal. `hk₁` is what turns the `getElem?` back into `hfield`'s
+  -- total `getElem`.
+  have hfield' : (fs[k₁]?).getD .bool = .container gs := by
+    rw [List.getElem?_eq_getElem hk₁]; exact hfield
+  simp [getGeneralizedIndex, getGeneralizedIndex.go, getPowerOfTwoCeil, chunkCount,
+    itemPosition, elemType, hfield', stepCapacity, SSZType.isBasicType,
+    Nat.not_le.mpr hk₁, Nat.not_le.mpr hk₂]
+
+/-- **A two-step container path is openable.** The outer container's field `k₁`
+holds a container sub-tree. Opening that sub-tree at its own field `k₂` composes
+with the outer path by `IsOpenable.trans`, at the concatenated index
+`k₁ * 2 ^ d₂ + k₂` the gindex builder produces.
+
+**`hsub` is the one unproven step here.** It says the outer tree's field-`k₁`
+sub-tree is the inner value's own `ofShape` tree. Stating it generically is the
+obstacle. `SSZType.interpFields` is a bare right-nested `Prod` chain with no
+accessor. "Field `k₁` of `vs`" therefore needs a dependent projection at type
+`(fs.getD k₁ .bool).interp`. That is new API, and not a lemma. A caller at a
+concrete container discharges `hsub` by `rfl`.
+
+`k₁` needs no range bound, since `ofSubtrees` pads every position. -/
+theorem ofShape_container_isOpenable₂ [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k₁ : Nat)
+    (gs : List SSZType) (ws : SSZType.interpFields gs) (k₂ : Nat)
+    (hk₂ : k₂ < gs.length)
+    (hsub : nodeAt (Node.ofShape HasherTag.H (.container fs) vs)
+              (chunkDepth fs.length) k₁
+            = Node.ofShape HasherTag.H (.container gs) ws) :
+    IsOpenable HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+      (chunkDepth fs.length + chunkDepth gs.length)
+      (k₁ * 2 ^ chunkDepth gs.length + k₂) := by
+  refine IsOpenable.trans
+    (ofShape_container_isOpenable' hzero fs vs k₁) ?_
+    (Nat.lt_of_lt_of_le hk₂ (le_two_pow_chunkDepth gs.length))
+  rw [hsub]
+  exact ofShape_container_isOpenable' hzero gs ws k₂
+
+/-- **A two-step container gindex decomposes to its `(depth, index)` pair.** The
+composed gindex is `2 ^ (d₁ + d₂) + (k₁ * 2 ^ d₂ + k₂)`. The one-step converse
+lemmas take that form, once the proof bounds the index by `2 ^ (d₁ + d₂)`. -/
+theorem gindexSplit_container_field₂ {fs gs : List SSZType} {k₁ k₂ : Nat}
+    {g : GeneralizedIndex} (hk₁ : k₁ < fs.length) (hk₂ : k₂ < gs.length)
+    (hfield : fs[k₁] = .container gs)
+    (hg : getGeneralizedIndex (.container fs) [.field k₁, .field k₂] = .ok g) :
+    floorLog2 g = chunkDepth fs.length + chunkDepth gs.length
+      ∧ getSubtreeIndex g = k₁ * 2 ^ chunkDepth gs.length + k₂ := by
+  have h1 : k₁ < 2 ^ chunkDepth fs.length :=
+    Nat.lt_of_lt_of_le hk₁ (le_two_pow_chunkDepth fs.length)
+  have h2 : k₂ < 2 ^ chunkDepth gs.length :=
+    Nat.lt_of_lt_of_le hk₂ (le_two_pow_chunkDepth gs.length)
+  -- The composed index fits the composed depth. `k₁` contributes at most
+  -- `2 ^ d₁ - 1` blocks of `2 ^ d₂`, and `k₂` stays inside one block.
+  have hidx : k₁ * 2 ^ chunkDepth gs.length + k₂
+      < 2 ^ (chunkDepth fs.length + chunkDepth gs.length) := by
+    have hstep : k₁ * 2 ^ chunkDepth gs.length + k₂
+        < (k₁ + 1) * 2 ^ chunkDepth gs.length := by
+      rw [Nat.succ_mul]; omega
+    have hle : (k₁ + 1) * 2 ^ chunkDepth gs.length
+        ≤ 2 ^ chunkDepth fs.length * 2 ^ chunkDepth gs.length :=
+      Nat.mul_le_mul_right _ h1
+    rw [← Nat.pow_add] at hle
+    omega
+  -- Rewrite the builder's `(2 ^ d₁ + k₁) * 2 ^ d₂ + k₂` into the `2 ^ d + i` form
+  -- the converse lemmas take.
+  have hshape : (2 ^ chunkDepth fs.length + k₁) * 2 ^ chunkDepth gs.length + k₂
+      = 2 ^ (chunkDepth fs.length + chunkDepth gs.length)
+        + (k₁ * 2 ^ chunkDepth gs.length + k₂) := by
+    rw [Nat.add_mul, Nat.pow_add, Nat.add_assoc]
+  rw [getGeneralizedIndex_container_field₂ hk₁ hk₂ hfield] at hg
+  have hgv : g = 2 ^ (chunkDepth fs.length + chunkDepth gs.length)
+      + (k₁ * 2 ^ chunkDepth gs.length + k₂) := by
+    injection hg with h; rw [← h, hshape]
+  subst hgv
+  exact ⟨floorLog2_two_pow_add hidx, getSubtreeIndex_two_pow_add hidx⟩
+
+/-- **Completeness at a two-step container gindex.** The shape behind
+`FINALIZED_ROOT_GINDEX` (`BeaconState.finalized_checkpoint.root`) and
+`EXECUTION_BLOCK_HASH_GINDEX`
+(`BeaconBlockBody.execution_payload.block_hash`).
+
+Stated at the raw `(depth, index)` pair. `getGeneralizedIndex_container_field₂`
+above is the arithmetic half. It shows the gindex those constants carry composes
+to exactly this depth and index. Neither constant appears here, and the concrete
+field lists never appear either, so the `#guard`ed arithmetic below is what ties
+the two together. Inherits `hsub` from the witness. -/
+theorem isValidMerkleBranch_complete_containerField₂
+    [HasherTag] [CombineWidth32 HasherTag.H]
+    (hzero : ∀ d, IsPerfect HasherTag.H (zeroLeaf HasherTag.H d) d)
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k₁ : Nat)
+    (gs : List SSZType) (ws : SSZType.interpFields gs) (k₂ : Nat)
+    (hk₂ : k₂ < gs.length)
+    (hsub : nodeAt (Node.ofShape HasherTag.H (.container fs) vs)
+              (chunkDepth fs.length) k₁
+            = Node.ofShape HasherTag.H (.container gs) ws) :
+    isValidMerkleBranch
+        (honestLeaf HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (chunkDepth fs.length + chunkDepth gs.length)
+          (k₁ * 2 ^ chunkDepth gs.length + k₂))
+        (honestBranch HasherTag.H (Node.ofShape HasherTag.H (.container fs) vs)
+          (chunkDepth fs.length + chunkDepth gs.length)
+          (k₁ * 2 ^ chunkDepth gs.length + k₂))
+        (chunkDepth fs.length + chunkDepth gs.length)
+        (k₁ * 2 ^ chunkDepth gs.length + k₂)
+        (bytesToRoot (Node.merkleRoot HasherTag.H
+          (Node.ofShape HasherTag.H (.container fs) vs)))
+      = true :=
+  isValidMerkleBranch_complete
+    (ofShape_container_isOpenable₂ hzero fs vs k₁ gs ws k₂ hk₂ hsub)
+
+/-! **Pin: the light-client gindices decompose as the spec says.** Values from
+`consensus-specs` (`altair/`, `capella/` and `electra/light-client/sync-protocol.md`).
+Each is a one-step container field, so `isValidMerkleBranch_complete_containerField`
+covers it. Kept as a regression on the `floorLog2` / `getSubtreeIndex` pair every
+call site above passes to the check. -/
+-- capella `EXECUTION_PAYLOAD_GINDEX`: `BeaconBlockBody` field 9 of 11.
+#guard floorLog2 25 == 4 && getSubtreeIndex 25 == 9
+-- altair `CURRENT_` / `NEXT_SYNC_COMMITTEE_GINDEX`: `BeaconState` fields 22, 23
+-- of 24.
+#guard floorLog2 54 == 5 && getSubtreeIndex 54 == 22
+#guard floorLog2 55 == 5 && getSubtreeIndex 55 == 23
+-- The `_ELECTRA` respellings of the same two fields, which is what Fulu and
+-- Gloas carry: Electra's `BeaconState` grew to 37 fields, and Fulu (38) and
+-- Gloas (46) grew it again, all inside `(32, 64]`, so the depth is 6, not 5.
+#guard floorLog2 86 == 6 && getSubtreeIndex 86 == 22
+#guard floorLog2 87 == 6 && getSubtreeIndex 87 == 23
+
+/-! **Pin: gindex composition is `trans`'s index concatenation.**
+`EXECUTION_BLOCK_HASH_GINDEX = 412` walks capella `BeaconBlockBody` field 9 of
+11 at depth 4. It then walks capella `ExecutionPayload` field 12 of 15, also at
+depth 4. That is `25 * 2 ^ 4 + 12 = 412`. Decomposed it is depth `4 + 4` and index
+`9 * 2 ^ 4 + 12 = 156`, which is exactly `IsOpenable.trans`'s
+`i₁ * 2 ^ d₂ + i₂`.
+
+`FINALIZED_ROOT_GINDEX = 105` follows the same law at `52 * 2 + 1`, depth
+`5 + 1`, index `20 * 2 + 1 = 41`. Its `_ELECTRA` respelling `169` is
+`84 * 2 + 1` over the 37-field Electra `BeaconState`.
+
+`EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 832` (`gloas/light-client/sync-protocol.md:55`)
+is a three-step path, `signed_execution_payload_bid` then `message` then
+`parent_block_hash`. The two-step composition does not reach it, so only its
+`(depth, index)` split appears below. -/
+#guard floorLog2 412 == 4 + 4 && getSubtreeIndex 412 == 9 * 2 ^ 4 + 12
+#guard floorLog2 105 == 5 + 1 && getSubtreeIndex 105 == 20 * 2 + 1
+#guard floorLog2 169 == 6 + 1 && getSubtreeIndex 169 == 20 * 2 + 1
+#guard floorLog2 832 == 9 && getSubtreeIndex 832 == 320
+
+end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/GeneralizedIndexBranch.lean
@@ -1,4 +1,5 @@
 import EthCLLib.Proofs.MerkleBranch
+import EthCLLib.Proofs.MerkleShape
 import SizzLean.Spec.GeneralizedIndex
 import SizzLean.Proofs.ShapeWidth
 

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -1,4 +1,8 @@
 import EthCLLib.Spec.SigningRoot
+import EthCLLib.Proofs.MerkleOpening
+import SizzLean.Proofs.Perfect
+import SizzLean.Hasher.CombineWidth
+import SizzLean.Proofs.Util
 
 /-!
 # `EthCLLib.Proofs.MerkleBranch`: what `isValidMerkleBranch` accepts
@@ -9,9 +13,24 @@ import EthCLLib.Spec.SigningRoot
 Past the length guard, the check reduces to a plain fold of `branch` over `leaf`,
 compared to `root`.
 
+Open a tree at `index` with `honestLeaf` / `honestBranch`, and the check returns
+`true`. `IsOpenable` (`EthCLLib/Proofs/MerkleOpening.lean`) is the path-shaped
+hypothesis, and every `IsPerfect` tree satisfies it at every index
+(`isOpenable_of_isPerfect`).
+
+The theorems quantify over `Node.merkleRoot`, the tree's own root. The spec's
+callers pass a root from elsewhere: `process_deposit` reads
+`state.eth1_data.deposit_root`, and hands the check a wire-deserialised `Array`
+rather than a `Node`.
+
 Bit ordering: `branch` runs bottom-to-top and entry `i` is the level-`i` sibling.
 The routing convention lives in `EthCLLib.Spec.MerklePath`. The shipped check and
 this fold both call `routeRight`, so the two agree by definition.
+
+Under an abstract `[HasherTag]`, `isValidMerkleBranch_complete` and the two guard
+bridges apply as they stand. The results carrying `[CombineWidth32 HasherTag.H]`
+need `pureHasherTag` or `fastHasherTag`, since `HasherTag.H` is otherwise a stuck
+projection matching no instance.
 -/
 
 set_option autoImplicit false
@@ -19,6 +38,9 @@ set_option autoImplicit false
 namespace EthCLLib.Proofs
 
 open SizzLean
+open SizzLean.Hasher
+open SizzLean.Cache.MerkleTree
+open SizzLean.Proofs
 open EthCLLib.Spec
 
 /-! ### The proof-side fold
@@ -47,6 +69,19 @@ private theorem branchFold_succ [HasherTag] (leaf : ByteArray)
   unfold branchFold
   rw [List.range_succ, List.foldl_append]
   rfl
+
+/-- **Reads at or above `depth` cannot matter.** Two branches agreeing below
+`depth` drive the same walk. The induction step can therefore ignore the sibling
+`siblingPath` pushes on at the top. -/
+private theorem branchFold_congr [HasherTag] (leaf : ByteArray)
+    (b b' : Array (Vector UInt8 32)) (depth index : Nat)
+    (hagree : ∀ i, i < depth → b[i]! = b'[i]!) :
+    branchFold leaf b depth index = branchFold leaf b' depth index := by
+  induction depth with
+  | zero => rfl
+  | succ d ih =>
+      rw [branchFold_succ, branchFold_succ, ih (fun i hi => hagree i (by omega)),
+          hagree d (by omega)]
 
 /-- The checked fold itself, in range: every `branch[i]` read hits, so the
 `IndexError` arm never fires. The statement sits on the inner `foldlM`, since the
@@ -118,11 +153,150 @@ private theorem isValidMerkleBranch_iff [HasherTag] (leaf : Vector UInt8 32)
   rw [isValidMerkleBranch_eq_beq _ _ _ _ _ hsize]
   exact beq_iff_eq
 
+/-- **Core completeness.** Along an openable path into `n`, folding the extracted
+leaf and sibling path reconstructs the tree's root.
+
+The proof inducts on `IsOpenable`. Each pair case peels the top level with
+`branchFold_succ`. It then rewrites the lower `d` steps to ignore the pushed top
+sibling, through `branchFold_congr` against `getElem!_push_lt`, in range by
+`siblingPath_size`. It applies the sub-path IH, rewrites the cached sibling read
+back to `merkleRoot` (`rootOf_eq_merkleRoot`, which needs no hypothesis), and
+closes with `merkleRoot_pair`. Each constructor fixes its own bit, so neither
+case has to split.
+
+The base case is the `rootOf`/`merkleRoot` bridge: a zero-step fold returns the
+stop node's root unchanged.
+
+The siblings arrive root-typed, as `isValidMerkleBranch` takes them, and each
+`vecToBytes (bytesToRoot ·)` round-trips on the 32-byte widths `IsOpenable`
+carries. -/
+private theorem branchFold_eq_merkleRoot [HasherTag] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable HasherTag.H n depth index →
+      branchFold (leafAt HasherTag.H n depth index)
+          ((siblingPath HasherTag.H n depth index).map bytesToRoot) depth index
+        = Node.merkleRoot HasherTag.H n := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index =>
+      simpa [branchFold, leafAt_zero] using rootOf_eq_merkleRoot HasherTag.H m
+  | @left l r d index c hbit hl hr32 hc ihl =>
+      -- bit clear: our leaf sits in the LEFT subtree. The level-`d` sibling is
+      -- `r`'s root, mixed on the right (`combine acc sibling`).
+      -- The constructor and the fold both test `routeRight index d`, so `hbit`
+      -- discharges the openers and the fold together.
+      rw [branchFold_succ]
+      simp only [leafAt, siblingPath, hbit, Bool.false_eq_true, if_false]
+      have hsz : (siblingPath HasherTag.H l d index).size = d := siblingPath_size HasherTag.H hl
+      rw [branchFold_congr _ _ ((siblingPath HasherTag.H l d index).map bytesToRoot) d index
+            (fun i hi => by
+              rw [Array.map_push, getElem!_push_lt _ _ _
+                (by rw [Array.size_map, hsz]; exact hi)]),
+          ihl]
+      have htop := getElem!_push_size ((siblingPath HasherTag.H l d index).map bytesToRoot)
+        (bytesToRoot (Node.rootOf HasherTag.H r))
+      rw [Array.size_map, hsz] at htop
+      rw [Array.map_push, htop,
+        vecToBytes_bytesToRoot _ (by rw [rootOf_eq_merkleRoot]; exact hr32),
+        rootOf_eq_merkleRoot HasherTag.H r, merkleRoot_pair HasherTag.H hc]
+  | @right l r d index c hbit hr hl32 hc ihr =>
+      -- bit set: our leaf sits in the RIGHT subtree. The level-`d` sibling is
+      -- `l`'s root, mixed on the left (`combine sibling acc`).
+      rw [branchFold_succ]
+      simp only [leafAt, siblingPath, hbit, if_true]
+      have hsz : (siblingPath HasherTag.H r d index).size = d := siblingPath_size HasherTag.H hr
+      rw [branchFold_congr _ _ ((siblingPath HasherTag.H r d index).map bytesToRoot) d index
+            (fun i hi => by
+              rw [Array.map_push, getElem!_push_lt _ _ _
+                (by rw [Array.size_map, hsz]; exact hi)]),
+          ihr]
+      have htop := getElem!_push_size ((siblingPath HasherTag.H r d index).map bytesToRoot)
+        (bytesToRoot (Node.rootOf HasherTag.H l))
+      rw [Array.size_map, hsz] at htop
+      rw [Array.map_push, htop,
+        vecToBytes_bytesToRoot _ (by rw [rootOf_eq_merkleRoot]; exact hl32),
+        rootOf_eq_merkleRoot HasherTag.H l, merkleRoot_pair HasherTag.H hc]
+
+/-- Sanity: at depth 1, the honest leaf of the left branch (bit 0 clear) is the
+left leaf's bytes, root-typed. The path stops on a leaf, so `leafAt` reads its
+bytes back without hashing.
+
+`Node.rootOf` is `@[irreducible]`, so this enters its leaf arm by the named
+equation lemma rather than by `rfl`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    honestLeaf Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0 = bytesToRoot z := by
+  simp [honestLeaf, leafAt, Node.rootOf_leaf, routeRight]
+
 /-- Root-typing a sibling array preserves its length. Named so the statement
 below can cite it, rather than carrying `(by rw [Array.size_map]; exact hsize)`
 inline where a reader expects a term. -/
 theorem size_map_bytesToRoot {sibs : Array ByteArray} {depth : Nat}
     (hsize : sibs.size = depth) : (sibs.map bytesToRoot).size = depth := by
   rw [Array.size_map]; exact hsize
+
+/-- **Completeness (acceptance #2).** Any openable path makes
+`isValidMerkleBranch` accept its honest opening at `index` (`honestLeaf` and
+`honestBranch`).
+
+`IsOpenable` records the sibling widths itself, so this statement needs no
+`CombineWidth32` instance. The check runs under the ambient `[HasherTag]`, and
+the walk uses the same `HasherTag.H`, so both sides hash identically. -/
+theorem isValidMerkleBranch_complete [HasherTag]
+    {n : Node} {depth index : Nat} (ho : IsOpenable HasherTag.H n depth index) :
+    isValidMerkleBranch (honestLeaf HasherTag.H n depth index)
+        (honestBranch HasherTag.H n depth index)
+        depth index (bytesToRoot (Node.merkleRoot HasherTag.H n))
+      = true := by
+  simp only [honestLeaf, honestBranch]
+  have hleaf : (leafAt HasherTag.H n depth index).size = 32 := leafAt_size HasherTag.H ho
+  -- the honest branch has size `depth`, so the shipped check's length guard passes
+  have hsize :
+      ((siblingPath HasherTag.H n depth index).map bytesToRoot).size = depth :=
+    size_map_bytesToRoot (siblingPath_size HasherTag.H ho)
+  rw [isValidMerkleBranch_iff _ _ _ _ _ hsize,
+    vecToBytes_bytesToRoot _ hleaf, branchFold_eq_merkleRoot ho]
+
+/-- Completeness on a perfect tree at any index, through `isOpenable_of_isPerfect`. The
+`[CombineWidth32]` instance carries the 32-byte `combine` contract. The whole-tree
+hypothesis needs that contract to know the width of every sibling root.
+
+**Axiom use**: resolution at `Sha256` picks the instance proved from
+`sha256Combine_eq_spec`, so an FFI instantiation inherits that axiom silently.
+`Sha256Spec` resolves axiom-free. -/
+theorem isValidMerkleBranch_complete_perfect [HasherTag] [CombineWidth32 HasherTag.H]
+    {n : Node} {depth : Nat} (hp : IsPerfect HasherTag.H n depth) (index : Nat) :
+    isValidMerkleBranch (honestLeaf HasherTag.H n depth index)
+        (honestBranch HasherTag.H n depth index)
+        depth index (bytesToRoot (Node.merkleRoot HasherTag.H n))
+      = true :=
+  isValidMerkleBranch_complete (isOpenable_of_isPerfect hp index)
+
+/-- Completeness specialised to the pure-Lean `Sha256Spec` hasher, whose
+`CombineWidth32` instance (built from `sha256Spec_combine_size`,
+`SizzLean/Hasher/CombineWidth.lean`) supplies the size fact. -/
+theorem isValidMerkleBranch_complete_sha256Spec
+    {n : Node} {depth : Nat} (hp : IsPerfect Sha256Spec n depth) (index : Nat) :
+    @isValidMerkleBranch pureHasherTag (honestLeaf Sha256Spec n depth index)
+        (honestBranch Sha256Spec n depth index)
+        depth index (bytesToRoot (Node.merkleRoot Sha256Spec n))
+      = true := by
+  haveI : CombineWidth32 pureHasherTag.H := inferInstanceAs (CombineWidth32 Sha256Spec)
+  exact @isValidMerkleBranch_complete_perfect pureHasherTag _ n depth hp index
+
+/-- Worked completeness: a concrete depth-1 `combine`-tree of two 32-byte leaves.
+Feeding the honest opening of the left leaf makes the pure-`Sha256Spec` check
+accept, discharged straight from `isValidMerkleBranch_complete_sha256Spec`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    @isValidMerkleBranch pureHasherTag
+        (honestLeaf Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0)
+        (honestBranch Sha256Spec (.pair (.leaf z) (.leaf o) none) 1 0)
+        1 0
+        (bytesToRoot (Node.merkleRoot Sha256Spec (.pair (.leaf z) (.leaf o) none)))
+      = true := by
+  exact isValidMerkleBranch_complete_sha256Spec
+    (.pair (.leaf _ (by rfl)) (.leaf _ (by rfl)) (by simp)) 0
 
 end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
@@ -1,0 +1,265 @@
+import EthCLLib.Spec.Arith
+import EthCLLib.Spec.MerklePath
+import SizzLean.Proofs.Perfect
+import SizzLean.Proofs.Util
+
+/-!
+# `EthCLLib.Proofs.MerkleOpening`: openable paths and honest Merkle openings
+
+The path vocabulary the completeness proof quantifies over, and the openers that
+produce a witness for it.
+
+`IsOpenable` is the central predicate: a root-to-leaf path witness at one index,
+which is all a completeness proof ever walks. See its declaration docstring for
+the per-level obligations. `leafAt` and `siblingPath` extract the honest opening,
+and `honestLeaf` / `honestBranch` are their root-typed sugar. `isOpenable_of_isPerfect`
+injects every `IsPerfect` tree from SizzLean into the predicate.
+
+All of it routes by `EthCLLib.Spec.routeRight`, the same bit the shipped check
+folds on. That convention belongs to `is_valid_merkle_branch`, a consensus-spec
+function. The whole opening half therefore sits framework-side, and SizzLean
+keeps only shape and width (`SizzLean.Proofs.Perfect`).
+
+Both openers fall through silently on a shape mismatch. A caller therefore relies
+on holding an `IsOpenable` witness, and not on the openers rejecting bad input.
+
+`rootOf_eq_merkleRoot` licenses reading `siblingPath`'s cache reads as the honest
+`Node.merkleRoot`, unconditionally. `merkleRoot_pair` is the single bridge that
+collapses the cached and uncached readings of `Node.merkleRoot`.
+
+The completeness proof (`Proofs/MerkleBranch.lean`) and the computational
+witnesses (`Tests/MerkleWitness.lean`) both open a tree through this module. The
+tested expressions and the proved ones therefore stay the same.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Proofs
+
+open SizzLean SizzLean.Hasher SizzLean.Cache.MerkleTree EthCLLib.Spec
+open SizzLean.Proofs
+
+/-! ### The path predicate -/
+
+/-- A root-to-leaf *path* witness for `Node` at `index`: the spine the honest
+opening walks. Where `IsPerfect` constrains the whole tree, `IsOpenable`
+constrains only the followed child at each level. For the off-path sibling it
+records the two facts completeness consumes, a 32-byte root and cache validity
+at this level. `hc` says nothing about caches *inside* the sibling subtrees. An
+`IsOpenable` tree may therefore carry poisoned ones, and completeness then proves
+acceptance against that tree's own `merkleRoot`. Every `IsPerfect` tree is
+`IsOpenable` at every index (`isOpenable_of_isPerfect`).
+
+The base case stops at *any* node whose root is 32 bytes, not only a `.leaf`.
+A path can therefore end on a subtree. That is what SSZ means by the leaf at a
+generalized index, since `hash_tree_root` of a composite field is a subtree root.
+`Node.rootOf (.leaf b) = b` definitionally, so a leaf-terminating path is the
+special case, and it changes no deposit-shaped corollary. -/
+inductive IsOpenable (H : Type) [Hasher H] : Node → Nat → Nat → Prop where
+  | stop (m : Node) (hsz : (Node.rootOf H m).size = 32) (index : Nat) :
+      IsOpenable H m 0 index
+  | left {l r : Node} {d index : Nat} {c : Option ByteArray}
+      (hbit : routeRight index d = false)
+      (hl : IsOpenable H l d index)
+      (hr32 : (Node.merkleRoot H r).size = 32)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsOpenable H (.pair l r c) (d + 1) index
+  | right {l r : Node} {d index : Nat} {c : Option ByteArray}
+      (hbit : routeRight index d = true)
+      (hr : IsOpenable H r d index)
+      (hl32 : (Node.merkleRoot H l).size = 32)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsOpenable H (.pair l r c) (d + 1) index
+
+/-! ### The openers -/
+
+/-- The 32-byte chunk at the end of `index`'s bits, read from the root of `n`,
+most-significant bit (level `depth-1`) first. It is the root of whatever node
+the path stops on.
+
+The function is total. Its remaining arm, a `.leaf` asked to open at positive
+depth, is unreachable under `IsOpenable` and falls through to
+`SizzLean.Spec.zero32`, the canonical all-zero chunk.
+
+That fallthrough is silent, so a caller without an `IsOpenable` witness in hand
+gets a plausible-looking zero chunk out of a shape mismatch. Holding the witness
+is what rules that out. The openers themselves report nothing. -/
+def leafAt (H : Type) [Hasher H] : Node → (depth : Nat) → (index : Nat) → ByteArray
+  | m,             0,     _     => Node.rootOf H m
+  | .pair l r _,   d + 1, index =>
+      if routeRight index d then leafAt H r d index else leafAt H l d index
+  | _,             _,     _     => SizzLean.Spec.zero32
+
+/-- `leafAt` at depth 0 is the stop node's root, whatever the node's shape.
+
+The depth-0 arm above matches any `Node`, but the equation compiler splits on the
+*node* first. The arm therefore does not fire while the node is an opaque
+variable, and a `cases` has to show that no other arm applies. Stating that once
+here keeps every base case downstream a plain rewrite. The same holds for
+`siblingPath_zero` below. -/
+theorem leafAt_zero (H : Type) [Hasher H] (m : Node) (index : Nat) :
+    leafAt H m 0 index = Node.rootOf H m := by
+  cases m <;> rfl
+
+/-- The sibling hashes along the root path to the leaf at `index`, ordered
+bottom-to-top. Index `0` is the leaf-level sibling, and index `depth-1` is the
+sibling just under the root.
+
+The recursion enters the chosen subtree first, then pushes this level's sibling,
+the *other* subtree's root, at the end. The top sibling therefore lands at the
+highest array index, which matches `isValidMerkleBranch`'s bit-`i`-at-level-`i`
+fold.
+
+Sibling roots come from `Node.rootOf`, the cache-reading observer, which
+allocates nothing. It agrees with `Node.merkleRoot` on every `Node`
+(`rootOf_eq_merkleRoot`), so reading a sibling's cache as its `merkleRoot` needs
+no hypothesis. -/
+def siblingPath (H : Type) [Hasher H] :
+    Node → (depth : Nat) → (index : Nat) → Array ByteArray
+  | .pair l r _,   d + 1, index =>
+      if routeRight index d
+      then (siblingPath H r d index).push (Node.rootOf H l)
+      else (siblingPath H l d index).push (Node.rootOf H r)
+  | _,             _,     _     => #[]
+
+/-- A depth-0 opening has no siblings, whatever the node's shape. Needs the same
+`cases` as `leafAt_zero`, for the same reason. -/
+theorem siblingPath_zero (H : Type) [Hasher H] (m : Node) (index : Nat) :
+    siblingPath H m 0 index = #[] := by
+  cases m <;> rfl
+
+/-! ### Sizes along an openable path -/
+
+/-- `siblingPath` has exactly `depth` entries along an openable path. Each
+constructor case knows its own bit, so the routing `if` reduces without a
+mirrored `split`. -/
+theorem siblingPath_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      (siblingPath H n depth index).size = depth := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => simp [siblingPath_zero]
+  | left hbit _ _ _ ihl =>
+      unfold siblingPath
+      simp [hbit, Array.size_push, ihl]
+  | right hbit _ _ _ ihr =>
+      unfold siblingPath
+      simp [hbit, Array.size_push, ihr]
+
+/-- Each entry of `siblingPath` along an openable path is 32 bytes. Entries below
+the top come from the sub-path IH. The top entry is the recorded sibling root,
+whose width and honest cache the predicate carries. No `CombineWidth32` here,
+because `IsOpenable` records the widths itself. -/
+theorem siblingPath_entries_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      ∀ i, i < depth → ((siblingPath H n depth index)[i]!).size = 32 := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => intro i hi; omega
+  | @left l r d index c hbit hl hr32 hc ihl =>
+      intro i hi
+      unfold siblingPath
+      simp only [hbit, Bool.false_eq_true, if_false]
+      have hsz : (siblingPath H l d index).size = d := siblingPath_size H hl
+      rcases Nat.lt_or_ge i d with hid | hid
+      · rw [getElem!_push_lt _ _ _ (by rw [hsz]; exact hid)]
+        exact ihl i hid
+      · have hi' : i = d := by omega
+        have htop := getElem!_push_size (siblingPath H l d index) (Node.rootOf H r)
+        rw [hsz] at htop
+        rw [hi', htop, rootOf_eq_merkleRoot H r]
+        exact hr32
+  | @right l r d index c hbit hr hl32 hc ihr =>
+      intro i hi
+      unfold siblingPath
+      simp only [hbit, if_true]
+      have hsz : (siblingPath H r d index).size = d := siblingPath_size H hr
+      rcases Nat.lt_or_ge i d with hid | hid
+      · rw [getElem!_push_lt _ _ _ (by rw [hsz]; exact hid)]
+        exact ihr i hid
+      · have hi' : i = d := by omega
+        have htop := getElem!_push_size (siblingPath H r d index) (Node.rootOf H l)
+        rw [hsz] at htop
+        rw [hi', htop, rootOf_eq_merkleRoot H l]
+        exact hl32
+
+/-- The chunk `leafAt` reaches along an openable path is 32 bytes: it is the stop
+node's root, whose width the `IsOpenable.stop` witness carries directly. -/
+theorem leafAt_size (H : Type) [Hasher H] :
+    ∀ {n : Node} {depth index : Nat}, IsOpenable H n depth index →
+      (leafAt H n depth index).size = 32 := by
+  intro n depth index ho
+  induction ho with
+  | stop m hsz index => rw [leafAt_zero]; exact hsz
+  | left hbit _ _ _ ihl => unfold leafAt; simp [hbit, ihl]
+  | right hbit _ _ _ ihr => unfold leafAt; simp [hbit, ihr]
+
+/-! ### Perfect trees are openable -/
+
+/-- Every perfect tree is openable at every index. The followed child comes from
+the same-depth subtree witness. The off-path sibling root is 32 bytes by
+`merkleRoot_size`, which is why the statement needs `CombineWidth32`. Cache
+validity at this level is `IsPerfect`'s own `hc`.
+
+The name does not extend SizzLean's `IsPerfect` namespace, since the conclusion
+is an EthCLLib predicate. A `SizzLean.Cache.MerkleTree.IsPerfect.isOpenable`
+would put a framework-typed declaration inside the SSZ library's namespace, which
+is the coupling this split removes. -/
+theorem isOpenable_of_isPerfect {H : Type} [Hasher H] [CombineWidth32 H] :
+    ∀ {n : Node} {d : Nat}, IsPerfect H n d → ∀ (index : Nat),
+      IsOpenable H n d index := by
+  intro n d hp
+  induction hp with
+  | leaf b hsz =>
+      intro index
+      exact .stop (.leaf b) (by rw [Node.rootOf_leaf]; exact hsz) index
+  | @pair l r d c hl hr hc ihl ihr =>
+      intro index
+      cases hbit : routeRight index d
+      · exact .left hbit (ihl index) (merkleRoot_size H hr) hc
+      · exact .right hbit (ihr index) (merkleRoot_size H hl) hc
+
+/-! ### The root-typed sugar -/
+
+/-- The honest leaf opening at `index`: the root of the node the path stops on,
+root-typed.
+
+No width hypothesis: `bytesToRoot` zero-pads a short buffer rather than failing,
+so this silently widens a malformed tree (see the `#guard` below). The theorems
+are safe because `IsOpenable.stop` carries
+`hsz : (Node.rootOf H m).size = 32`. -/
+def honestLeaf (H : Type) [Hasher H] (n : Node) (depth index : Nat) : Vector UInt8 32 :=
+  bytesToRoot (leafAt H n depth index)
+
+/-- The honest branch opening at `index`: the sibling path, root-typed entrywise.
+Same absent width hypothesis as `honestLeaf`, applied per entry. -/
+def honestBranch (H : Type) [Hasher H] (n : Node) (depth index : Nat) :
+    Array (Vector UInt8 32) :=
+  (siblingPath H n depth index).map bytesToRoot
+
+/-! **Pin: the sugar zero-pads a wrong-width leaf.** A 3-byte leaf opened at
+depth 0 comes back widened to 32. `honestBranch` returns an empty array, whose
+size matches depth 0. -/
+#guard
+  let b : ByteArray := ByteArray.mk #[1, 2, 3]
+  (honestLeaf Sha256Spec (.leaf b) 0 0).toList == [1, 2, 3] ++ List.replicate 29 0
+    && (honestBranch Sha256Spec (.leaf b) 0 0).size == 0
+
+/-- `bytesToRoot` then `vecToBytes` is the identity on exactly-32-byte buffers.
+`bytesToRoot b` reads the 32 bytes of `b` into a vector, and `vecToBytes`
+unwraps it. The composite is `b` iff `b` has exactly its 32 bytes. For
+`b.size ≠ 32` it truncates or zero-pads, which is why the hypothesis is there. -/
+theorem vecToBytes_bytesToRoot (b : ByteArray) (hsz : b.size = 32) :
+    vecToBytes (bytesToRoot b) = b := by
+  apply ByteArray.ext
+  show (Vector.ofFn (fun i : Fin 32 => b.get! i.val)).toArray = b.data
+  rw [Vector.toArray_ofFn]
+  apply Array.ext
+  · rw [Array.size_ofFn]; exact (ByteArray.size_data.trans hsz).symm
+  · intro i h1 h2
+    rw [Array.getElem_ofFn, SizzLean.Proofs.get!_eq_getElem b i h2,
+        ByteArray.getElem_eq_getElem_data]
+
+end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleOpening.lean
@@ -1,5 +1,6 @@
 import EthCLLib.Spec.Arith
 import EthCLLib.Spec.MerklePath
+import SizzLean.Cache.MerkleTree.Build
 import SizzLean.Proofs.Perfect
 import SizzLean.Proofs.Util
 
@@ -130,6 +131,75 @@ theorem siblingPath_zero (H : Type) [Hasher H] (m : Node) (index : Nat) :
     siblingPath H m 0 index = #[] := by
   cases m <;> rfl
 
+/-- The node reached from the root of `n` by following `index`'s bits, most
+significant first. Composition opens the *node* the first path reached, so it
+needs this rather than `leafAt`.
+
+The shape-mismatch arm returns `.leaf SizzLean.Spec.zero32`, so its root agrees
+with `leafAt`'s own fallthrough without a side condition. -/
+def nodeAt : Node → (depth : Nat) → (index : Nat) → Node
+  | m,             0,     _     => m
+  | .pair l r _,   d + 1, index =>
+      if routeRight index d then nodeAt r d index else nodeAt l d index
+  | _,             _,     _     => .leaf SizzLean.Spec.zero32
+
+/-- `nodeAt` at depth 0 is the node itself. Needs the same `cases` as
+`leafAt_zero`, for the same reason. -/
+theorem nodeAt_zero (m : Node) (index : Nat) : nodeAt m 0 index = m := by
+  cases m <;> rfl
+
+/-- **The two openers agree.** `leafAt` is `nodeAt` followed by `Node.rootOf`.
+
+Both recursions route on the same bit. Their shape-mismatch arms agree too:
+`leafAt` returns `zero32`, and `nodeAt` returns `.leaf zero32`.
+
+The completeness theorems state their leaf with `leafAt`. This lemma carries that
+leaf into `Node.rootOf`, which `rootOf_ofShape_eq_hashTreeRoot` turns into a
+`hash_tree_root`. -/
+theorem leafAt_eq_rootOf_nodeAt (H : Type) [Hasher H] :
+    ∀ (n : Node) (depth index : Nat),
+      leafAt H n depth index = Node.rootOf H (nodeAt n depth index)
+  | m,           0,     index => by
+      rw [leafAt_zero, nodeAt_zero]
+  | .pair l r c, d + 1, index => by
+      show (if routeRight index d then leafAt H r d index else leafAt H l d index)
+        = Node.rootOf H (if routeRight index d then nodeAt r d index else nodeAt l d index)
+      cases routeRight index d
+      · simpa using leafAt_eq_rootOf_nodeAt H l d index
+      · simpa using leafAt_eq_rootOf_nodeAt H r d index
+  | .leaf b,     d + 1, index => by
+      show SizzLean.Spec.zero32 = Node.rootOf H (.leaf SizzLean.Spec.zero32)
+      rw [Node.rootOf_leaf]
+
+/-! ### Index arithmetic for path composition
+
+Composing a depth-`d₁` path at `i₁` with a depth-`d₂` path at `i₂` addresses the
+combined index `i₁ * 2 ^ d₂ + i₂`. Below `d₂` that index reads `i₂`'s bits, at
+and above it reads `i₁`'s. Both lemmas cross into `Nat.testBit` first, through
+`routeRight_eq_testBit`. -/
+
+/-- Below the inner depth, the combined index reads the inner index's bits. -/
+theorem routeRight_combine_low (i₁ i₂ d₂ k : Nat) (hk : k < d₂) :
+    routeRight (i₁ * 2 ^ d₂ + i₂) k = routeRight i₂ k := by
+  -- Bits below `d₂` depend only on the value mod `2 ^ d₂`, which the outer
+  -- term, a multiple of `2 ^ d₂`, drops out of.
+  rw [routeRight_eq_testBit, routeRight_eq_testBit]
+  have hmod : ∀ x : Nat, Nat.testBit x k = Nat.testBit (x % 2 ^ d₂) k := by
+    intro x
+    rw [Nat.testBit_mod_two_pow]
+    simp [hk]
+  rw [hmod (i₁ * 2 ^ d₂ + i₂), hmod i₂, Nat.add_comm (i₁ * 2 ^ d₂) i₂,
+      Nat.add_mul_mod_self_right]
+
+/-- At and above the inner depth, the combined index reads the outer index's
+bits, shifted down by `d₂`. `i₂ < 2 ^ d₂` is what makes the inner index vanish
+under the division. -/
+theorem routeRight_combine_high (i₁ i₂ d₂ k : Nat) (hi₂ : i₂ < 2 ^ d₂) :
+    routeRight (i₁ * 2 ^ d₂ + i₂) (d₂ + k) = routeRight i₁ k := by
+  rw [routeRight_eq_testBit, routeRight_eq_testBit,
+      Nat.mul_comm i₁ (2 ^ d₂), Nat.testBit_two_pow_mul_add i₁ hi₂,
+      if_neg (by omega : ¬ d₂ + k < d₂), Nat.add_sub_cancel_left]
+
 /-! ### Sizes along an openable path -/
 
 /-- `siblingPath` has exactly `depth` entries along an openable path. Each
@@ -220,6 +290,157 @@ theorem isOpenable_of_isPerfect {H : Type} [Hasher H] [CombineWidth32 H] :
       cases hbit : routeRight index d
       · exact .left hbit (ihl index) (merkleRoot_size H hr) hc
       · exact .right hbit (ihr index) (merkleRoot_size H hl) hc
+
+/-! ### Path composition -/
+
+/-- An openable path depends on the index only through its low `depth` bits.
+Composition needs it, since the outer witness holds at `i₁` and has to be re-read
+at the combined index. -/
+theorem IsOpenable.index_congr {H : Type} [Hasher H] :
+    ∀ {n : Node} {d i : Nat}, IsOpenable H n d i → ∀ (j : Nat),
+      (∀ k, k < d → routeRight i k = routeRight j k) →
+      IsOpenable H n d j := by
+  intro n d i ho
+  induction ho with
+  | stop m hsz _ => intro j _; exact .stop m hsz j
+  | @left l r d i c hbit hl hr32 hc ih =>
+      intro j hbits
+      refine .left (by rw [← hbits d (Nat.lt_succ_self d)]; exact hbit)
+        (ih j (fun k hk => hbits k (Nat.lt_succ_of_lt hk))) hr32 hc
+  | @right l r d i c hbit hr hl32 hc ih =>
+      intro j hbits
+      refine .right (by rw [← hbits d (Nat.lt_succ_self d)]; exact hbit)
+        (ih j (fun k hk => hbits k (Nat.lt_succ_of_lt hk))) hl32 hc
+
+/-- **Path composition.** Take an openable path of depth `d₁`, then an openable
+path of depth `d₂` out of the node it reached. Together they are an openable
+path of depth `d₁ + d₂` at the concatenated index, with the outer path holding
+the high bits.
+
+A generalized index descending through a container field into that field's own
+tree is exactly this. -/
+theorem IsOpenable.trans {H : Type} [Hasher H] :
+    ∀ {n : Node} {d₁ i₁ : Nat}, IsOpenable H n d₁ i₁ →
+      ∀ {d₂ i₂ : Nat}, IsOpenable H (nodeAt n d₁ i₁) d₂ i₂ → i₂ < 2 ^ d₂ →
+        IsOpenable H n (d₁ + d₂) (i₁ * 2 ^ d₂ + i₂) := by
+  intro n d₁ i₁ h₁
+  induction h₁ with
+  | stop m hsz i₁ =>
+      intro d₂ i₂ h₂ hi₂
+      -- `nodeAt m 0 i₁ = m`, and `0 + d₂ = d₂`, so the inner witness is the
+      -- whole thing once its index is re-read at the combined value.
+      rw [nodeAt_zero] at h₂
+      simp only [Nat.zero_add]
+      exact h₂.index_congr _ (fun k hk => (routeRight_combine_low i₁ i₂ d₂ k hk).symm)
+  | @left l r d i₁ c hbit hl hr32 hc ih =>
+      intro d₂ i₂ h₂ hi₂
+      have h₂' : IsOpenable H (nodeAt l d i₁) d₂ i₂ := by simpa [nodeAt, hbit] using h₂
+      -- The constructor builds depth `(d + d₂) + 1`, the goal reads `d + 1 + d₂`.
+      -- Equal but not defeq while `d₂` is a variable, so say so explicitly.
+      rw [show d + 1 + d₂ = (d + d₂) + 1 by omega]
+      refine .left ?_ (ih h₂' hi₂) hr32 hc
+      -- Bit `d + d₂` of the combined index is bit `d` of `i₁`, which `hbit` fixes.
+      rw [Nat.add_comm d d₂, routeRight_combine_high i₁ i₂ d₂ d hi₂]
+      exact hbit
+  | @right l r d i₁ c hbit hr hl32 hc ih =>
+      intro d₂ i₂ h₂ hi₂
+      have h₂' : IsOpenable H (nodeAt r d i₁) d₂ i₂ := by simpa [nodeAt, hbit] using h₂
+      rw [show d + 1 + d₂ = (d + d₂) + 1 by omega]
+      refine .right ?_ (ih h₂' hi₂) hl32 hc
+      rw [Nat.add_comm d d₂, routeRight_combine_high i₁ i₂ d₂ d hi₂]
+      exact hbit
+
+/-! **Pin: composition concatenates the index, outer bits high.** Leaves sit in
+index order, so opening at `k` reaches leaf `k`. Composing at `i₁ = 1`, `i₂ = 1`
+addresses `1 * 2 ^ 2 + 1 = 5`. The last conjunct holds leaf 3, where a
+swapped-operand reading would have sent it. -/
+#guard
+  let mk : UInt8 → ByteArray := fun v => ByteArray.mk (Array.replicate 32 v)
+  let t : Node :=
+    .pair
+      (.pair (.pair (.leaf (mk 0)) (.leaf (mk 1)) none)
+             (.pair (.leaf (mk 2)) (.leaf (mk 3)) none) none)
+      (.pair (.pair (.leaf (mk 4)) (.leaf (mk 5)) none)
+             (.pair (.leaf (mk 6)) (.leaf (mk 7)) none) none)
+      none
+  (leafAt Sha256Spec t 3 5).toList == (mk 5).toList
+    && (leafAt Sha256Spec (nodeAt t 1 1) 2 1).toList == (mk 5).toList
+    && (leafAt Sha256Spec t 3 3).toList == (mk 3).toList
+
+/-! ### Trees the builders produce -/
+
+/-- Both halves of a `2 ^ (d + 1)`-bounded list are `2 ^ d`-bounded, which
+`ofSubtrees_isOpenable`'s half-splitting induction opens on. -/
+private theorem take_drop_length_le {α : Type} (xs : List α) (d : Nat)
+    (hlen : xs.length ≤ 2 ^ (d + 1)) :
+    (xs.take (2 ^ d)).length ≤ 2 ^ d ∧ (xs.drop (2 ^ d)).length ≤ 2 ^ d := by
+  have hpow : 2 ^ (d + 1) = 2 ^ d + 2 ^ d := by rw [Nat.pow_succ]; omega
+  refine ⟨?_, ?_⟩
+  · rw [List.length_take]; omega
+  · rw [List.length_drop]; omega
+
+/-- **`ofSubtrees` is openable at every position.** Take the balanced tree over
+at most `2 ^ depth` sub-trees, padded right with `zeroLeaf`. It admits a
+root-to-leaf path at any `k`, and stops on the sub-tree there.
+
+`k` is a bare `Nat`. Past capacity it routes on its low `depth` bits and lands
+at `k % 2 ^ depth`, as the spec's `is_valid_merkle_branch` also does.
+
+The induction threads the capacity bound. `take_drop_length_le` splits it across
+the two halves, and each half hands its share to the induction hypothesis. Only
+the depth-0 base case ignores it.
+
+The bound is there because `ofSubtrees` truncates an over-capacity list without
+saying so.
+The spec instead refuses ("if `limit < len(chunks)`: do not merkleize, input
+exceeds limit", `ssz/simple-serialize.md:381-382`).
+
+This is the container and composite-list shape. `Node.ofShape` builds a
+`container fs` as `ofSubtrees` over the field sub-trees at depth
+`chunkDepth fs.length` (`Build.lean:188`). It builds a composite `vector` the
+same way (`:172`). It builds a composite `list` at `chunkDepth cap`, where the
+bound arrives as `len ≤ cap ≤ 2 ^ chunkDepth cap` (`:184`). -/
+theorem ofSubtrees_isOpenable (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero : ∀ d, IsPerfect H (zeroLeaf H d) d) :
+    ∀ (depth : Nat) (subs : List Node),
+      subs.length ≤ 2 ^ depth →
+      (∀ s ∈ subs, (Node.rootOf H s).size = 32) →
+      ∀ k, IsOpenable H (Node.ofSubtrees H subs depth) depth k := by
+  intro depth
+  induction depth with
+  | zero =>
+      -- At depth 0 the bound admits at most one sub-tree, and either arm stops
+      -- immediately.
+      intro subs _hlen hsz k
+      cases subs with
+      | nil =>
+          refine .stop _ ?_ k
+          rw [rootOf_eq_merkleRoot]
+          exact merkleRoot_size H (hzero 0)
+      | cons s tl => exact .stop s (hsz s (by simp)) k
+  | succ d ih =>
+      intro subs hlen hsz k
+      obtain ⟨hLlen, hRlen⟩ := take_drop_length_le subs d hlen
+      have hL : ∀ s ∈ subs.take (2 ^ d), (Node.rootOf H s).size = 32 :=
+        fun s hs => hsz s (List.take_subset _ _ hs)
+      have hR : ∀ s ∈ subs.drop (2 ^ d), (Node.rootOf H s).size = 32 :=
+        fun s hs => hsz s (List.drop_subset _ _ hs)
+      unfold Node.ofSubtrees
+      simp only [List.splitAt_eq]
+      -- The right half is either more sub-trees or, once they run out, a
+      -- `zeroLeaf` pad. Both are openable and both have a 32-byte root. The
+      -- cache obligation is the same either way, inlined per arm.
+      cases hbit : routeRight k d
+      · refine .left hbit (ih _ hLlen hL k) ?_ ?_
+        · by_cases hre : (subs.drop (2 ^ d)).isEmpty = true
+          · rw [if_pos hre]; exact merkleRoot_size H (hzero d)
+          · rw [if_neg hre]; exact merkleRoot_ofSubtrees_size H hzero d _ hR
+        · exact cached_root_honest H _ _
+      · refine .right hbit ?_ (merkleRoot_ofSubtrees_size H hzero d _ hL) ?_
+        · by_cases hre : (subs.drop (2 ^ d)).isEmpty = true
+          · rw [if_pos hre]; exact isOpenable_of_isPerfect (hzero d) k
+          · rw [if_neg hre]; exact ih _ hRlen hR k
+        · exact cached_root_honest H _ _
 
 /-! ### The root-typed sugar -/
 

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleShape.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleShape.lean
@@ -1,0 +1,152 @@
+import EthCLLib.Proofs.MerkleOpening
+import SizzLean.Proofs.Merkleize
+import SizzLean.Proofs.ShapeAgreement
+
+/-!
+# `EthCLLib.Proofs.MerkleShape`: reading a position out of a built tree
+
+Where `MerkleOpening.lean` says a path exists, this module says what the path
+reaches. `nodeAt_ofSubtrees` reads position `k` of an `ofSubtrees` tree back as
+sub-tree `k % 2 ^ depth`. `nodeAt_ofShape_container` specialises that to a
+container, whose depth makes the residue collapse.
+
+Both results quantify over `nodeAt`, so they sit framework-side with the rest of
+the path vocabulary. SizzLean supplies the tree builders and their shape facts,
+and states nothing about paths into them.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Proofs
+
+open SizzLean SizzLean.Hasher SizzLean.Cache.MerkleTree SizzLean.Spec
+open EthCLLib.Spec
+
+/-! ### Reading a position out of an `ofSubtrees` tree
+
+`nodeAt` routes on bit `d` of the index and passes the index **unchanged** into
+the chosen child, re-reading the next bit one level down. `ofSubtrees` splits its
+list at `2 ^ d`, so the right child's position is `k - 2 ^ d`. The two only line
+up modulo `2 ^ depth`.
+
+The statement below therefore indexes at `k % 2 ^ depth`, and not at `k` under a
+`k < subs.length` hypothesis. Under that hypothesis the right branch's induction
+hypothesis would need `k < 2 ^ d`, which is false exactly there. -/
+
+/-- `routeRight` reads bit `d`. -/
+private theorem routeRight_true_iff (k d : Nat) :
+    routeRight k d = true ↔ k / 2 ^ d % 2 = 1 := by
+  simp [routeRight, Nat.shiftRight_eq_div_pow]
+
+/-- Splitting a residue at the top bit. Stated additively so `omega` can finish
+each of the two branches below, treating `2 ^ d` and the residues as atoms. -/
+private theorem mod_two_pow_succ (k d : Nat) :
+    k % 2 ^ (d + 1) = 2 ^ d * (k / 2 ^ d % 2) + k % 2 ^ d := by
+  have h1 : k % 2 ^ (d + 1) / 2 ^ d = k / 2 ^ d % 2 := by
+    rw [Nat.pow_succ]
+    exact Nat.mod_mul_right_div_self k (2 ^ d) 2
+  have h2 : k % 2 ^ (d + 1) % 2 ^ d = k % 2 ^ d :=
+    Nat.mod_mod_of_dvd k ⟨2, by rw [Nat.pow_succ]⟩
+  have h3 := Nat.div_add_mod (k % 2 ^ (d + 1)) (2 ^ d)
+  rw [h1, h2] at h3
+  omega
+
+private theorem mod_two_pow_succ_of_false {k d : Nat} (h : routeRight k d = false) :
+    k % 2 ^ (d + 1) = k % 2 ^ d := by
+  have hne : k / 2 ^ d % 2 ≠ 1 := by
+    intro hc
+    rw [(routeRight_true_iff k d).mpr hc] at h
+    exact Bool.noConfusion h
+  have hlt : k / 2 ^ d % 2 < 2 := Nat.mod_lt _ (by omega)
+  rw [mod_two_pow_succ, show k / 2 ^ d % 2 = 0 by omega]
+  omega
+
+private theorem mod_two_pow_succ_of_true {k d : Nat} (h : routeRight k d = true) :
+    k % 2 ^ (d + 1) = 2 ^ d + k % 2 ^ d := by
+  rw [mod_two_pow_succ, (routeRight_true_iff k d).mp h]
+  omega
+
+/-- **Position `k` of an `ofSubtrees` tree is sub-tree `k % 2 ^ depth`.**
+
+The out-of-range `zeroLeaf` pad never appears. The hypothesis says something
+occupies the position. In the right branch that reads
+`2 ^ d + k % 2 ^ d < subs.length`, which forces the dropped half to be
+non-empty. The pad's depth varies with the descent, and this proof never has to
+name it. -/
+theorem nodeAt_ofSubtrees (H : Type) [Hasher H] :
+    ∀ (depth : Nat) (subs : List Node) (k : Nat) (hk : k % 2 ^ depth < subs.length),
+      nodeAt (Node.ofSubtrees H subs depth) depth k = subs[k % 2 ^ depth] := by
+  intro depth
+  induction depth with
+  | zero =>
+      -- `hk` is the very proof the goal's `getElem` carries, so it must not be
+      -- rewritten in place. Everything goes through `simp`, which copes with the
+      -- dependency.
+      intro subs k hk
+      rw [nodeAt_zero]
+      cases subs with
+      | nil      => simp at hk
+      | cons s _ => simp [Node.ofSubtrees, Nat.mod_one]
+  | succ d ih =>
+      intro subs k hk
+      have hmodlt : k % 2 ^ d < 2 ^ d := Nat.mod_lt _ (Nat.two_pow_pos d)
+      rw [ofSubtrees_succ]
+      simp only [nodeAt]
+      cases hbit : routeRight k d with
+      | false =>
+          have hmod := mod_two_pow_succ_of_false hbit
+          have hklt : k % 2 ^ d < subs.length := by rw [← hmod]; exact hk
+          simp only [Bool.false_eq_true, if_false]
+          have hk' : k % 2 ^ d < (subs.take (2 ^ d)).length := by
+            rw [List.length_take]; omega
+          rw [ih (subs.take (2 ^ d)) k hk']
+          simp [hmod]
+      | true =>
+          have hmod := mod_two_pow_succ_of_true hbit
+          have hklt : 2 ^ d + k % 2 ^ d < subs.length := by rw [← hmod]; exact hk
+          have hne : ¬ (subs.drop (2 ^ d)).isEmpty = true := by
+            simp only [List.isEmpty_iff, List.drop_eq_nil_iff]
+            omega
+          simp only [if_true, if_neg hne]
+          have hk' : k % 2 ^ d < (subs.drop (2 ^ d)).length := by
+            rw [List.length_drop]; omega
+          rw [ih (subs.drop (2 ^ d)) k hk']
+          simp [hmod]
+
+/-! ### Reading a container's field sub-tree
+
+`nodeAt_ofSubtrees` indexes modulo `2 ^ depth`. At a container the depth is
+`chunkDepth fs.length`, and `chunkDepth` is `⌈log₂⌉`. The tree is therefore at
+least as wide as the field list, and the residue collapses. -/
+
+/-- Sub-tree `k` of a container is field `k`'s own `ofShape` tree. Induction on
+`fs` and `k` together, matching `fieldAt`'s recursion exactly. -/
+private theorem subtreesForFields_getElem (H : Type) [Hasher H] :
+    ∀ (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat) (hk : k < fs.length),
+      (Node.subtreesForFields H fs vs)[k]'(by
+        rw [subtreesForFields_length]; exact hk)
+        = Node.ofShape H (fs[k]) (SSZType.fieldAt fs vs k hk)
+  | _ :: _,  _,  0,     _  => by
+      simp [Node.subtreesForFields, SSZType.fieldAt]
+  | _ :: ts, vs, k + 1, hk => by
+      have hk' : k < ts.length := by simp only [List.length_cons] at hk; omega
+      simp only [Node.subtreesForFields, List.getElem_cons_succ, SSZType.fieldAt]
+      exact subtreesForFields_getElem H ts vs.2 k hk'
+
+/-- The field-`k` sub-tree of a container tree is the field value's own `ofShape`
+tree. `GeneralizedIndexBranch.lean`'s two-step witness discharges its `hsub`
+through this. -/
+theorem nodeAt_ofShape_container (H : Type) [Hasher H]
+    (fs : List SSZType) (vs : SSZType.interpFields fs) (k : Nat) (hk : k < fs.length) :
+    nodeAt (Node.ofShape H (.container fs) vs) (chunkDepth fs.length) k
+      = Node.ofShape H (fs[k]) (SSZType.fieldAt fs vs k hk) := by
+  have hmod : k % 2 ^ chunkDepth fs.length = k :=
+    Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hk (le_two_pow_chunkDepth fs.length))
+  have hk'' : k % 2 ^ chunkDepth fs.length < (Node.subtreesForFields H fs vs).length := by
+    rw [hmod, subtreesForFields_length]; exact hk
+  simp only [Node.ofShape]
+  rw [nodeAt_ofSubtrees H (chunkDepth fs.length) (Node.subtreesForFields H fs vs) k hk'']
+  simp only [hmod]
+  exact subtreesForFields_getElem H fs vs k hk
+
+end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
@@ -41,4 +41,14 @@ theorem routeRight_eq_div_mod (index i : Nat) :
   show ((index >>> i) &&& 1 == 1) = (index / 2 ^ i % 2 == 1)
   rw [Nat.shiftRight_eq_div_pow, Nat.and_one_is_mod]
 
+/-- `routeRight` is core's `Nat.testBit`. A bridge rather than a definitional
+change, so the spec-facing spelling stays while the index-splitting lemmas in
+`EthCLLib/Proofs/MerkleOpening.lean` reach core's bit lemmas. -/
+theorem routeRight_eq_testBit (index i : Nat) :
+    routeRight index i = Nat.testBit index i := by
+  rw [routeRight_eq_div_mod, Nat.testBit_eq_decide_div_mod_eq]
+  cases Nat.mod_two_eq_zero_or_one (index / 2 ^ i) with
+  | inl h => simp [h]
+  | inr h => simp [h]
+
 end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Tests.lean
+++ b/packages/EthCLLib/EthCLLib/Tests.lean
@@ -5,6 +5,7 @@ import EthCLLib.Tests.TierMerge
 import EthCLLib.Tests.CryptoBackendSpike
 import EthCLLib.Tests.ContainerForm
 import EthCLLib.Tests.FrameworkUtils
+import EthCLLib.Tests.MerkleWitness
 import EthCLLib.Tests.PreambleSection
 
 /-!

--- a/packages/EthCLLib/EthCLLib/Tests/MerkleWitness.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/MerkleWitness.lean
@@ -1,0 +1,74 @@
+import EthCLLib.Proofs.MerkleOpening
+import EthCLLib.Proofs.MerkleBranch
+import EthCLLib.Spec.SigningRoot
+
+/-!
+# `EthCLLib.Tests.MerkleWitness`: Merkle-branch length-guard witnesses
+
+Two rejection witnesses for `isValidMerkleBranch`, an over-length branch and a
+short one, pinning the guard in both directions.
+
+The spec returns early on `depth != len(branch)`
+(`specs/phase0/beacon-chain.md:809`). Completeness covers only the branches an
+honest opening produces, so it says nothing about this direction. These two
+statements are the ones `Proofs/MerkleBranch.lean` does not imply.
+
+The guard settles both before any hashing, so they close by `simp` and carry no
+compiler axiom.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Tests
+
+open SizzLean SizzLean.Hasher SizzLean.Cache.MerkleTree
+open EthCLLib.Spec EthCLLib.Proofs
+
+/-- **Over-length rejection.** The spec's `is_valid_merkle_branch` guards
+`depth != len(branch)` (`specs/phase0/beacon-chain.md:809`), so it rejects a
+branch longer than `depth` outright. Padding the depth-1 witness's honest branch
+with an extra sibling makes `branch.size = 2 ≠ 1 = depth`, so the check returns
+`false`.
+
+The guard decides this before the fold runs. Nothing hashes, and the root
+argument never forces. `simp` closes it on the branch's size alone. Plain
+`decide` does not: its `Decidable` instance will not reduce through
+`siblingPath`. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    letI : HasherTag := fastHasherTag
+    let tree : Node := .pair (.leaf z) (.leaf o) none
+    isValidMerkleBranch
+        (honestLeaf Sha256 tree 1 0)
+        ((honestBranch Sha256 tree 1 0).push (bytesToRoot o))
+        1 0
+        (bytesToRoot (Node.merkleRoot Sha256 tree))
+      = false := by
+  simp [isValidMerkleBranch, honestBranch, siblingPath, routeRight]
+
+/-- **Short-branch rejection.** The same guard cuts the other way. The spec
+compares `depth != len(branch)`, so it rejects a branch *shorter* than `depth`
+too. Popping the depth-1 witness's single sibling leaves `branch.size = 0 ≠ 1 =
+depth`, so the check returns `false` even though the leaf and root are the honest
+ones. `simp` closes it for the same reason as above.
+
+**Why index 1 and not 0.** At index 1 the removed sibling is the left child `z`,
+32 zero bytes. That is exactly what an unguarded `branch[0]!` returns on an empty
+array. The reconstruction would therefore still succeed, so the guard alone
+accounts for the `false`. At index 0 the sibling is `o`, the reconstruction fails
+on its own, and the test no longer isolates the guard. -/
+example :
+    let z : ByteArray := (ByteArray.mk (Array.replicate 32 0))
+    let o : ByteArray := (ByteArray.mk (Array.replicate 32 1))
+    letI : HasherTag := fastHasherTag
+    let tree : Node := .pair (.leaf z) (.leaf o) none
+    isValidMerkleBranch
+        (honestLeaf Sha256 tree 1 1)
+        ((honestBranch Sha256 tree 1 1).pop)
+        1 1
+        (bytesToRoot (Node.merkleRoot Sha256 tree))
+      = false := by
+  simp [isValidMerkleBranch, honestBranch, siblingPath, routeRight]
+
+end EthCLLib.Tests

--- a/packages/SizzLean/SizzLean.lean
+++ b/packages/SizzLean/SizzLean.lean
@@ -2,6 +2,7 @@ import SizzLean.Repr.Class
 import SizzLean.Repr.Instances
 import SizzLean.Repr.Deriving
 import SizzLean.Spec.SSZError
+import SizzLean.Spec.GeneralizedIndex
 import SizzLean.Hasher.Class
 import SizzLean.Hasher.Sha256
 import SizzLean.Hasher.Sha256Spec
@@ -16,6 +17,7 @@ import SizzLean.Proofs.SSZListPush
 import SizzLean.Proofs.SSZListGetElem
 import SizzLean.Proofs.SSZListSet
 import SizzLean.Proofs.Perfect
+import SizzLean.Proofs.ShapeWidth
 
 /-!
 # `SizzLean`: library root
@@ -31,6 +33,9 @@ their own code. They map one-to-one onto the sections of
   and the `deriving SSZRepr` handler.
 * `Spec/SSZError`: the deserialise-error sum returned by
   `SSZ.deserialize`.
+* `Spec/GeneralizedIndex`: `get_generalized_index` over `SSZType`,
+  the gindex arithmetic around it, and the `GIndexError` sum it
+  returns.
 * `Hasher/Class`, `Hasher/Sha256`, `Hasher/Sha256Spec`: the
   `Hasher` typeclass and its two shipping instances. The FFI
   `Sha256` instance delegates to the `LeanHazmatSha256` package

--- a/packages/SizzLean/SizzLean.lean
+++ b/packages/SizzLean/SizzLean.lean
@@ -18,6 +18,8 @@ import SizzLean.Proofs.SSZListGetElem
 import SizzLean.Proofs.SSZListSet
 import SizzLean.Proofs.Perfect
 import SizzLean.Proofs.ShapeWidth
+import SizzLean.Proofs.Merkleize
+import SizzLean.Proofs.ShapeAgreement
 
 /-!
 # `SizzLean`: library root
@@ -71,12 +73,13 @@ uses or by sibling packages (`EthCLSpecs` reaches into
 handler infrastructure). They are deliberately not listed here so
 this file reads as the user's mental model of the library.
 
-The `Proofs.SSZList*` modules are imported above to keep their
-native initializers in SizzLean's precompiled plugin. Their current EthCLSpecs
-consumers reach them by a qualified-path import; without these root imports, Lake
-emits the `.olean` but omits the module from the native plugin graph, causing
-plugin resolution to fail at runtime (`undefined symbol: initialize_SizzLean_…`).
-Any further `Proofs/` module that a sibling package imports needs the same line.
+The `Proofs/` modules listed above are imported to keep their native
+initializers in SizzLean's precompiled plugin. Their current EthCLSpecs and
+EthCLLib consumers reach them by a qualified-path import; without these root
+imports, Lake emits the `.olean` but omits the module from the native plugin
+graph, causing plugin resolution to fail at runtime
+(`undefined symbol: initialize_SizzLean_…`). Any further `Proofs/` module that a
+sibling package imports needs the same line.
 
 Acceptance / property-test gates live in a separate `lean_lib`
 (`SizzLeanTests`); the default `lake build` skips them and they

--- a/packages/SizzLean/SizzLean.lean
+++ b/packages/SizzLean/SizzLean.lean
@@ -15,6 +15,7 @@ import SizzLean.Cache.Update
 import SizzLean.Proofs.SSZListPush
 import SizzLean.Proofs.SSZListGetElem
 import SizzLean.Proofs.SSZListSet
+import SizzLean.Proofs.Perfect
 
 /-!
 # `SizzLean`: library root

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
@@ -64,6 +64,31 @@ call sites that just need the digest. -/
 def Node.merkleRoot (H : Type) [Hasher H] (n : Node) : ByteArray :=
   (n.merkleRootWithCache H).1
 
+/-! ### The three arms, stated before the seal
+
+`Node.merkleRoot` and `Node.rootOf` are the same structural recursion
+(`Proofs/Perfect.lean`'s `rootOf_eq_merkleRoot`), and they carry the same
+unfolding hazard. Both are therefore sealed. `Node.merkleRootWithCache` is the
+recursion, and `Node.merkleRoot` returns its first component, so the seal covers
+both. See `Cache/MerkleTree/Zero.lean`'s `Node.rootOf` for the reasoning and for
+why the attribute sits after the equations. -/
+
+/-- `merkleRoot` on a leaf is the leaf's bytes. -/
+theorem Node.merkleRoot_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.merkleRoot H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, honest or not. -/
+theorem Node.merkleRoot_pair_some (H : Type) [Hasher H]
+    (l r : Node) (root : ByteArray) :
+    Node.merkleRoot H (.pair l r (some root)) = root := rfl
+
+/-- An empty slot recurses and combines. -/
+theorem Node.merkleRoot_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.merkleRoot H (.pair l r none)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := rfl
+
+attribute [irreducible] Node.merkleRoot Node.merkleRootWithCache
+
 /-! ### Acceptance: cached path matches the spec oracle
 
 Two small hand-built trees, each compared against

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
@@ -106,17 +106,9 @@ inner `Vector UInt8 32` (= `Bytes32`) is a 32-byte basic-byte
 vector whose HTR is `zero32` when all-zero, identical to a `zero32`
 leaf in our tree. The outer `Vector ... n` then merkleizes the
 element roots at `chunkDepth n` depth, padding with `ZERO_HASHES`.
-This matches `Node.ofLeaves H (List.replicate n zeroBytes32) d`
+This matches `Node.ofLeaves H (List.replicate n zero32) d`
 when `2^d ≥ n`.
 -/
-
-/-- 32-byte all-zero `ByteArray`. Mirrors `Tree.Zero.zero32` but kept
-local because the latter is `private`. -/
-private def zeroBytes32 : ByteArray :=
-  let rec build : Nat → ByteArray → ByteArray
-    | 0,     acc => acc
-    | k + 1, acc => build k (acc.push 0)
-  build 32 ByteArray.empty
 
 /-- A `Vector UInt8 32` of all-zero bytes, the SSZ-side
 representation of the zero leaf. -/
@@ -126,7 +118,7 @@ private def zeroBytes32Vec : Vector UInt8 32 :=
 -- 4 zero leaves at depth 2, the simplest non-trivial case.
 example :
     (Node.ofLeaves Sha256
-        [zeroBytes32, zeroBytes32, zeroBytes32, zeroBytes32] 2).merkleRoot Sha256
+        [zero32, zero32, zero32, zero32] 2).merkleRoot Sha256
       =
     SizzLean.SSZ.hashTreeRoot Sha256
         (Vector.replicate 4 zeroBytes32Vec) := by
@@ -135,7 +127,7 @@ example :
 -- 8 zero leaves at depth 3, exact power-of-two, no zero-padding.
 example :
     (Node.ofLeaves Sha256
-        (List.replicate 8 zeroBytes32) 3).merkleRoot Sha256
+        (List.replicate 8 zero32) 3).merkleRoot Sha256
       =
     SizzLean.SSZ.hashTreeRoot Sha256
         (Vector.replicate 8 zeroBytes32Vec) := by

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
@@ -2,6 +2,7 @@ import SizzLean.Hasher.Class
 import SizzLean.Hasher.Sha256
 import LeanHazmatSha256
 import SizzLean.Cache.MerkleTree.Node
+import SizzLean.Hasher.Sha256Equiv
 
 /-!
 # `SizzLean.Cache.MerkleTree.Zero`: the zero-hash tower and the depth-padding leaf
@@ -223,5 +224,65 @@ def Node.ofLeaves (H : Type) [Hasher H] (leaves : List ByteArray)
       let root := Hasher.combine (H := H)
         (Node.rootOf H leftNode) (Node.rootOf H rightNode)
       .pair leftNode rightNode (some root)
+
+/-! ### Zero-table facts for the shape proofs
+
+`zeroHashes` and `zeroHashRec` are `private`, so the shape proofs work against
+these instead. -/
+
+/-- The memo table reads back its own recurrence at every in-range depth. -/
+private theorem zeroHashes_get (d : Nat) (h : d < 100) :
+    zeroHashes.get ⟨d, h⟩ = zeroHashRec d := by
+  simp [zeroHashes, Vector.get]
+
+/-- `zeroHashAt` is the recurrence at every depth: inside the table by lookup,
+past it by the fallback. `[Hasher H]` never enters: the memo is
+Sha256-specific. -/
+private theorem zeroHashAt_eq (H : Type) [Hasher H] (d : Nat) :
+    zeroHashAt H d = zeroHashRec d := by
+  unfold zeroHashAt
+  split
+  · rename_i h
+    exact zeroHashes_get d h
+  · rfl
+
+/-- Every entry of the recurrence is 32 bytes. The step rewrites the FFI combine
+to the pure-Lean reference through `sha256Combine_eq_spec`. -/
+private theorem zeroHashRec_size : ∀ (d : Nat), (zeroHashRec d).size = 32
+  | 0 => rfl
+  | d + 1 => by
+      show (LeanHazmat.Sha256.sha256Combine (zeroHashRec d) (zeroHashRec d)).size = 32
+      rw [sha256Combine_eq_spec]
+      exact LeanSha256.combine_size_eq_32 _ _
+
+/-- `zeroLeaf` at depth 0 is the zero-chunk leaf, stated through `zeroHashAt` so
+the tower lemmas chain without a detour through `zero32`. -/
+theorem zeroLeaf_zero (H : Type) [Hasher H] :
+    zeroLeaf H 0 = .leaf (zeroHashAt H 0) := by
+  rw [zeroHashAt_eq H 0]
+  rfl
+
+/-- `zeroLeaf` at a positive depth: the cached pair of two depth-`d` zero
+subtrees, the slot holding the table entry. -/
+theorem zeroLeaf_succ (H : Type) [Hasher H] (d : Nat) :
+    zeroLeaf H (d + 1)
+      = .pair (zeroLeaf H d) (zeroLeaf H d) (some (zeroHashAt H (d + 1))) := rfl
+
+/-- Each entry is the FFI combine of the previous entry with itself. Checks
+`zeroLeaf`'s pre-filled slots. -/
+theorem zeroHashAt_succ (H : Type) [Hasher H] (d : Nat) :
+    zeroHashAt H (d + 1)
+      = LeanHazmat.Sha256.sha256Combine (zeroHashAt H d) (zeroHashAt H d) := by
+  rw [zeroHashAt_eq H (d + 1), zeroHashAt_eq H d]
+  rfl
+
+/-- Every zero-hash is 32 bytes.
+
+**Axiom use**: carries `sha256Combine_eq_spec` (`Hasher/Sha256Equiv.lean`)
+through `zeroHashRec_size`. -/
+theorem zeroHashAt_size (H : Type) [Hasher H] (d : Nat) :
+    (zeroHashAt H d).size = 32 := by
+  rw [zeroHashAt_eq H d]
+  exact zeroHashRec_size d
 
 end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
@@ -141,12 +141,39 @@ slot at construction time.
 Not a substitute for `merkleRootWithCache`, since it doesn't fill
 cache slots in the input tree. Use when you only need the root
 *value* and the input is expected to be already cached (in which
-case it's O(1)). -/
-partial def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
+case it's O(1)).
+
+**Do not unfold this in a tactic.** Reason about it through
+`rootOf_eq_merkleRoot`, or through the equation lemmas below. See the seal note
+there for what the `@[irreducible]` attribute does and does not stop. -/
+def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
   | .leaf b               => b
   | .pair _ _ (some r)    => r
   | .pair l r none        =>
       Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r)
+
+/-! ### `Node.rootOf`'s equations, then the seal
+
+The three arms, stated before `Node.rootOf` goes irreducible. Proofs reach the
+recursion through these (or, better, through `rootOf_eq_merkleRoot`) instead of
+unfolding the definition and walking a real tree. -/
+
+/-- A leaf is its own root. -/
+theorem Node.rootOf_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.rootOf H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, with no descent. This arm
+makes `rootOf` O(1) on a committed tree, and it is why `rootOf` cannot notice a
+poisoned cache. -/
+theorem Node.rootOf_pair_some (H : Type) [Hasher H] (l r : Node) (root : ByteArray) :
+    Node.rootOf H (.pair l r (some root)) = root := rfl
+
+/-- An empty cache slot combines the children's roots. -/
+theorem Node.rootOf_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.rootOf H (.pair l r none)
+      = Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r) := rfl
+
+attribute [irreducible] Node.rootOf
 
 /-- A `Node` whose root is the all-zero subtree of depth `d`. Used
 by `Node.ofLeaves` to pad the right of an underfilled tree, and by

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
@@ -68,10 +68,11 @@ open SizzLean
 
 /-- 32-byte all-zero `ByteArray`. The leaf at every depth-`0`
 position of an all-zero subtree. Identical to `Spec.zero32`, kept
-here as a small private duplicate rather than importing the
-spec-internal helper because the Tree layer is meant to stand
-alone (so a future caller could load it without the spec). -/
-private def zero32 : ByteArray :=
+here as a small duplicate rather than importing the spec-internal
+helper because the Tree layer is meant to stand alone (so a future
+caller could load it without the spec). Public so the tower bridge
+can state `Cache.zero32 = Spec.zero32`. -/
+def zero32 : ByteArray :=
   let rec build : Nat → ByteArray → ByteArray
     | 0,     acc => acc
     | k + 1, acc => build k (acc.push 0)
@@ -267,6 +268,13 @@ subtrees, the slot holding the table entry. -/
 theorem zeroLeaf_succ (H : Type) [Hasher H] (d : Nat) :
     zeroLeaf H (d + 1)
       = .pair (zeroLeaf H d) (zeroLeaf H d) (some (zeroHashAt H (d + 1))) := rfl
+
+/-- The tower's base is the zero chunk. Exported because `zeroHashes` and the
+recurrence behind it are private, so an importer cannot reduce `zeroHashAt H 0`
+without indexing the `Vector.ofFn` table by hand. -/
+theorem zeroHashAt_zero (H : Type) [Hasher H] : zeroHashAt H 0 = zero32 := by
+  rw [zeroHashAt_eq H 0]
+  rfl
 
 /-- Each entry is the FFI combine of the previous entry with itself. Checks
 `zeroLeaf`'s pre-filled slots. -/

--- a/packages/SizzLean/SizzLean/Hasher/Class.lean
+++ b/packages/SizzLean/SizzLean/Hasher/Class.lean
@@ -63,4 +63,16 @@ Naming it explicitly resolves the ambiguity. Downstream files
 example {H : Type} [Hasher H] (b₁ b₂ : ByteArray) : ByteArray :=
   Hasher.combine (H := H) (Hasher.hash (H := H) b₁) b₂
 
+/-- The 32-byte-output contract of `Hasher.combine`, as a class the Merkle-proof
+lemmas take instead of threading `∀ a b, (combine a b).size = 32` through every
+statement.
+
+The class introduces no axiom of its own. Discharging the binder pulls in
+whatever the chosen instance rests on, so add an instance resting on an
+`@[extern]` bridge deliberately. `Prop` rather than `Type` keeps the witness
+proof-irrelevant and erased from compiled code. -/
+class CombineWidth32 (H : Type) [Hasher H] : Prop where
+  /-- `combine` returns exactly 32 bytes on any two inputs. -/
+  size : ∀ a b : ByteArray, (Hasher.combine (H := H) a b).size = 32
+
 end SizzLean

--- a/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
+++ b/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
@@ -1,0 +1,35 @@
+import SizzLean.Hasher.Sha256Spec
+import SizzLean.Hasher.Sha256Equiv
+
+/-!
+# `SizzLean.Hasher.CombineWidth`: the combine-width witnesses
+
+`CombineWidth32` instances for both concrete hashers. The class itself is in
+`Hasher/Class.lean`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Hasher
+
+/-- `Sha256Spec.combine` always returns a 32-byte digest, by
+`LeanSha256.combine_size_eq_32`. No axiom. -/
+theorem sha256Spec_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256Spec) a b).size = 32 :=
+  LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the pure-Lean hasher. -/
+instance : CombineWidth32 Sha256Spec := ⟨sha256Spec_combine_size⟩
+
+/-- `Sha256.combine` always returns a 32-byte digest, by `sha256Combine_eq_spec`
+then `LeanSha256.combine_size_eq_32`. -/
+theorem sha256_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256) a b).size = 32 := by
+  show (LeanHazmat.Sha256.sha256Combine a b).size = 32
+  rw [sha256Combine_eq_spec]
+  exact LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the FFI hasher. -/
+instance : CombineWidth32 Sha256 := ⟨sha256_combine_size⟩
+
+end SizzLean.Hasher

--- a/packages/SizzLean/SizzLean/Proofs/Merkleize.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Merkleize.lean
@@ -1,0 +1,422 @@
+import SizzLean.Cache.MerkleTree.Build
+import SizzLean.Proofs.Perfect
+
+/-!
+# `SizzLean.Proofs.Merkleize`: the spec merkleizer builds the cache tree
+
+`Spec.merkleize` is breadth-first. It folds one whole layer at a time with
+`combineLayerAt`, pads an odd tail with the level's zero hash, and
+short-circuits a singleton. `Node.ofLeaves` is
+depth-first: split at `2 ^ d`, recurse, pad the right with `zeroLeaf`. This file
+proves the two agree.
+
+Hasher-generic, under one hypothesis: that the cache layer's zero tower and the
+spec's agree (`hzt`). The two towers are different functions, a
+Sha256-specific memo against an `H`-generic recurrence, so the agreement cannot
+be free. `ShapeAgreement.lean` discharges it for both concrete hashers.
+
+Proof-only, and re-exported from `SizzLean.lean` alongside `Proofs/Perfect` and
+`Proofs/ShapeWidth`. `EthCLSpecs` imports the agreement results built on it, and
+a `Proofs/` module off the root never reaches the shared object.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+open SizzLean.Spec
+
+/-- `Node.ofLeaves` with a level offset: identical to it except the right-hand
+padding is a `zeroLeaf` at `lvl + d` rather than at `d`.
+
+Proof-local. It exists only to give the BFS induction a DFS counterpart whose
+padding tracks `combineLayerAt`'s `curLvl`. `ofLeavesAt_zero` collapses it back
+to `Node.ofLeaves` at the end. -/
+private def ofLeavesAt (H : Type) [Hasher H] (leaves : List ByteArray)
+    (depth : Nat) (lvl : Nat) : Node :=
+  match depth, leaves with
+  | 0,     []      => zeroLeaf H lvl
+  | 0,     l :: _  => .leaf l
+  | d + 1, ls      =>
+      let (leftLeaves, rightLeaves) := ls.splitAt (2 ^ d)
+      let leftNode := ofLeavesAt H leftLeaves d lvl
+      let rightNode :=
+        if rightLeaves.isEmpty then zeroLeaf H (lvl + d)
+        else ofLeavesAt H rightLeaves d lvl
+      .pair leftNode rightNode
+        (some (Hasher.combine (H := H) (Node.rootOf H leftNode) (Node.rootOf H rightNode)))
+
+/-- At offset 0 the builder is `Node.ofLeaves` itself. Structural induction on
+`depth`, generalising the leaf list because the recursive calls change it. -/
+private theorem ofLeavesAt_zero (H : Type) [Hasher H] :
+    ∀ (depth : Nat) (leaves : List ByteArray),
+      ofLeavesAt H leaves depth 0 = Node.ofLeaves H leaves depth := by
+  intro depth
+  induction depth with
+  | zero => intro leaves; cases leaves <;> rfl
+  | succ d ih =>
+      intro leaves
+      -- The rewrite needs `Nat.zero_add`. `ofLeavesAt`'s pad is
+      -- `zeroLeaf H (0 + d)` where `ofLeaves`' is `zeroLeaf H d`.
+      simp only [ofLeavesAt, Node.ofLeaves, List.splitAt_eq, Nat.zero_add, ih]
+
+/-! ### Equations for the offset builder
+
+`ofLeavesAt` matches on `depth` and `leaves` together and binds its halves with
+`let`, so the raw definition does not rewrite comfortably. The three lemmas below
+state its arms in the form the induction consumes. `splitAt` is already resolved
+to `take`/`drop`, and the depth-`d+1` root already read out of the cache
+slot. -/
+
+private theorem ofLeavesAt_nil (H : Type) [Hasher H] (lvl : Nat) :
+    ofLeavesAt H [] 0 lvl = zeroLeaf H lvl := rfl
+
+private theorem ofLeavesAt_cons (H : Type) [Hasher H] (l : ByteArray) (ls : List ByteArray)
+    (lvl : Nat) : ofLeavesAt H (l :: ls) 0 lvl = .leaf l := rfl
+
+private theorem ofLeavesAt_succ (H : Type) [Hasher H] (ls : List ByteArray) (d lvl : Nat) :
+    ofLeavesAt H ls (d + 1) lvl
+      = .pair (ofLeavesAt H (ls.take (2 ^ d)) d lvl)
+          (if (ls.drop (2 ^ d)).isEmpty then zeroLeaf H (lvl + d)
+           else ofLeavesAt H (ls.drop (2 ^ d)) d lvl)
+          (some (Hasher.combine (H := H)
+            (Node.rootOf H (ofLeavesAt H (ls.take (2 ^ d)) d lvl))
+            (Node.rootOf H
+              (if (ls.drop (2 ^ d)).isEmpty then zeroLeaf H (lvl + d)
+               else ofLeavesAt H (ls.drop (2 ^ d)) d lvl)))) := by
+  simp only [ofLeavesAt, List.splitAt_eq]
+
+/-- The workhorse. `ofLeavesAt` fills its cache slot at construction time, so
+`rootOf` reads the combine straight out without descending. -/
+private theorem rootOf_ofLeavesAt_succ (H : Type) [Hasher H] (ls : List ByteArray) (d lvl : Nat) :
+    Node.rootOf H (ofLeavesAt H ls (d + 1) lvl)
+      = Hasher.combine (H := H)
+          (Node.rootOf H (ofLeavesAt H (ls.take (2 ^ d)) d lvl))
+          (Node.rootOf H
+            (if (ls.drop (2 ^ d)).isEmpty then zeroLeaf H (lvl + d)
+             else ofLeavesAt H (ls.drop (2 ^ d)) d lvl)) := by
+  rw [ofLeavesAt_succ, Node.rootOf_pair_some]
+
+/-! ### `combineLayerAt` as a list operation
+
+One BFS layer is a positional pairing. The DFS split needs three facts about it.
+How long the result is, when it is empty, and how it commutes with `take` and
+`drop` at half the index. Nothing here mentions `Node`. -/
+
+/-- Two-at-a-time list induction. `combineLayerAt` consumes a pair per step, so
+plain `List.rec` hands back an induction hypothesis about `y :: rs` where every
+proof below needs one about `rs`. Stated once, over a fuel bound, and reused. -/
+private theorem twoStepInduction {motive : List ByteArray → Prop}
+    (hnil : motive []) (hone : ∀ x, motive [x])
+    (hcons : ∀ x y rs, motive rs → motive (x :: y :: rs)) :
+    ∀ ls, motive ls := by
+  have key : ∀ (fuel : Nat) (ls : List ByteArray), ls.length ≤ fuel → motive ls := by
+    intro fuel
+    induction fuel with
+    | zero =>
+        intro ls h
+        cases ls with
+        | nil => exact hnil
+        | cons a t => simp at h
+    | succ m ih =>
+        intro ls h
+        match ls with
+        | []  => exact hnil
+        | [x] => exact hone x
+        | x :: y :: rs =>
+            exact hcons x y rs (ih rs (by simp only [List.length_cons] at h; omega))
+  intro ls
+  exact key ls.length ls (Nat.le_refl _)
+
+/-- A layer is empty exactly when its input is. This is what lets the BFS and
+DFS sides agree on the `isEmpty` guard that picks padding over recursion. -/
+private theorem combineLayerAt_eq_nil_iff (H : Type) [Hasher H] (lvl : Nat) :
+    ∀ (ls : List ByteArray), combineLayerAt H lvl ls = [] ↔ ls = [] := by
+  refine twoStepInduction ?_ ?_ ?_
+  · simp [combineLayerAt_nil]
+  · intro x; simp [combineLayerAt_singleton]
+  · intro x y rs _; simp [combineLayerAt_cons₂]
+
+private theorem combineLayerAt_isEmpty (H : Type) [Hasher H] (lvl : Nat) :
+    ∀ (ls : List ByteArray), (combineLayerAt H lvl ls).isEmpty = ls.isEmpty := by
+  refine twoStepInduction ?_ ?_ ?_
+  · simp [combineLayerAt_nil]
+  · intro x; simp [combineLayerAt_singleton]
+  · intro x y rs _; simp [combineLayerAt_cons₂]
+
+/-- Pairing commutes with `take` at half the index: the first `2 * k` entries
+form the first `k` pairs. -/
+private theorem combineLayerAt_take (H : Type) [Hasher H] (lvl : Nat) :
+    ∀ (ls : List ByteArray) (k : Nat),
+      combineLayerAt H lvl (ls.take (2 * k)) = (combineLayerAt H lvl ls).take k := by
+  refine twoStepInduction ?_ ?_ ?_
+  · intro k; simp [combineLayerAt_nil]
+  · intro x k
+    cases k with
+    | zero => simp [combineLayerAt_nil]
+    | succ j =>
+        -- `2 * (j + 1)` is not syntactically a successor, so `take_succ_cons`
+        -- fires only after the rewrite below puts it in that form.
+        simp [show 2 * (j + 1) = 2 * j + 1 + 1 by omega, combineLayerAt_singleton]
+  · intro x y rs ih k
+    cases k with
+    | zero => simp [combineLayerAt_nil]
+    | succ j =>
+        simp only [show 2 * (j + 1) = 2 * j + 1 + 1 by omega, List.take_succ_cons,
+          combineLayerAt_cons₂, ih j]
+
+/-- Pairing commutes with `drop` at half the index. -/
+private theorem combineLayerAt_drop (H : Type) [Hasher H] (lvl : Nat) :
+    ∀ (ls : List ByteArray) (k : Nat),
+      combineLayerAt H lvl (ls.drop (2 * k)) = (combineLayerAt H lvl ls).drop k := by
+  refine twoStepInduction ?_ ?_ ?_
+  · intro k; simp [combineLayerAt_nil]
+  · intro x k
+    cases k with
+    | zero => simp
+    | succ j =>
+        simp [show 2 * (j + 1) = 2 * j + 1 + 1 by omega, combineLayerAt_singleton,
+          combineLayerAt_nil]
+  · intro x y rs ih k
+    cases k with
+    | zero => simp
+    | succ j =>
+        simp only [show 2 * (j + 1) = 2 * j + 1 + 1 by omega, List.drop_succ_cons,
+          combineLayerAt_cons₂, ih j]
+
+/-! ### One BFS layer is one DFS level -/
+
+/-- A non-empty list keeps a non-empty prefix. -/
+private theorem take_ne_nil {ls : List ByteArray} (hls : ls ≠ []) (k : Nat) (hk : 0 < k) :
+    ls.take k ≠ [] := by
+  cases ls with
+  | nil => exact absurd rfl hls
+  | cons a t =>
+      rw [show k = (k - 1) + 1 by omega, List.take_succ_cons]
+      simp
+
+/-- **The crux: one BFS layer is one DFS level.** Fold `combineLayerAt` over the
+leaf list and build one level shallower at the next offset. That gives the same
+root as building the original list one level deeper.
+
+Stated for a **non-empty** list, and the empty case does not fold into it.
+`Spec.merkleize` short-circuits an empty chunk list to a single tower lookup,
+while `ofLeavesAt` keeps building real `pair` nodes down to its given depth.
+`rootOf_ofLeavesAt_nil` below covers that case.
+
+`hzt` enters in exactly one place, the `[x]` base case, where the BFS side pads
+with `zeroHashAtDepth H lvl` and the DFS side with `Node.rootOf H (zeroLeaf H lvl)`.
+Everywhere else the two pads are the same `zeroLeaf` term, because the offset was
+chosen so that `lvl + (d + 1)` and `(lvl + 1) + d` coincide. -/
+private theorem ofLeavesAt_layer (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    ∀ (depth : Nat) (ls : List ByteArray), ls ≠ [] → ∀ (lvl : Nat),
+      Node.rootOf H (ofLeavesAt H ls (depth + 1) lvl)
+        = Node.rootOf H (ofLeavesAt H (combineLayerAt H lvl ls) depth (lvl + 1)) := by
+  intro depth
+  induction depth with
+  | zero =>
+      intro ls hls lvl
+      match ls with
+      | []  => exact absurd rfl hls
+      | [x] =>
+          -- The lone leaf pairs with the level's zero pad on both sides.
+          simp [rootOf_ofLeavesAt_succ, combineLayerAt_singleton, ofLeavesAt_cons,
+            Node.rootOf_leaf, hzt]
+      | x :: y :: rs =>
+          -- Two real leaves: the DFS split puts `x` left and `y` right, which is
+          -- the pair `combineLayerAt` produces. No padding, so no `hzt`.
+          simp [rootOf_ofLeavesAt_succ, combineLayerAt_cons₂, ofLeavesAt_cons,
+            Node.rootOf_leaf]
+  | succ d ih =>
+      intro ls hls lvl
+      have hpow : 2 ^ (d + 1) = 2 * 2 ^ d := by rw [Nat.pow_succ]; omega
+      have hpos : 0 < 2 ^ (d + 1) := Nat.two_pow_pos _
+      have htake : (combineLayerAt H lvl ls).take (2 ^ d)
+          = combineLayerAt H lvl (ls.take (2 ^ (d + 1))) := by
+        rw [hpow, combineLayerAt_take]
+      have hdrop : (combineLayerAt H lvl ls).drop (2 ^ d)
+          = combineLayerAt H lvl (ls.drop (2 ^ (d + 1))) := by
+        rw [hpow, combineLayerAt_drop]
+      -- Both expansions take explicit arguments. A bare rewrite would fire on
+      -- the freshly exposed left child instead of the right-hand side.
+      rw [rootOf_ofLeavesAt_succ H ls (d + 1) lvl,
+        rootOf_ofLeavesAt_succ H (combineLayerAt H lvl ls) d (lvl + 1),
+        htake, hdrop,
+        ih (ls.take (2 ^ (d + 1))) (take_ne_nil hls _ hpos) lvl,
+        combineLayerAt_isEmpty,
+        show lvl + 1 + d = lvl + (d + 1) by omega]
+      -- Both `if`s now test the same condition and pad with the same term.
+      by_cases hemp : ls.drop (2 ^ (d + 1)) = []
+      · simp [hemp]
+      · rw [if_neg (by simp [hemp]), if_neg (by simp [hemp]),
+          ih (ls.drop (2 ^ (d + 1))) hemp lvl]
+
+/-! ### `merkleizeAt`'s four arms, and the core theorem -/
+
+-- `merkleizeAt`'s termination is structural on `remaining`, so the compiled
+-- matcher splits on it first and neither of these reduces while it is a
+-- variable. Casing it makes both arms fire.
+private theorem merkleizeAt_nil (H : Type) [Hasher H] (lvl remaining : Nat) :
+    merkleizeAt H [] lvl remaining = zeroHashAtDepth H remaining := by
+  cases remaining <;> rfl
+
+private theorem merkleizeAt_singleton (H : Type) [Hasher H] (c : ByteArray) (lvl remaining : Nat) :
+    merkleizeAt H [c] lvl remaining = promoteThroughZeros H c lvl remaining := by
+  cases remaining <;> rfl
+
+/-- The defensive arm: more than one chunk with no levels left to build. The
+spec's own merkleizer asserts `count <= limit` before it starts. The pyspec would
+therefore refuse this state, and it has no defined answer. -/
+private theorem merkleizeAt_multi_zero (H : Type) [Hasher H]
+    (x y : ByteArray) (rs : List ByteArray) (lvl : Nat) :
+    merkleizeAt H (x :: y :: rs) lvl 0 = x := rfl
+
+private theorem merkleizeAt_multi_succ (H : Type) [Hasher H]
+    (x y : ByteArray) (rs : List ByteArray) (lvl k : Nat) :
+    merkleizeAt H (x :: y :: rs) lvl (k + 1)
+      = merkleizeAt H (combineLayerAt H lvl (x :: y :: rs)) (lvl + 1) k := rfl
+
+/-- The singleton short-circuit agrees with the builder. `merkleizeAt` sends a
+one-element list straight to `promoteThroughZeros`. The builder still descends,
+putting the single leaf on the far left and a `zeroLeaf` pad on every right.
+
+This needs no depth bound. `promoteThroughZeros` pads with the zero hash *of the
+level it is at*. The builder pads with that same term, so the tower recurrence
+never comes up. -/
+private theorem promoteThroughZeros_eq_ofLeavesAt (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    ∀ (remaining : Nat) (c : ByteArray) (lvl : Nat),
+      promoteThroughZeros H c lvl remaining
+        = Node.rootOf H (ofLeavesAt H [c] remaining lvl) := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro c lvl
+      rw [promoteThroughZeros_zero, ofLeavesAt_cons, Node.rootOf_leaf]
+  | succ k ih =>
+      intro c lvl
+      rw [promoteThroughZeros_succ, ih, ← combineLayerAt_singleton H lvl c]
+      exact (ofLeavesAt_layer H hzt k [c] (by simp) lvl).symm
+
+/-- **The spec merkleizer builds the cache tree**, for a non-empty chunk list.
+Induction on `remaining`, casing `cs` to match `merkleizeAt`'s three arms. The
+singleton arm is the lemma above. The multi-chunk arm is one layer plus the
+induction hypothesis. The defensive depth-0 arm holds because the builder also
+keeps only the head at depth 0. -/
+private theorem merkleizeAt_eq_ofLeavesAt (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    ∀ (remaining : Nat) (cs : List ByteArray), cs ≠ [] → ∀ (lvl : Nat),
+      merkleizeAt H cs lvl remaining
+        = Node.rootOf H (ofLeavesAt H cs remaining lvl) := by
+  intro remaining
+  induction remaining with
+  | zero =>
+      intro cs hcs lvl
+      match cs with
+      | []  => exact absurd rfl hcs
+      | [c] =>
+          rw [merkleizeAt_singleton, promoteThroughZeros_zero, ofLeavesAt_cons,
+            Node.rootOf_leaf]
+      | x :: y :: rs =>
+          rw [merkleizeAt_multi_zero, ofLeavesAt_cons, Node.rootOf_leaf]
+  | succ k ih =>
+      intro cs hcs lvl
+      match cs with
+      | []  => exact absurd rfl hcs
+      | [c] => rw [merkleizeAt_singleton, promoteThroughZeros_eq_ofLeavesAt H hzt]
+      | x :: y :: rs =>
+          have hne : combineLayerAt H lvl (x :: y :: rs) ≠ [] := by
+            simp [combineLayerAt_eq_nil_iff]
+          rw [merkleizeAt_multi_succ, ih _ hne (lvl + 1)]
+          exact (ofLeavesAt_layer H hzt k (x :: y :: rs) (by simp) lvl).symm
+
+/-- The empty chunk list: `merkleizeAt` returns one tower lookup, the builder
+returns a genuine tower, and the two are the same value at every depth. -/
+private theorem rootOf_ofLeavesAt_nil (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    ∀ (remaining lvl : Nat),
+      Node.rootOf H (ofLeavesAt H [] remaining lvl) = zeroHashAtDepth H (lvl + remaining) := by
+  intro remaining
+  induction remaining with
+  | zero => intro lvl; rw [ofLeavesAt_nil, hzt, Nat.add_zero]
+  | succ k ih =>
+      intro lvl
+      rw [rootOf_ofLeavesAt_succ, List.take_nil, List.drop_nil,
+        if_pos (by simp : ([] : List ByteArray).isEmpty = true),
+        ih lvl, hzt (lvl + k),
+        show lvl + (k + 1) = (lvl + k) + 1 by omega,
+        zeroHashAtDepth_succ H (lvl + k)]
+
+/-- **`merkleize` is the cache builder.** `merkleize` of a chunk list is the root
+of the tree `Node.ofLeaves` builds from it, at every depth. -/
+theorem merkleize_eq_ofLeaves (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d)
+    (cs : List ByteArray) (depth : Nat) :
+    merkleize H cs depth = Node.rootOf H (Node.ofLeaves H cs depth) := by
+  rw [merkleize_eq_merkleizeAt, ← ofLeavesAt_zero]
+  by_cases hcs : cs = []
+  · subst hcs
+    rw [merkleizeAt_nil, rootOf_ofLeavesAt_nil H hzt depth 0, Nat.zero_add]
+  · exact merkleizeAt_eq_ofLeavesAt H hzt depth cs hcs 0
+
+/-! ### The two structural helpers the shape arms need -/
+
+theorem ofSubtrees_succ (H : Type) [Hasher H] (subs : List Node) (d : Nat) :
+    Node.ofSubtrees H subs (d + 1)
+      = .pair (Node.ofSubtrees H (subs.take (2 ^ d)) d)
+          (if (subs.drop (2 ^ d)).isEmpty then zeroLeaf H d
+           else Node.ofSubtrees H (subs.drop (2 ^ d)) d)
+          (some (Hasher.combine (H := H)
+            (Node.rootOf H (Node.ofSubtrees H (subs.take (2 ^ d)) d))
+            (Node.rootOf H
+              (if (subs.drop (2 ^ d)).isEmpty then zeroLeaf H d
+               else Node.ofSubtrees H (subs.drop (2 ^ d)) d)))) := by
+  simp only [Node.ofSubtrees, List.splitAt_eq]
+
+private theorem rootOf_ofSubtrees_succ (H : Type) [Hasher H] (subs : List Node) (d : Nat) :
+    Node.rootOf H (Node.ofSubtrees H subs (d + 1))
+      = Hasher.combine (H := H)
+          (Node.rootOf H (Node.ofSubtrees H (subs.take (2 ^ d)) d))
+          (Node.rootOf H
+            (if (subs.drop (2 ^ d)).isEmpty then zeroLeaf H d
+             else Node.ofSubtrees H (subs.drop (2 ^ d)) d)) := by
+  rw [ofSubtrees_succ, Node.rootOf_pair_some]
+
+private theorem rootOf_ofLeaves_succ (H : Type) [Hasher H] (ls : List ByteArray) (d : Nat) :
+    Node.rootOf H (Node.ofLeaves H ls (d + 1))
+      = Hasher.combine (H := H)
+          (Node.rootOf H (Node.ofLeaves H (ls.take (2 ^ d)) d))
+          (Node.rootOf H
+            (if (ls.drop (2 ^ d)).isEmpty then zeroLeaf H d
+             else Node.ofLeaves H (ls.drop (2 ^ d)) d)) := by
+  rw [← ofLeavesAt_zero, rootOf_ofLeavesAt_succ]
+  simp only [Nat.zero_add, ofLeavesAt_zero]
+
+/-- Composite arms merkleize a list of sub-tree *roots*, so they need the builder
+over sub-trees rather than over leaves. The two builders share the split-at-`2^d`
+shape, so this is `List.map` commuting with `take`, `drop` and `isEmpty`. -/
+theorem rootOf_ofSubtrees_eq_ofLeaves (H : Type) [Hasher H] :
+    ∀ (depth : Nat) (subs : List Node),
+      Node.rootOf H (Node.ofSubtrees H subs depth)
+        = Node.rootOf H (Node.ofLeaves H (subs.map (Node.rootOf H)) depth) := by
+  intro depth
+  induction depth with
+  | zero =>
+      intro subs
+      cases subs with
+      | nil => rfl
+      | cons s tl =>
+          rw [show Node.ofSubtrees H (s :: tl) 0 = s from rfl,
+            show Node.ofLeaves H ((s :: tl).map (Node.rootOf H)) 0
+              = .leaf (Node.rootOf H s) from rfl, Node.rootOf_leaf]
+  | succ d ih =>
+      intro subs
+      rw [rootOf_ofSubtrees_succ, rootOf_ofLeaves_succ]
+      simp only [← List.map_take, ← List.map_drop, List.isEmpty_map, ih]
+      by_cases hemp : subs.drop (2 ^ d) = []
+      · simp [hemp]
+      · rw [if_neg (by simp [hemp]), if_neg (by simp [hemp]), ih]
+
+end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Proofs/Perfect.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Perfect.lean
@@ -1,4 +1,5 @@
 import SizzLean.Cache.MerkleTree.Merkle
+import SizzLean.Cache.MerkleTree.Build
 import SizzLean.Hasher.CombineWidth
 
 /-!
@@ -74,6 +75,11 @@ theorem merkleRoot_pair (H : Type) [Hasher H] {l r : Node} {c : Option ByteArray
       rw [Node.merkleRoot_pair_some H l r root]
       exact hc root rfl
 
+/-- `Node.merkleRoot` on a leaf returns the leaf bytes. Local alias for
+`Node.merkleRoot_leaf`, which sits beside the definition. -/
+theorem merkleRoot_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.merkleRoot H (.leaf b) = b := Node.merkleRoot_leaf H b
+
 /-- `Node.rootOf` agrees with `Node.merkleRoot` on **every** `Node`, with no
 shape or cache-validity hypothesis: the two are the same structural recursion.
 Neither inspects whether a populated cache slot is honest, so this holds for a
@@ -108,6 +114,90 @@ theorem merkleRoot_size (H : Type) [Hasher H] [CombineWidth32 H] :
   | leaf b hsz => simpa [Node.merkleRoot_leaf] using hsz
   | @pair l r d c hl hr hc ihl ihr =>
       rw [merkleRoot_pair H hc]
+      exact CombineWidth32.size _ _
+
+/-- The `zeroLeaf` pad's root is 32 bytes. `hzero` supplies the width through
+`merkleRoot_size`. -/
+theorem rootOf_zeroLeaf_size_of_isPerfect (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero : ∀ d, IsPerfect H (zeroLeaf H d) d) (d : Nat) :
+    (Node.rootOf H (zeroLeaf H d)).size = 32 := by
+  rw [rootOf_eq_merkleRoot]
+  exact merkleRoot_size H (hzero d)
+
+/-! ### Trees the builders produce -/
+
+/-- The `hc` obligation for a node the builders cached honestly. Every
+constructor in `Cache/MerkleTree/Build.lean` fills the slot with
+`combine (rootOf l) (rootOf r)`, which `rootOf_eq_merkleRoot` turns into
+`combine (merkleRoot l) (merkleRoot r)`. -/
+theorem cached_root_honest (H : Type) [Hasher H] (l r : Node) :
+    ∀ root,
+      some (Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r)) = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := by
+  intro root heq
+  rw [Option.some.injEq] at heq
+  rw [← heq]
+  simp only [rootOf_eq_merkleRoot]
+
+/-- `zeroLeaf` trees are perfect for any hasher whose `combine` agrees with the
+FFI `sha256Combine` that populated the memo. `hcomb` is `rfl` for `Sha256`.
+
+**Axiom use**: inherits `sha256Combine_eq_spec` (`Hasher/Sha256Equiv.lean`)
+through `zeroHashAt_size`, at every hasher. -/
+theorem zeroLeaf_isPerfect_of_combine (H : Type) [Hasher H]
+    (hcomb : ∀ a b, Hasher.combine (H := H) a b = LeanHazmat.Sha256.sha256Combine a b) :
+    ∀ (d : Nat), IsPerfect H (zeroLeaf H d) d := by
+  intro d
+  induction d with
+  | zero =>
+      rw [zeroLeaf_zero]
+      exact .leaf _ (zeroHashAt_size H 0)
+  | succ k ih =>
+      have hkp : IsPerfect H (zeroLeaf H k) k := ih
+      -- The depth-`k` zero subtree's root is the table entry, carried by the
+      -- leaf's own bytes or by the pair's pre-filled cache slot.
+      have hroot : Node.merkleRoot H (zeroLeaf H k) = zeroHashAt H k := by
+        cases k with
+        | zero => rw [zeroLeaf_zero, merkleRoot_leaf]
+        | succ j =>
+            rw [zeroLeaf_succ, Node.merkleRoot_pair_some]
+      rw [zeroLeaf_succ]
+      refine .pair hkp hkp ?_
+      intro root heq
+      rw [Option.some.injEq] at heq
+      rw [← heq, hroot, hcomb, zeroHashAt_succ H k]
+
+/-- `zeroLeaf` perfection at `Sha256`, where `combine` is `sha256Combine` and
+`hcomb` is `rfl`. Discharges the `hzero` hypothesis the padded-tree theorems
+carry.
+
+**Axiom use**: inherits `sha256Combine_eq_spec` (`Hasher/Sha256Equiv.lean`)
+through `zeroHashAt_size`. -/
+theorem zeroLeaf_isPerfect_sha256 (d : Nat) :
+    IsPerfect Sha256 (zeroLeaf Sha256 d) d :=
+  zeroLeaf_isPerfect_of_combine Sha256 (fun _ _ => rfl) d
+
+/-- Every `ofSubtrees` tree has a 32-byte root, given its sub-trees do. Interior
+levels are `combine` outputs, 32 by `CombineWidth32`. Depth 0 is either a
+supplied sub-tree or the `zeroLeaf` pad, whose width comes from `hzero`. A single
+`cases` on the depth, no induction. -/
+theorem merkleRoot_ofSubtrees_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero : ∀ d, IsPerfect H (zeroLeaf H d) d) :
+    ∀ (depth : Nat) (subs : List Node),
+      (∀ s ∈ subs, (Node.rootOf H s).size = 32) →
+      (Node.merkleRoot H (Node.ofSubtrees H subs depth)).size = 32 := by
+  intro depth subs hsz
+  cases depth with
+  | zero =>
+      cases subs with
+      | nil => exact merkleRoot_size H (hzero 0)
+      | cons s tl =>
+          rw [show Node.ofSubtrees H (s :: tl) 0 = s from rfl, ← rootOf_eq_merkleRoot]
+          exact hsz s (by simp)
+  | succ d =>
+      unfold Node.ofSubtrees
+      simp only [List.splitAt_eq]
+      rw [merkleRoot_pair H (cached_root_honest H _ _)]
       exact CombineWidth32.size _ _
 
 end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Proofs/Perfect.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Perfect.lean
@@ -1,0 +1,113 @@
+import SizzLean.Cache.MerkleTree.Merkle
+import SizzLean.Hasher.CombineWidth
+
+/-!
+# `SizzLean.Proofs.Perfect`: perfect combine-trees
+
+The tree-shape vocabulary Merkle-proof theorems quantify over. `IsPerfect` says a
+`Node` is a perfect binary combine-tree of a given depth under a hasher. Three
+shape facts follow. `merkleRoot_pair` collapses the cached and uncached readings
+of a pair. `rootOf_eq_merkleRoot` licenses reading any cache observation as the
+honest root. `merkleRoot_size` gives every root in such a tree 32 bytes.
+
+The path vocabulary sits one layer up, in `EthCLLib.Proofs.MerkleOpening`.
+`IsOpenable`, `leafAt` and `siblingPath` all route by a convention that
+`is_valid_merkle_branch` owns, and that check is a consensus-spec function rather
+than an SSZ-document one. SizzLean therefore states shape and width, and the
+framework states openings.
+
+Pure `Node` vocabulary, hasher-generic. The declarations sit in the
+`SizzLean.Cache.MerkleTree` namespace, where `Node` and the cache walkers live,
+while the file sits under `SizzLean/Proofs/`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+
+/-- A `Node` that is a *perfect* binary combine-tree of depth `d` under hasher
+`H`. Leaves at depth `0` carry exactly 32 bytes. Interior nodes at depth `d+1`
+are pairs of depth-`d` perfect subtrees whose cache slot, *if populated*, holds
+the honest `combine` of the children's roots.
+
+The cache-validity side condition (`hc`) lets these theorems reach cached trees.
+For an uncached pair (`c = none`) `hc` is vacuous. For a cached pair it pins the
+stored root to `combine (merkleRoot H l) (merkleRoot H r)`, the value
+`merkleRootWithCache` computes. `Node.merkleRoot` therefore agrees either way
+(`merkleRoot_pair`).
+
+Two shapes fall outside the predicate. A `zeroLeaf`-padded subtree caches
+Sha256-specific zero-hash bytes, so it meets `hc` only for that hasher.
+`Node.mixInLength` pairs a depth-`d` subtree with a depth-0 length leaf. Above
+`d = 0` its two children sit at different depths, so it is not `IsPerfect`. At
+`d = 0` both children are depth-0 leaves and it is, which nothing here depends
+on.
+
+The hasher `H` is a parameter because the invariant refers to
+`Node.merkleRoot H`. -/
+inductive IsPerfect (H : Type) [Hasher H] : Node → Nat → Prop where
+  | leaf (b : ByteArray) (hsz : b.size = 32) : IsPerfect H (.leaf b) 0
+  | pair {l r : Node} {d : Nat} {c : Option ByteArray}
+      (hl : IsPerfect H l d) (hr : IsPerfect H r d)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsPerfect H (.pair l r c) (d + 1)
+
+/-- The root of a valid perfect pair is the honest `combine` of the children's
+roots, at a populated cache slot and an empty one alike. For `none` this is
+`merkleRootWithCache`'s own recursion. For `some root` the cache-validity witness
+`hc` pins the stored value.
+
+The tree-walking proofs go through this bridge instead of unfolding
+`merkleRootWithCache` on an uncached node. They therefore apply unchanged to the
+cached trees the constructors emit. -/
+theorem merkleRoot_pair (H : Type) [Hasher H] {l r : Node} {c : Option ByteArray}
+    (hc : ∀ root, c = some root →
+      root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+    Node.merkleRoot H (.pair l r c)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := by
+  cases c with
+  | none => exact Node.merkleRoot_pair_none H l r
+  | some root =>
+      rw [Node.merkleRoot_pair_some H l r root]
+      exact hc root rfl
+
+/-- `Node.rootOf` agrees with `Node.merkleRoot` on **every** `Node`, with no
+shape or cache-validity hypothesis: the two are the same structural recursion.
+Neither inspects whether a populated cache slot is honest, so this holds for a
+tree carrying poisoned caches too, both read the same poison.
+
+Both walkers are `@[irreducible]`, since unfolding either in a tactic walks a
+real 262144-leaf tree. Every arm therefore enters by its named equation lemma,
+and not by `simp [Node.rootOf]` or `simp [Node.merkleRoot]`. -/
+theorem rootOf_eq_merkleRoot (H : Type) [Hasher H] (n : Node) :
+    Node.rootOf H n = Node.merkleRoot H n := by
+  induction n with
+  | leaf b => rw [Node.rootOf_leaf, Node.merkleRoot_leaf]
+  | pair l r c ihl ihr =>
+      cases c with
+      | some x => rw [Node.rootOf_pair_some, Node.merkleRoot_pair_some]
+      | none =>
+          rw [Node.rootOf_pair_none, Node.merkleRoot_pair_none, ihl, ihr]
+
+/-- Every root in a perfect tree is 32 bytes. Leaves are 32 by `IsPerfect.leaf`.
+Interior nodes are `combine` outputs, 32 by the `CombineWidth32` contract. The
+proof reaches that contract through `merkleRoot_pair`, which covers a cached pair
+and an uncached one alike.
+
+The contract arrives as a `[CombineWidth32 H]` instance, so this theorem
+introduces no axiom of its own. An instantiation costs whatever the supplied
+instance rests on (see `SizzLean/Hasher/Class.lean`). -/
+theorem merkleRoot_size (H : Type) [Hasher H] [CombineWidth32 H] :
+    ∀ {n : Node} {depth : Nat}, IsPerfect H n depth →
+      (Node.merkleRoot H n).size = 32 := by
+  intro n depth hp
+  induction hp with
+  | leaf b hsz => simpa [Node.merkleRoot_leaf] using hsz
+  | @pair l r d c hl hr hc ihl ihr =>
+      rw [merkleRoot_pair H hc]
+      exact CombineWidth32.size _ _
+
+end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Proofs/ShapeAgreement.lean
+++ b/packages/SizzLean/SizzLean/Proofs/ShapeAgreement.lean
@@ -1,0 +1,245 @@
+import SizzLean.Proofs.Merkleize
+import SizzLean.Proofs.ShapeWidth
+import SizzLean.Spec.GeneralizedIndex
+
+/-!
+# `SizzLean.Proofs.ShapeAgreement`: built trees carry the spec's roots
+
+`Node.ofShape` and `SSZType.hashTreeRoot` run arm-for-arm parallel
+(`Build.lean:110-114`). This file proves the root identity that parallelism
+implies. `SizzLeanTests/TreeBackedCoherence.lean` checks it by `native_decide` on
+concrete containers.
+
+Every completeness theorem on the Merkle stack quantifies over
+`Node.ofShape … merkleRoot`. This converts them into claims about the roots the
+spec computes.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+open SizzLean.Spec
+
+/-! ### The two zero towers
+
+The cache layer memoises a Sha256-specific table. The spec recomputes an
+`H`-generic recurrence. They agree at every depth, since both run the same
+doubling recurrence and the memo only caches its first 100 entries. -/
+
+/-- A zero subtree's root is its table entry: depth 0 is the leaf itself, and
+every deeper one reads the slot `zeroLeaf` pre-filled at construction. -/
+private theorem rootOf_zeroLeaf (H : Type) [Hasher H] :
+    ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAt H d
+  | 0     => by rw [zeroLeaf_zero, Node.rootOf_leaf]
+  | _ + 1 => by rw [zeroLeaf_succ, Node.rootOf_pair_some]
+
+/-- The memo table and the spec recurrence agree at every depth.
+
+`hcomb` is the one hasher-specific input. The cache tower is a Sha256-specific
+memo that calls the FFI `sha256Combine` directly. The spec tower goes through
+`Hasher.combine (H := H)`. -/
+private theorem zeroHashAt_eq_zeroHashAtDepth (H : Type) [Hasher H]
+    (hcomb : ∀ a b, Hasher.combine (H := H) a b = LeanHazmat.Sha256.sha256Combine a b) :
+    ∀ d, zeroHashAt H d = zeroHashAtDepth H d
+  -- The two `zero32`s are separate definitions, the cache layer keeping its own
+  -- copy so it can load without the spec, so the base closes by `rfl` rather
+  -- than by matching syntactically.
+  | 0 => by rw [zeroHashAtDepth_zero, zeroHashAt_zero]; rfl
+  | d + 1 => by
+      rw [zeroHashAt_succ H d, zeroHashAtDepth_succ H d, ← hcomb,
+        zeroHashAt_eq_zeroHashAtDepth H hcomb d]
+
+/-- **The two zero towers agree.** The cache layer's is the spec's, at every
+depth. -/
+private theorem rootOf_zeroLeaf_eq_zeroHashAtDepth (H : Type) [Hasher H]
+    (hcomb : ∀ a b, Hasher.combine (H := H) a b = LeanHazmat.Sha256.sha256Combine a b)
+    (d : Nat) : Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d := by
+  rw [rootOf_zeroLeaf, zeroHashAt_eq_zeroHashAtDepth H hcomb]
+
+/-- At the shipped FFI hasher, `combine` *is* `sha256Combine`, so the tower
+agreement is free. -/
+theorem rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256 :
+    ∀ d, Node.rootOf Sha256 (zeroLeaf Sha256 d) = zeroHashAtDepth Sha256 d :=
+  rootOf_zeroLeaf_eq_zeroHashAtDepth Sha256 (fun _ _ => rfl)
+
+/-- At the pure-Lean reference hasher, `combine` is `LeanSha256.combine`, a
+different function from the memo's FFI call. The bridge is the named
+`sha256Combine_eq_spec` axiom, which therefore appears in `#print axioms` of this
+corollary and everything downstream of it. -/
+theorem rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256Spec :
+    ∀ d, Node.rootOf Sha256Spec (zeroLeaf Sha256Spec d) = zeroHashAtDepth Sha256Spec d :=
+  rootOf_zeroLeaf_eq_zeroHashAtDepth Sha256Spec
+    (fun _ _ => by rw [sha256Combine_eq_spec]; rfl)
+
+/-- The degenerate `uintN` width. The builder pads an empty buffer where the
+spec returns the zero chunk bare, and padding nothing to a chunk *is* the zero
+chunk. -/
+private theorem padToChunk_empty : padToChunk ByteArray.empty = SizzLean.Spec.zero32 := rfl
+
+/-- The length mix-in commutes with taking roots. `Node.mixInLength` fills its
+cache slot with the combine, and `Spec.mixInLength` *is* that combine. -/
+private theorem rootOf_mixInLength (H : Type) [Hasher H] (n : Node) (count : Nat) :
+    Node.rootOf H (Node.mixInLength H n count)
+      = Hasher.combine (H := H) (Node.rootOf H n) (natToChunk count) := by
+  rw [Node.mixInLength, Node.rootOf_pair_some, Node.rootOf_leaf]
+
+/-! ### Every built tree carries the spec's root
+
+The three statements below are proven together because `Node.ofShape`,
+`Node.subtreesForFields` and `Node.subtreesForListComposite` are one `mutual`
+group (`Build.lean:116-215`). Lean 4.29.1 generates no functional-induction
+principle for that block, so this mirrors the definition's own pattern match
+under the explicit `(sizeOf type, phase, elements)` measure `ShapeWidth.lean`
+introduced. The `phase` component is what lets `subtreesForListComposite` call
+`ofShape` at an unchanged element type.
+
+No arm closes by `rfl`. `SSZType.hashTreeRoot` and `SSZType.serialize` both come
+from `mutual` blocks, so neither reduces definitionally, even on the arms whose
+two sides read identically. Every arm goes through the equation lemmas
+instead. -/
+
+-- The dependent match on `s.interp` refines against `interp`'s per-constructor
+-- recursion, the same elaborator cost `Build.lean` and `ShapeWidth.lean` raise
+-- this for.
+set_option maxHeartbeats 1000000
+
+mutual
+
+/-- **Every built tree carries the spec's root.** -/
+theorem rootOf_ofShape_eq_hashTreeRoot (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    (s : SSZType) → (x : s.interp) →
+      Node.rootOf H (Node.ofShape H s x) = SSZType.hashTreeRoot H s x
+  | .uintN 8,   _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf]
+  | .uintN 16,  _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf,
+        SSZType.serialize, uint16LE]
+  | .uintN 32,  _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf,
+        SSZType.serialize, uint32LE]
+  | .uintN 64,  _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf,
+        SSZType.serialize, uint64LE]
+  | .uintN 128, _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf]
+  | .uintN 256, _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf]
+  | .uintN _,   _ => by
+      -- The builder's catch-all pads an empty buffer. The spec returns `zero32`
+      -- bare, and `padToChunk ByteArray.empty = Spec.zero32`. The guarded
+      -- equation lemma will not fire from a bare pattern variable, so unfold
+      -- both matches and let `split` enumerate.
+      -- `split` on two matches relates the two sides' witnesses by `HEq` across
+      -- types that agree only after `subst_vars` substitutes the width
+      -- equation, so `heq_eq_eq` cannot fire before then. After that
+      -- `simp_all` closes both the diagonal cases and the impossible
+      -- cross-cases, the latter from a `∀ x, ¬ _ ≍ x` hypothesis at `x` itself.
+      rw [Node.ofShape.eq_def, SSZType.hashTreeRoot.eq_def]
+      split <;> split <;> (try subst_eqs) <;>
+        simp_all [Node.rootOf_leaf, SSZType.serialize, uint16LE, uint32LE, uint64LE,
+          padToChunk_empty]
+  | .bool, _ => by
+      simp [Node.ofShape, SSZType.hashTreeRoot, Node.rootOf_leaf]
+  | .bitvector _, _ => by
+      simp only [Node.ofShape, SSZType.hashTreeRoot]
+      exact (merkleize_eq_ofLeaves H hzt _ _).symm
+  | .bitlist _, _ => by
+      -- `hashTreeRoot`'s body mentions `merkleize` under its own namespace, which
+      -- no rewrite can match by name, so the last step goes through `exact`
+      -- (defeq) rather than `rw` (syntactic).
+      simp only [Node.ofShape, SSZType.hashTreeRoot]
+      rw [rootOf_mixInLength, mixInLength_eq]
+      exact congrArg (fun r => Hasher.combine (H := H) r (natToChunk _))
+        (merkleize_eq_ofLeaves H hzt _ _).symm
+  | .vector t n, v => by
+      simp only [Node.ofShape, SSZType.hashTreeRoot]
+      split
+      · exact (merkleize_eq_ofLeaves H hzt _ _).symm
+      · rw [rootOf_ofSubtrees_eq_ofLeaves,
+          rootOf_subtreesForListComposite_eq H hzt t _ []]
+        exact (merkleize_eq_ofLeaves H hzt _ _).symm
+  | .list t cap, xs => by
+      simp only [Node.ofShape, SSZType.hashTreeRoot]
+      split
+      · rw [rootOf_mixInLength, mixInLength_eq]
+        exact congrArg (fun r => Hasher.combine (H := H) r (natToChunk _))
+          (merkleize_eq_ofLeaves H hzt _ _).symm
+      · rw [rootOf_mixInLength, mixInLength_eq, rootOf_ofSubtrees_eq_ofLeaves,
+          rootOf_subtreesForListComposite_eq H hzt t _ []]
+        exact congrArg (fun r => Hasher.combine (H := H) r (natToChunk _))
+          (merkleize_eq_ofLeaves H hzt _ _).symm
+  | .container fs, vs => by
+      simp only [Node.ofShape, SSZType.hashTreeRoot]
+      rw [rootOf_ofSubtrees_eq_ofLeaves, rootOf_subtreesForFields_eq H hzt fs vs]
+      exact (merkleize_eq_ofLeaves H hzt _ _).symm
+termination_by s _ => (sizeOf s, 0, 0)
+
+/-- Companion: the per-field sub-tree roots are the spec's field roots. -/
+theorem rootOf_subtreesForFields_eq (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d) :
+    (fs : List SSZType) → (vs : SSZType.interpFields fs) →
+      (Node.subtreesForFields H fs vs).map (Node.rootOf H)
+        = SSZType.hashTreeRootFields H fs vs
+  | [],      _  => by simp [Node.subtreesForFields, SSZType.hashTreeRootFields]
+  | t :: ts, vs => by
+      have ihHead := rootOf_ofShape_eq_hashTreeRoot H hzt t vs.1
+      have ihTail := rootOf_subtreesForFields_eq H hzt ts vs.2
+      simp [Node.subtreesForFields, SSZType.hashTreeRootFields, ihHead, ihTail]
+termination_by fs _ => (sizeOf fs, 0, 0)
+
+/-- Companion: the per-element sub-tree roots are the spec's element roots. The
+statement generalises over the accumulator, since both builders recurse
+tail-first and close with a `reverse`. -/
+theorem rootOf_subtreesForListComposite_eq (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d)
+    (t : SSZType) :
+    (xs : List t.interp) → (acc : List Node) →
+      (Node.subtreesForListComposite H t xs acc).map (Node.rootOf H)
+        = SSZType.hashTreeRootListComposite H t xs (acc.map (Node.rootOf H))
+  | [],      acc => by
+      simp [Node.subtreesForListComposite, SSZType.hashTreeRootListComposite]
+  | x :: xs, acc => by
+      have ihHead := rootOf_ofShape_eq_hashTreeRoot H hzt t x
+      have ihTail := rootOf_subtreesForListComposite_eq H hzt t xs
+        (Node.ofShape H t x :: acc)
+      simp [Node.subtreesForListComposite, SSZType.hashTreeRootListComposite,
+        ihHead] at ihTail ⊢
+      exact ihTail
+termination_by xs _ => (sizeOf t, 1, xs.length)
+
+end
+
+/-! ### The `merkleRoot` form, and the two concrete hashers -/
+
+/-- The `merkleRoot` form, which every completeness theorem on the stack
+quantifies over. `rootOf_eq_merkleRoot` holds on every `Node` with no hypothesis,
+so this is a rewrite. -/
+theorem merkleRoot_ofShape_eq_hashTreeRoot (H : Type) [Hasher H]
+    (hzt : ∀ d, Node.rootOf H (zeroLeaf H d) = zeroHashAtDepth H d)
+    (s : SSZType) (x : s.interp) :
+    Node.merkleRoot H (Node.ofShape H s x) = SSZType.hashTreeRoot H s x := by
+  rw [← rootOf_eq_merkleRoot]
+  exact rootOf_ofShape_eq_hashTreeRoot H hzt s x
+
+/-- At the shipped FFI hasher, the one the fork bodies bind through
+`fastHasherTag`. Carries no named FFI axiom: the zero tower is free here. -/
+theorem merkleRoot_ofShape_eq_hashTreeRoot_sha256
+    (s : SSZType) (x : s.interp) :
+    Node.merkleRoot Sha256 (Node.ofShape Sha256 s x)
+      = SSZType.hashTreeRoot Sha256 s x :=
+  merkleRoot_ofShape_eq_hashTreeRoot Sha256
+    rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256 s x
+
+/-- At the pure-Lean reference hasher. Carries `sha256Combine_eq_spec`, since the
+memo tower reaches the reference hasher only through that bridge. -/
+theorem merkleRoot_ofShape_eq_hashTreeRoot_sha256Spec
+    (s : SSZType) (x : s.interp) :
+    Node.merkleRoot Sha256Spec (Node.ofShape Sha256Spec s x)
+      = SSZType.hashTreeRoot Sha256Spec s x :=
+  merkleRoot_ofShape_eq_hashTreeRoot Sha256Spec
+    rootOf_zeroLeaf_eq_zeroHashAtDepth_sha256Spec s x
+
+end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Proofs/ShapeWidth.lean
+++ b/packages/SizzLean/SizzLean/Proofs/ShapeWidth.lean
@@ -1,0 +1,321 @@
+import SizzLean.Cache.MerkleTree.Build
+import SizzLean.Proofs.Perfect
+
+/-!
+# `SizzLean.Proofs.ShapeWidth`: every built tree has a 32-byte root
+
+`ofSubtrees_isOpenable` (`EthCLLib.Proofs.MerkleOpening`) asks each sub-tree for
+a 32-byte root before it will hand back a path witness. For a container or a
+composite list those sub-trees are `Node.ofShape` trees. The obligation is
+therefore "every shape builds to a 32-byte root". The proof below runs by mutual
+induction over the `ofShape` / `subtreesForFields` / `subtreesForListComposite`
+block (`Cache/MerkleTree/Build.lean:116-215`).
+
+Proof-only, and re-exported from `SizzLean.lean` alongside `Proofs/Perfect`
+because `EthCLLib` imports it. A `Proofs/` module off the root never reaches the
+library's shared object, and the importer then fails at load time.
+
+Hasher-generic. The zero-padding arms need the `zeroLeaf` pad's own root width,
+which enters as the `hzero32` hypothesis, the same way `ofSubtrees_isOpenable`
+threads `hzero`. Its witness `rootOf_zeroLeaf_size` reaches the FFI-populated
+memo through `zeroHashAt_size`, so that declaration carries
+`sha256Combine_eq_spec`. The rest of the file is axiom-free.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+open SizzLean.Spec
+
+/-- `padToChunk` widens a short buffer to exactly one chunk. Only true for
+`b.size ≤ 32`: the definition returns `b` untouched when it is already at least a
+chunk wide, so an over-long buffer stays over-long. Every `ofShape` basic-type arm
+feeds it a serialisation of at most 32 bytes. -/
+private theorem padToChunk_size (b : ByteArray) (hb : b.size ≤ 32) :
+    (padToChunk b).size = 32 := by
+  -- The `else` arm is a fuel loop pushing `32 - b.size` zero bytes, so the width
+  -- claim is about the loop. Generalise over it before touching the `if`.
+  have key : ∀ (k : Nat) (acc : ByteArray),
+      (padToChunk.go k acc).size = acc.size + k := by
+    intro k
+    induction k with
+    | zero => intro acc; rfl
+    | succ n ih =>
+        intro acc
+        rw [show padToChunk.go (n + 1) acc = padToChunk.go n (acc.push 0) from rfl,
+            ih (acc.push 0), ByteArray.size_push]
+        omega
+  -- `padToChunk`'s `let n := b.size` elaborates to a `have`, which `split` will
+  -- not see through. The `rfl` below zeta-reduces it and exposes the `if`.
+  have hbp : BYTES_PER_CHUNK = 32 := rfl
+  rw [show padToChunk b
+        = if b.size ≥ BYTES_PER_CHUNK then b
+          else padToChunk.go (BYTES_PER_CHUNK - b.size) b from rfl]
+  split
+  · omega
+  · rw [key]; omega
+
+/-- Every chunk `chunkify` emits is exactly 32 bytes. Each one is `padToChunk` of
+a 32-wide `extract`, and an extract is never wider than its window. Feeds the
+`ofLeaves` arms of `rootOf_ofShape_size`, whose leaves are all `chunkify` output. -/
+private theorem chunkify_size (b : ByteArray) : ∀ c ∈ chunkify b, c.size = 32 := by
+  -- Same shape as `padToChunk_size`: the claim is about the accumulator loop, so
+  -- carry "every entry so far is 32 bytes" as the invariant.
+  have key : ∀ (k : Nat) (acc : List ByteArray),
+      (∀ c ∈ acc, c.size = 32) → ∀ c ∈ chunkify.go b k acc, c.size = 32 := by
+    intro k
+    induction k with
+    | zero => intro acc hacc; exact hacc
+    | succ n ih =>
+        intro acc hacc
+        rw [show chunkify.go b (n + 1) acc
+              = chunkify.go b n
+                  (padToChunk (b.extract (n * BYTES_PER_CHUNK)
+                    (n * BYTES_PER_CHUNK + BYTES_PER_CHUNK)) :: acc) from rfl]
+        refine ih _ ?_
+        intro c hc
+        rcases List.mem_cons.mp hc with h | h
+        · subst h
+          exact padToChunk_size _ (by
+            have hbp : BYTES_PER_CHUNK = 32 := rfl
+            rw [ByteArray.size_extract]; omega)
+        · exact hacc c h
+  rw [show chunkify b
+        = if (b.size + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK = 0 then []
+          else chunkify.go b ((b.size + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK) [] from rfl]
+  split
+  · intro c hc; simp at hc
+  · exact key _ [] (by simp)
+
+/-- A `zeroLeaf` pad has a 32-byte root at every depth. Depth 0 is the zero
+chunk. A positive depth is a pair whose cache slot holds `zeroHashAt`, 32 bytes
+by `zeroHashAt_size`.
+
+Width is strictly weaker than `IsPerfect`. That predicate also pins every cached
+slot to the honest `combine`. It therefore needs a hypothesis tying the hasher
+to the one that populated the zero table (`zeroLeaf_isPerfect_of_combine`).
+Nothing here reads the bytes, only their length, so this statement drops that
+hypothesis. -/
+theorem rootOf_zeroLeaf_size (H : Type) [Hasher H] (d : Nat) :
+    (Node.rootOf H (zeroLeaf H d)).size = 32 := by
+  rw [rootOf_eq_merkleRoot]
+  cases d with
+  | zero => rw [zeroLeaf_zero, merkleRoot_leaf]; exact zeroHashAt_size H 0
+  | succ k =>
+      -- The seal on `merkleRoot` blocks unfolding. Enter through the
+      -- populated-slot arm, since `zeroLeaf` pre-fills it at construction.
+      rw [zeroLeaf_succ, Node.merkleRoot_pair_some]
+      exact zeroHashAt_size H (k + 1)
+
+/-- An `ofLeaves` tree has a 32-byte root, given its data leaves do. It needs no
+depth bound and no `IsPerfect` witness. Above depth 0 the constructor emits a
+pair whose cache slot already holds a `combine` output, 32 by `CombineWidth32`,
+whatever sits beneath it. Depth 0 is a data leaf or a `zeroLeaf` pad.
+
+Deliberately weaker in its hypotheses than the perfection route
+(an `IsPerfect` witness + `merkleRoot_size`), which would drag in `hzero`. -/
+private theorem rootOf_ofLeaves_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero32 : ∀ d, (Node.rootOf H (zeroLeaf H d)).size = 32)
+    (leaves : List ByteArray) (hsz : ∀ l ∈ leaves, l.size = 32) (depth : Nat) :
+    (Node.rootOf H (Node.ofLeaves H leaves depth)).size = 32 := by
+  rw [rootOf_eq_merkleRoot]
+  cases depth with
+  | zero =>
+      cases leaves with
+      | nil =>
+          rw [show Node.ofLeaves H ([] : List ByteArray) 0 = zeroLeaf H 0 from rfl,
+              ← rootOf_eq_merkleRoot]
+          exact hzero32 0
+      | cons l tl =>
+          rw [show Node.ofLeaves H (l :: tl) 0 = .leaf l from rfl, merkleRoot_leaf]
+          exact hsz l (by simp)
+  | succ d =>
+      unfold Node.ofLeaves
+      simp only [List.splitAt_eq]
+      rw [merkleRoot_pair H (by
+        intro root heq
+        rw [Option.some.injEq] at heq
+        rw [← heq]; simp only [rootOf_eq_merkleRoot])]
+      exact CombineWidth32.size _ _
+
+/-- An `ofSubtrees` tree has a 32-byte root, given its sub-trees do. The
+`hzero`-free counterpart of `merkleRoot_ofSubtrees_size` in
+`Proofs/Perfect.lean`, which routes the zero pad through `IsPerfect`. Here the
+pad's width comes straight from `rootOf_zeroLeaf_size`. -/
+private theorem rootOf_ofSubtrees_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero32 : ∀ d, (Node.rootOf H (zeroLeaf H d)).size = 32)
+    (subs : List Node) (hsz : ∀ s ∈ subs, (Node.rootOf H s).size = 32) (depth : Nat) :
+    (Node.rootOf H (Node.ofSubtrees H subs depth)).size = 32 := by
+  rw [rootOf_eq_merkleRoot]
+  cases depth with
+  | zero =>
+      cases subs with
+      | nil =>
+          rw [show Node.ofSubtrees H ([] : List Node) 0 = zeroLeaf H 0 from rfl,
+              ← rootOf_eq_merkleRoot]
+          exact hzero32 0
+      | cons s tl =>
+          rw [show Node.ofSubtrees H (s :: tl) 0 = s from rfl, ← rootOf_eq_merkleRoot]
+          exact hsz s (by simp)
+  | succ d =>
+      unfold Node.ofSubtrees
+      simp only [List.splitAt_eq]
+      rw [merkleRoot_pair H (by
+        intro root heq
+        rw [Option.some.injEq] at heq
+        rw [← heq]; simp only [rootOf_eq_merkleRoot])]
+      exact CombineWidth32.size _ _
+
+/-- A `mixInLength` wrapper has a 32-byte root: the constructor's cached slot holds
+a `combine` output, 32 by `CombineWidth32`. Needs nothing about the body. -/
+private theorem rootOf_mixInLength_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (n : Node) (count : Nat) :
+    (Node.rootOf H (Node.mixInLength H n count)).size = 32 := by
+  rw [rootOf_eq_merkleRoot, Node.mixInLength,
+      merkleRoot_pair H (by
+        intro root heq
+        rw [Option.some.injEq] at heq
+        rw [← heq]; simp only [rootOf_eq_merkleRoot])]
+  exact CombineWidth32.size _ _
+
+/-! ### Every `ofShape` tree has a 32-byte root
+
+The three statements below are proven together because `Node.ofShape`,
+`Node.subtreesForFields` and `Node.subtreesForListComposite` are one `mutual`
+group (`Build.lean:116-215`). Lean 4.29.1 generates no functional-induction
+principle for that block. `Node.ofShape.induct` and both spellings of the mutual
+variant are unknown identifiers, checked. This proof therefore mirrors the
+definition's own pattern match and carries an explicit lexicographic measure.
+
+The measure is `(sizeOf type, phase, elements)`. The first component falls on
+every descent into a field type or an element type. The `phase` component lets
+`subtreesForListComposite` call `ofShape` at the *same* element type. The list
+builder sits at phase 1 and the shape builder at phase 0, so that call descends
+even where the type stays the same. The third component carries the list
+builder's own recursion down its element list. -/
+
+-- The dependent match on `s.interp` refines against `interp`'s per-constructor
+-- recursion, the same elaborator cost that makes `Build.lean` raise this.
+set_option maxHeartbeats 1000000
+
+mutual
+
+/-- **Every `ofShape` tree has a 32-byte root**, together with the two sub-tree
+list builders that share its `mutual` block.
+
+This is the fact `ofSubtrees_isOpenable` needs at a container or composite-list
+position, and it is what makes a generalized index into such a field openable.
+
+No `hzero` here. Every arm bottoms out in `padToChunk` (exactly a chunk), a
+cached `combine` output, or a `zeroLeaf` root, and all three are 32 bytes. -/
+theorem rootOf_ofShape_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero32 : ∀ d, (Node.rootOf H (zeroLeaf H d)).size = 32) :
+    (s : SSZType) → (x : s.interp) → (Node.rootOf H (Node.ofShape H s x)).size = 32
+  | .uintN 8,    _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]; exact padToChunk_size _ (by simp)
+  | .uintN 16,   _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]
+      exact padToChunk_size _ (by simp [SSZType.serialize, uint16LE])
+  | .uintN 32,   _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]
+      exact padToChunk_size _ (by simp [SSZType.serialize, uint32LE])
+  | .uintN 64,   _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]
+      exact padToChunk_size _ (by simp [SSZType.serialize, uint64LE])
+  | .uintN 128,  _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]
+      exact padToChunk_size _ (by simp [natToChunk_size])
+  | .uintN 256,  _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]
+      exact padToChunk_size _ (by simp [natToChunk_size])
+  | .uintN _,    _ => by
+      -- The builder's own catch-all (a non-spec width, one zero chunk). Its
+      -- equation lemma carries the guard "the width is none of the six
+      -- literals", which `simp only [Node.ofShape]` cannot discharge from a bare
+      -- pattern variable. Unfold the whole match and let `split` do the case
+      -- work. `split` also enumerates the non-`uintN` arms. Each of those
+      -- carries a constructor-clash equation, so `simp_all` closes them.
+      rw [Node.ofShape.eq_def]
+      split <;>
+        first
+          | (rw [Node.rootOf_leaf]
+             exact padToChunk_size _ (by
+               simp [SSZType.serialize, uint16LE, uint32LE, uint64LE, natToChunk_size]))
+          | simp_all
+  | .bool,       _ => by
+      simp only [Node.ofShape, Node.rootOf_leaf]; exact padToChunk_size _ (by simp)
+  | .bitvector _, _ => by
+      simp only [Node.ofShape]; exact rootOf_ofLeaves_size H hzero32 _ (chunkify_size _) _
+  | .bitlist _,   _ => by
+      simp only [Node.ofShape]; exact rootOf_mixInLength_size H _ _
+  | .vector t _, _ => by
+      -- Basic elements flatten to chunks. Composite elements recurse per element.
+      simp only [Node.ofShape]
+      split
+      · exact rootOf_ofLeaves_size H hzero32 _ (chunkify_size _) _
+      · exact rootOf_ofSubtrees_size H hzero32 _
+          (rootOf_subtreesForListComposite_size H hzero32 t _ [] (by simp)) _
+  | .list _ _,   _ => by
+      -- Both branches wrap in `mixInLength`, whose root is a `combine` output,
+      -- so neither needs anything about the body.
+      simp only [Node.ofShape]
+      split <;> exact rootOf_mixInLength_size H _ _
+  | .container fs, vs => by
+      simp only [Node.ofShape]
+      exact rootOf_ofSubtrees_size H hzero32 _ (rootOf_subtreesForFields_size H hzero32 fs vs) _
+termination_by s _ => (sizeOf s, 0, 0)
+
+/-- The sub-tree list has one entry per field. It sits here and not with the
+agreement proofs, because `ofSubtrees_isOpenable`'s capacity side condition needs
+it from this module onwards. -/
+theorem subtreesForFields_length (H : Type) [Hasher H] :
+    ∀ (fs : List SSZType) (vs : SSZType.interpFields fs),
+      (Node.subtreesForFields H fs vs).length = fs.length
+  | [],      _  => by simp [Node.subtreesForFields]
+  | _ :: ts, vs => by
+      simp only [Node.subtreesForFields, List.length_cons,
+        subtreesForFields_length H ts vs.2]
+
+/-- Companion: every per-field sub-tree of a container has a 32-byte root. This is
+the form `ofSubtrees_isOpenable` consumes directly. -/
+theorem rootOf_subtreesForFields_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero32 : ∀ d, (Node.rootOf H (zeroLeaf H d)).size = 32) :
+    (fs : List SSZType) → (vs : SSZType.interpFields fs) →
+      ∀ n ∈ Node.subtreesForFields H fs vs, (Node.rootOf H n).size = 32
+  | [],      _  => by intro n hn; simp [Node.subtreesForFields] at hn
+  | t :: ts, vs => by
+      intro n hn
+      simp only [Node.subtreesForFields, List.mem_cons] at hn
+      rcases hn with h | h
+      · subst h; exact rootOf_ofShape_size H hzero32 t vs.1
+      · exact rootOf_subtreesForFields_size H hzero32 ts vs.2 n h
+termination_by fs _ => (sizeOf fs, 0, 0)
+
+/-- Companion: every per-element sub-tree of a composite list or vector has a
+32-byte root. The statement generalises over the accumulator, since
+`subtreesForListComposite` recurses tail-first for stack safety. -/
+theorem rootOf_subtreesForListComposite_size (H : Type) [Hasher H] [CombineWidth32 H]
+    (hzero32 : ∀ d, (Node.rootOf H (zeroLeaf H d)).size = 32)
+    (t : SSZType) :
+    (xs : List t.interp) → (acc : List Node) →
+      (∀ n ∈ acc, (Node.rootOf H n).size = 32) →
+      ∀ n ∈ Node.subtreesForListComposite H t xs acc, (Node.rootOf H n).size = 32
+  | [],      acc, hacc => by
+      intro n hn
+      simp only [Node.subtreesForListComposite, List.mem_reverse] at hn
+      exact hacc n hn
+  | x :: xs, acc, hacc => by
+      intro n hn
+      simp only [Node.subtreesForListComposite] at hn
+      refine rootOf_subtreesForListComposite_size H hzero32 t xs _ ?_ n hn
+      intro m hm
+      rcases List.mem_cons.mp hm with h | h
+      · subst h; exact rootOf_ofShape_size H hzero32 t x
+      · exact hacc m h
+termination_by xs _ _ => (sizeOf t, 1, xs.length)
+
+end
+
+end SizzLean.Cache.MerkleTree

--- a/packages/SizzLean/SizzLean/Spec/GIndexError.lean
+++ b/packages/SizzLean/SizzLean/Spec/GIndexError.lean
@@ -1,0 +1,36 @@
+/-!
+# `SizzLean.Spec.GIndexError`: generalized-index path failure
+
+The error carrier `get_generalized_index` returns. A path fails when it does not
+address a node of the shape it is read against.
+
+Its own type, not tags on `SizzLean.Spec.SSZError`, for the reason
+`SizzLean.Cache.IndexError` states: `SSZError` is the decode taxonomy, and no
+decoder produces any tag below.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Spec
+
+/-- The ways an access path fails against a shape.
+
+* `basicTypeDescent`: a step continued past a basic type, which has no children.
+  Mirrors `assert not issubclass(typ, BasicValue)`, checked before every step
+  (`ssz/merkle-proofs.md:178`).
+* `lengthOnNonList`: a `.length` step addressed a shape with no length mix-in
+  node. Mirrors `assert issubclass(typ, (List, ByteList))`
+  (`ssz/merkle-proofs.md:180`).
+* `indexOutOfRange`: a `.field k` step named a position the shape does not hold.
+  That is a field index past the field list, or an element past a vector's length
+  or a list's capacity. Mirrors the `KeyError` each composite
+  `key_to_static_gindex` raises (remerkleable `complex.py`, `bitfields.py`). The
+  prose spec refuses a container the same way, since there a step is a field name
+  and an absent name has no index. -/
+inductive GIndexError where
+  | basicTypeDescent : GIndexError
+  | lengthOnNonList  : GIndexError
+  | indexOutOfRange  : GIndexError
+  deriving Repr, DecidableEq
+
+end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/GeneralizedIndex.lean
+++ b/packages/SizzLean/SizzLean/Spec/GeneralizedIndex.lean
@@ -1,0 +1,313 @@
+import SizzLean.Spec.HashTreeRoot
+import SizzLean.Spec.GIndexError
+
+/-!
+# `SizzLean.Spec.GeneralizedIndex`: SSZ generalized-index arithmetic
+
+A *generalized index* numbers the nodes of a binary Merkle tree. The root is `1`,
+and node `k`'s children are `2k` and `2k+1` (consensus-specs *§Merkle proofs*).
+A node at tree `depth` and left-to-right `index` (`0 ≤ index < 2^depth`) has
+generalized index `2^depth + index`.
+
+This module models `get_power_of_two_ceil`, `get_generalized_index`,
+`get_generalized_index_length` (= `floorLog2`) and `get_subtree_index`. It also
+recovers `(depth, index)` from a gindex, the pair the `isValidMerkleBranch`
+completeness kit consumes.
+
+Pure `Nat`/`SSZType` arithmetic, kernel-clean, zero new axioms.
+
+## Which definition this models
+
+`ssz/merkle-proofs.md` presents `get_generalized_index` as Python over
+`item_length` / `chunk_count` / `get_item_position`. That block is prose, not
+generated spec code: it names `Elements` and `Bits`, which exist in neither
+remerkleable nor the pyspec. The executable spec builds a gindex through
+remerkleable (`Path(ssz_class) / step …`, then `Path.gindex()`). The governing
+rule is therefore the per-type `key_to_static_gindex`, which `itemPosition`
+models.
+Where the two readings differ, notably on how a bitfield step selects its chunk,
+the executable one wins.
+
+## Where this connects
+
+The converse lemmas below tie a gindex to the `(depth, index)` pair.
+`EthCLLib.Proofs.GeneralizedIndexBranch` carries that through to acceptance for a
+container field, one step and two. That covers the light-client
+`EXECUTION_PAYLOAD` / sync-committee / `FINALIZED_ROOT` /
+`EXECUTION_BLOCK_HASH` gindices and the Fulu data column sidecar's
+`blob_kzg_commitments` proof.
+
+A path crossing a composite *list* element (the Deneb blob sidecar's
+`blob_kzg_commitments[i]`) is out of reach. It needs an openability lemma for the
+mix-in-length level, which the tree vocabulary does not carry.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Spec
+
+/-- A generalized Merkle-tree index (consensus-specs *§Merkle proofs*). A plain
+`Nat`. The valid range is `g ≥ 1`, since the root is `1`. Hypotheses pin that
+range where it matters, and no subtype does. -/
+abbrev GeneralizedIndex := Nat
+
+/-- `get_generalized_index_length(g)` = `floorlog2(g)`: the tree depth a gindex
+addresses. Unconditionally `Nat.log2 g`, including `g = 0`, where `log2 0 = 0`. -/
+def floorLog2 (g : GeneralizedIndex) : Nat := g.log2
+
+/-- `get_subtree_index(g) = g % 2^floorlog2(g)`: the left-to-right position of the
+addressed node within its depth level. -/
+def getSubtreeIndex (g : GeneralizedIndex) : Nat := g % 2 ^ floorLog2 g
+
+-- Worked positions: the root is 1, and node 12 sits at depth 3, index 4.
+example : floorLog2 1 = 0 := rfl
+example : floorLog2 12 = 3 := rfl
+example : getSubtreeIndex 12 = 4 := rfl
+
+/-- `get_power_of_two_ceil(x)` (consensus-specs *§Merkle proofs helpers*): the
+smallest power of two `≥ x`, with `0, 1 ↦ 1`. `chunkDepth` already computes that
+ceiling's exponent. -/
+def getPowerOfTwoCeil (x : Nat) : Nat := 2 ^ chunkDepth x
+
+-- From the spec table: 0→1, 3→4 (rounds up), 4→4 (already a power of two).
+example : getPowerOfTwoCeil 0 = 1 := rfl
+example : getPowerOfTwoCeil 3 = 4 := rfl
+example : getPowerOfTwoCeil 4 = 4 := rfl
+
+/-- One step of an SSZ access path. `field k` selects container field `k`, or
+element `k` of a vector or list. `length` selects a list's `__len__` node.
+Non-stringly-typed model of the spec's `int | SSZVariableName`. -/
+inductive PathStep where
+  | field  : Nat → PathStep
+  | length : PathStep
+
+/-- `chunk_count(typ)`: number of 32-byte chunks the top level of `typ` occupies.
+A container gives its field count. Vectors and lists of basic types pack several
+elements per chunk, modeled per the spec's `chunk_count` arms. -/
+def chunkCount : SSZType → Nat
+  | .container fs   => fs.length
+  | .vector t n     => (n * itemLength t + 31) / 32
+  | .list t cap     => (cap * itemLength t + 31) / 32
+  | .bitvector n    => (n + 255) / 256
+  | .bitlist cap    => (cap + 255) / 256
+  | .uintN _        => 1
+  | .bool           => 1
+where
+  /-- `item_length`: byte width of a basic type, else 32. -/
+  itemLength : SSZType → Nat
+    | .uintN bits => (bits + 7) / 8
+    | .bool       => 1
+    | _           => 32
+
+/-- Which 32-byte chunk of `typ`'s top level holds element (or field) `k`.
+
+A container gives each field its own chunk, so there the position is the field
+index. Everything else packs. A vector or list of basic types measures the
+element's byte offset and divides by the 32-byte chunk width, and a bitfield fits
+256 bits per chunk. Modeled on remerkleable's per-type `key_to_static_gindex`
+(`complex.py`, `bitfields.py`).
+
+The multiplication comes first, as in the spec's `start = k * item_length(elem)`
+then `start // 32`. `itemLength t` is `32` for composite `t`, so the one formula
+covers packed and unpacked alike. -/
+def itemPosition : SSZType → Nat → Nat
+  | .container _, k => k
+  | .bitvector _, k => k / 256
+  | .bitlist _,   k => k / 256
+  | .vector t _,  k => k * chunkCount.itemLength t / 32
+  | .list t _,    k => k * chunkCount.itemLength t / 32
+  | _,            k => k
+
+-- A container is one field per chunk, so the position is the field index.
+example : itemPosition (.container [.bool, .bool, .bool]) 2 = 2 := rfl
+-- Four `uint64`s fill one chunk, so every element of them sits at position 0.
+example : itemPosition (.vector (.uintN 64) 4) 2 = 0 := rfl
+-- 32 bytes per chunk for a byte list, so element 33 has moved on to chunk 1.
+example : itemPosition (.list (.uintN 8) 64) 33 = 1 := rfl
+-- Bitfields pack 256 bits to the chunk, not 32 bytes.
+example : itemPosition (.bitlist 512) 300 = 1 := rfl
+-- A width that does not divide 32: element 10 of a `uint24` vector starts at
+-- byte 30, so it is still chunk 0.
+example : itemPosition (.vector (.uintN 24) 16) 10 = 0 := rfl
+-- A width wider than a chunk: element 3 of a `uint512` vector starts at byte
+-- 192, chunk 6.
+example : itemPosition (.vector (.uintN 512) 4) 3 = 6 := rfl
+
+/-- `get_elem_type(typ, p)`: the type a path step lands on. Container field type,
+or the element type of a vector / list, or `bool` for a bitfield, whose elements
+are single bits. `.length` lands on the `uint64` length node.
+
+A bitfield element and a `.length` node are both basic, so `getGeneralizedIndex`
+raises `basicTypeDescent` on any step past one. That guard keeps the off-shape
+`| t, _ => t` arm out of view. -/
+def elemType : SSZType → PathStep → SSZType
+  | .container fs, .field k => fs.getD k .bool
+  | .vector t _,   .field _ => t
+  | .list t _,     .field _ => t
+  | .bitvector _,  .field _ => .bool
+  | .bitlist _,    .field _ => .bool
+  | _,             .length  => .uintN 64
+  | t,             _        => t
+
+/-- How many positions a `.field` step can name on `typ`. A container holds its
+fields, a vector its elements, and a list or bitfield its declared capacity. The
+capacity bounds the step. A gindex addresses a tree position, and a list's tree
+has capacity-many leaves however few are filled.
+
+Basic types get `0`, which no `k` satisfies. `getGeneralizedIndex` never reaches
+that arm: `basicTypeDescent` refuses a basic type first. -/
+def stepCapacity : SSZType → Nat
+  | .container fs => fs.length
+  | .vector _ n   => n
+  | .list _ cap   => cap
+  | .bitvector n  => n
+  | .bitlist cap  => cap
+  | .uintN _      => 0
+  | .bool         => 0
+
+/-- `get_generalized_index(typ, *path)`: fold the path into the gindex of the
+addressed node. `length` descends to the list length node (`base·2 + 1`). A field
+step multiplies by `base · getPowerOfTwoCeil (chunkCount typ)` and adds
+`itemPosition typ k`, where `base` is `2` for list and bitlist (the length
+mix-in level) and `1` otherwise.
+
+The added term is the *chunk* position. It coincides with the path index for a
+container and for composite elements. The two diverge wherever the top level
+packs, and `itemPosition` carries that distinction.
+
+Partial, as the spec is, and it refuses a path three ways.
+`basicTypeDescent` covers `assert not issubclass(typ, BasicValue)`, checked
+before every step. `lengthOnNonList` covers
+`assert issubclass(typ, (List, ByteList))` on a `.length` step.
+`indexOutOfRange` covers the `KeyError` each composite `key_to_static_gindex`
+raises for a step past `stepCapacity`. A path the spec refuses gets an error
+rather than a number, so an off-shape path cannot pass for a real tree
+position. -/
+def getGeneralizedIndex (typ : SSZType) (path : List PathStep) :
+    Except GIndexError GeneralizedIndex :=
+  go typ path 1
+where
+  go : SSZType → List PathStep → GeneralizedIndex → Except GIndexError GeneralizedIndex
+    | _, [],           acc => .ok acc
+    | t, step :: rest, acc =>
+        -- `merkle-proofs.md:178`: a basic type has no children, so no step of any
+        -- kind continues past one.
+        if t.isBasicType then .error .basicTypeDescent
+        else match step with
+          | .length =>
+              -- `merkle-proofs.md:180`: only a list carries a length mix-in node.
+              match t with
+              | .list _ _ => go (.uintN 64) rest (acc * 2 + 1)
+              | _         => .error .lengthOnNonList
+          | .field k =>
+              -- The range check every composite `key_to_static_gindex` runs. It
+              -- also keeps `elemType`'s `fs.getD k` off its default.
+              if k ≥ stepCapacity t then .error .indexOutOfRange
+              else
+                let base := match t with
+                  | .list _ _ | .bitlist _ => 2
+                  | _ => 1
+                go (elemType t (.field k)) rest
+                  (acc * base * getPowerOfTwoCeil (chunkCount t) + itemPosition t k)
+
+example :
+    getGeneralizedIndex (.container [.bool, .bool, .bool, .bool, .bool]) [.field 3]
+      = .ok 11 := rfl
+
+-- x.y[2] where x is a 2-field container, y is field 1 = list of 4 bools. Booleans
+-- are one byte, so all four pack into chunk 0 and the element step contributes 0,
+-- not 2. Getting this wrong is invisible without an example like this one.
+example :
+    getGeneralizedIndex (.container [.bool, .list .bool 4]) [.field 1, .field 2]
+      = .ok (3 * 2 * getPowerOfTwoCeil ((4 * 1 + 31) / 32) + 0) := rfl
+-- The same packing at the top level: `Vector[uint64, 4]` is a single chunk, so
+-- every element addresses gindex 1, the root's own chunk.
+example : getGeneralizedIndex (.vector (.uintN 64) 4) [.field 2] = .ok 1 := rfl
+-- Composite elements are one per chunk, so there the position is the index.
+example :
+    getGeneralizedIndex (.vector (.container [.bool, .bool]) 4) [.field 2]
+      = .ok (2 ^ 2 + 2) := rfl
+-- len(x.y): the __len__ node sits right of the list body root.
+example :
+    getGeneralizedIndex (.container [.bool, .list .bool 4]) [.field 1, .length]
+      = .ok 7 := rfl
+
+/-! The refused paths, one per assert. Without these the arms above would be
+indistinguishable from a total function that happens to agree on-shape. -/
+
+-- `merkle-proofs.md:178`, descending into a basic type.
+example : getGeneralizedIndex (.uintN 64) [.field 0] = .error .basicTypeDescent := rfl
+example : getGeneralizedIndex .bool [.field 7] = .error .basicTypeDescent := rfl
+-- A bitfield element is a bit, so the same assert refuses the step after one.
+-- `elemType` lands on `.bool`.
+example :
+    getGeneralizedIndex (.bitlist 512) [.field 300, .field 300]
+      = .error .basicTypeDescent := rfl
+-- `merkle-proofs.md:180`, `__len__` on a shape with no length mix-in.
+example :
+    getGeneralizedIndex (.container [.bool, .bool]) [.length]
+      = .error .lengthOnNonList := rfl
+example : getGeneralizedIndex (.vector .bool 4) [.length] = .error .lengthOnNonList := rfl
+-- A field index past the field list. Without the range check this returns
+-- `.ok 9`, a depth-3 address in a tree one level deep.
+example :
+    getGeneralizedIndex (.container [.bool, .bool]) [.field 7]
+      = .error .indexOutOfRange := rfl
+-- An element past a vector's length, and past a list's capacity.
+example :
+    getGeneralizedIndex (.vector (.container [.bool]) 4) [.field 99]
+      = .error .indexOutOfRange := rfl
+example : getGeneralizedIndex (.list .bool 4) [.field 4] = .error .indexOutOfRange := rfl
+-- Bitfields bound by bits, not by chunks: 512 bits is 2 chunks, and bit 512 is
+-- one past the end.
+example : getGeneralizedIndex (.bitlist 512) [.field 512] = .error .indexOutOfRange := rfl
+-- The capacity bounds the step, so the last addressable position of a list is
+-- `cap - 1` however few elements it holds.
+example : getGeneralizedIndex (.list .bool 4) [.field 3] = .ok 2 := rfl
+
+/-- `2 ^ d ≤ n < 2 ^ (d + 1)` pins `n.log2` to `d`. The toolchain's
+`Nat.log2_eq_iff` states that equivalence; this names the direction the
+decomposition lemmas below use, and discharges its `n ≠ 0` side condition from
+the lower bound. -/
+theorem log2_eq_of_bounds {n d : Nat} (hlo : 2 ^ d ≤ n) (hhi : n < 2 ^ (d + 1)) :
+    n.log2 = d := by
+  have hn : n ≠ 0 := by
+    have := Nat.one_le_two_pow (n := d)
+    omega
+  exact (Nat.log2_eq_iff hn).mpr ⟨hlo, hhi⟩
+
+/-- **Converse decomposition (depth).** A gindex built as `2 ^ d + k` with
+`k < 2 ^ d` reports depth `d`. The direction a call site needs: it constructs the
+gindex from a known `(depth, index)` and must get them back. -/
+theorem floorLog2_two_pow_add {d k : Nat} (hk : k < 2 ^ d) :
+    floorLog2 (2 ^ d + k) = d := by
+  unfold floorLog2
+  refine log2_eq_of_bounds (Nat.le_add_right _ _) ?_
+  rw [Nat.pow_succ]
+  omega
+
+/-- **Converse decomposition (index).** The same gindex reports position `k`. -/
+theorem getSubtreeIndex_two_pow_add {d k : Nat} (hk : k < 2 ^ d) :
+    getSubtreeIndex (2 ^ d + k) = k := by
+  unfold getSubtreeIndex
+  rw [floorLog2_two_pow_add hk, Nat.add_comm, Nat.add_mod_right]
+  exact Nat.mod_eq_of_lt hk
+
+/-- **The container arm, evaluated.** A single field step on a container is the
+textbook gindex `2 ^ chunkDepth fieldCount + k`. Here `acc = 1` and `base = 1`,
+and `itemPosition` on a container is the field index, a container being the one
+shape that never packs.
+
+`hk` discharges the range check. Without it the step is refused, so the
+hypothesis is what makes this an equation about a gindex at all.
+
+Not `rfl`, because `Nat.mul` recurses on its second argument, so `1 * x` does
+not reduce while `x` is open. -/
+theorem getGeneralizedIndex_container_field {fs : List SSZType} {k : Nat}
+    (hk : k < fs.length) :
+    getGeneralizedIndex (.container fs) [.field k]
+      = .ok (2 ^ chunkDepth fs.length + k) := by
+  simp [getGeneralizedIndex, getGeneralizedIndex.go, getPowerOfTwoCeil, chunkCount,
+    itemPosition, stepCapacity, SSZType.isBasicType, Nat.not_le.mpr hk]
+
+end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/GeneralizedIndex.lean
+++ b/packages/SizzLean/SizzLean/Spec/GeneralizedIndex.lean
@@ -37,9 +37,14 @@ container field, one step and two. That covers the light-client
 `EXECUTION_BLOCK_HASH` gindices and the Fulu data column sidecar's
 `blob_kzg_commitments` proof.
 
+Those results are about `SSZType.hashTreeRoot`, the function a client calls, via
+`merkleRoot_ofShape_eq_hashTreeRoot` (`Proofs/ShapeAgreement.lean`).
+
 A path crossing a composite *list* element (the Deneb blob sidecar's
 `blob_kzg_commitments[i]`) is out of reach. It needs an openability lemma for the
 mix-in-length level, which the tree vocabulary does not carry.
+
+The `.length` step has no completeness counterpart either.
 -/
 
 set_option autoImplicit false

--- a/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
+++ b/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
@@ -117,6 +117,25 @@ def natToChunk (n : Nat) : ByteArray :=
     | k + 1, m, acc => go k (m / 256) (acc.push (Nat.toUInt8 (m % 256)))
   go BYTES_PER_CHUNK n .empty
 
+/-- `natToChunk` emits exactly `BYTES_PER_CHUNK` bytes. The mix-in-length width
+proofs read the length chunk's root through this (`Proofs/ShapeWidth.lean`). -/
+theorem natToChunk_size (n : Nat) : (natToChunk n).size = 32 := by
+  -- Generalise over the accumulator: `k` steps add exactly `k` bytes.
+  have go_size : ∀ (k m : Nat) (acc : ByteArray),
+      (natToChunk.go k m acc).size = acc.size + k := by
+    intro k
+    induction k with
+    | zero => intro m acc; rfl
+    | succ j ih =>
+        intro m acc
+        show (natToChunk.go j (m / 256) (acc.push (Nat.toUInt8 (m % 256)))).size
+            = acc.size + (j + 1)
+        rw [ih, ByteArray.size_push]
+        omega
+  show (natToChunk.go BYTES_PER_CHUNK n .empty).size = 32
+  rw [go_size]
+  rfl
+
 /-- Split a `ByteArray` into a list of 32-byte chunks, right-padding
 the final chunk with zeros if its length is not a multiple of
 `BYTES_PER_CHUNK`. Empty input yields the empty list. The result is
@@ -313,6 +332,39 @@ def chunkDepth (n : Nat) : Nat :=
         if cur ≥ n then acc
         else go f (acc + 1) (cur * 2)
   go n 0 1
+
+/-- The loop invariant behind `le_two_pow_chunkDepth`. `chunkDepth.go` carries
+`acc` levels bought and `cur` leaf capacity. `cur = 2 ^ acc` ties them, and
+`n ≤ cur + fuel` says the remaining fuel closes the gap. Induction on `fuel`. -/
+private theorem chunkDepth_go_le (n : Nat) :
+    ∀ (fuel acc cur : Nat), cur = 2 ^ acc → n ≤ cur + fuel →
+      n ≤ 2 ^ chunkDepth.go n fuel acc cur := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro acc cur hcur hle
+      subst hcur
+      simpa [chunkDepth.go] using hle
+  | succ f ih =>
+      intro acc cur hcur hle
+      have hcur1 : 1 ≤ cur := by subst hcur; exact Nat.one_le_two_pow
+      simp only [chunkDepth.go]
+      split
+      · -- `cur ≥ n` stops the loop at `acc`, and `cur` is `2 ^ acc`.
+        rename_i hge
+        subst hcur
+        omega
+      · rename_i hlt
+        refine ih (acc + 1) (cur * 2) ?_ ?_
+        · rw [hcur, Nat.pow_succ]
+        · omega
+
+/-- **`chunkDepth` reaches its argument.** `n ≤ 2 ^ chunkDepth n`, so a list of
+`n` items fits the balanced tree `chunkDepth n` levels deep. This is the
+capacity bound `ofSubtrees_isOpenable` (`Proofs/Perfect.lean`) asks for, and
+`Node.ofShape` places container fields at `chunkDepth`-derived depths. -/
+theorem le_two_pow_chunkDepth (n : Nat) : n ≤ 2 ^ chunkDepth n :=
+  chunkDepth_go_le n n 0 1 rfl (by omega)
 
 /-! ### Mix-in helpers -/
 

--- a/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
+++ b/packages/SizzLean/SizzLean/Spec/HashTreeRoot.lean
@@ -238,8 +238,17 @@ what the spec's own recurrence defines for it, which is what
 paths agree at every depth with no side condition. A clamp or a
 `zero32` fallback would break that agreement above the table, which is
 what this replaced. -/
-private def zeroHashAtDepth (H : Type) [Hasher H] (d : Nat) : ByteArray :=
+def zeroHashAtDepth (H : Type) [Hasher H] (d : Nat) : ByteArray :=
   zeroHashAt H d
+
+/-- `ZERO_HASHES[0]` is the zero chunk. -/
+theorem zeroHashAtDepth_zero (H : Type) [Hasher H] :
+    zeroHashAtDepth H 0 = zero32 := rfl
+
+/-- `ZERO_HASHES[d + 1]` is `ZERO_HASHES[d]` paired with itself, at any `d`. -/
+theorem zeroHashAtDepth_succ (H : Type) [Hasher H] (d : Nat) :
+    zeroHashAtDepth H (d + 1)
+      = Hasher.combine (H := H) (zeroHashAtDepth H d) (zeroHashAtDepth H d) := rfl
 
 /-- Pair adjacent chunks at tree level `lvl`, using `ZERO_HASHES[lvl]`
 as the right sibling for an odd-length tail. The level argument is
@@ -273,21 +282,54 @@ private def combineLayerAtAux (H : Type) [Hasher H] (lvl : Nat) :
   | x :: y :: rs, acc =>
       combineLayerAtAux H lvl rs (Hasher.combine (H := H) x y :: acc)
 
-private def combineLayerAt (H : Type) [Hasher H] (lvl : Nat)
+/-- One BFS layer. Public, unlike the accumulator it runs on: the shape proofs in
+`Proofs/Merkleize.lean` state lemmas *about* a layer, which cannot name a private
+constant. The equation lemmas at the end of this file export the accumulator's
+behaviour. -/
+def combineLayerAt (H : Type) [Hasher H] (lvl : Nat)
     (cs : List ByteArray) : List ByteArray :=
   combineLayerAtAux H lvl cs []
 
 /-- Promote a single hash up through `remaining` levels of zero
 subtrees: each level pairs with `ZERO_HASHES[startLvl + k]` on the
-right. Used when the chunk list has reduced to a single item but
-the target depth hasn't been reached. -/
-private def promoteThroughZeros (H : Type) [Hasher H] :
+right. Used when the chunk list has reduced to a single item and
+the walk has not yet reached the target depth.
+
+Public for the same reason as `combineLayerAt`. The shape proofs state the
+singleton short-circuit's agreement with the tree builder. -/
+def promoteThroughZeros (H : Type) [Hasher H] :
     (current : ByteArray) → (startLvl : Nat) → (remaining : Nat) → ByteArray
   | c, _,        0     => c
   | c, startLvl, k + 1 =>
       promoteThroughZeros H
         (Hasher.combine (H := H) c (zeroHashAtDepth H startLvl))
         (startLvl + 1) k
+
+/-- The level-aware merkleization worker. It steps down through tree levels until
+it reaches the target depth, returning the single root. If it runs out of items
+first, it short-circuits the remaining levels through `ZERO_HASHES`.
+
+`curLvl` tracks the level, so `combineLayerAt` pads an odd tail with the zero
+subtree of the right depth. `remaining` counts the levels still to go.
+
+A top-level `def`, and not a `let rec` inside `merkleize`. The proof layer
+(`Proofs/Merkleize.lean`) inducts on it directly, and a lifted `let rec` is
+private by position, with a signature that depends on how Lean chose to abstract
+the enclosing binders. -/
+def merkleizeAt (H : Type) [Hasher H] :
+    List ByteArray → (curLvl : Nat) → (remaining : Nat) → ByteArray
+  | [],   _,      remaining => zeroHashAtDepth H remaining
+  | [c],  curLvl, remaining => promoteThroughZeros H c curLvl remaining
+  -- Levels exhausted with more than one chunk left: the caller asked for a tree too
+  -- shallow to hold its own leaves. `merkleize_chunks` opens with `assert count <=
+  -- limit` and raises here; we return the first chunk, the one arm of this function
+  -- that answers where the spec refuses to. Nothing routes here: `depth` always comes
+  -- from `chunkDepth` of the type's own cap, and a list longer than its cap fails
+  -- deserialization first. Modeling the assert means an error channel through every
+  -- `SSZRepr` instance, which is tracked rather than done.
+  | cs,   _,      0         => cs.head?.getD zero32
+  | cs,   curLvl, remaining + 1 =>
+      merkleizeAt H (combineLayerAt H curLvl cs) (curLvl + 1) remaining
 
 /-- Build the Merkle root of a balanced binary tree of `2^depth`
 leaves. `chunks` are the *real* left-aligned leaves; the
@@ -299,27 +341,12 @@ This matters for large caps like `VALIDATOR_REGISTRY_LIMIT = 2^40`:
 explicit padding would require `2^40` `zero32` leaves (~35 TB).
 The level-aware combine and the single-leaf promote let us
 process realistic chunk lists (a few dozen entries) in `O(depth)`
-hash steps regardless of the nominal cap. -/
-private def merkleize (H : Type) [Hasher H]
+hash steps regardless of the nominal cap.
+
+`merkleizeAt` is the descent itself, and this starts it at level 0. -/
+def merkleize (H : Type) [Hasher H]
     (chunks : List ByteArray) (depth : Nat) : ByteArray :=
-  -- Step down through tree levels until we either reach the target depth (return the
-  -- single root) or run out of items and short-circuit the remaining levels through
-  -- `ZERO_HASHES`. `curLvl` tracks the level so `combineLayerAt` pads an odd tail with
-  -- the zero subtree of the right depth, and `remaining` counts the levels still to go.
-  let rec goAt : List ByteArray → (curLvl : Nat) → (remaining : Nat) → ByteArray
-    | [],   _,      remaining => zeroHashAtDepth H remaining
-    | [c],  curLvl, remaining => promoteThroughZeros H c curLvl remaining
-    -- Levels exhausted with more than one chunk left: the caller asked for a tree too
-    -- shallow to hold its own leaves. `merkleize_chunks` opens with `assert count <=
-    -- limit` and raises here; we return the first chunk, the one arm of this function
-    -- that answers where the spec refuses to. Nothing routes here: `depth` always comes
-    -- from `chunkDepth` of the type's own cap, and a list longer than its cap fails
-    -- deserialization first. Modeling the assert means an error channel through every
-    -- `SSZRepr` instance, which is tracked rather than done.
-    | cs,   _,      0         => cs.head?.getD zero32
-    | cs,   curLvl, remaining + 1 =>
-        goAt (combineLayerAt H curLvl cs) (curLvl + 1) remaining
-  goAt chunks 0 depth
+  merkleizeAt H chunks 0 depth
 
 /-- `⌈log₂ (max 1 n)⌉`, used to derive a tree depth from a leaf
 count. `chunkDepth 0 = 0` (single-leaf tree of `zero32`),
@@ -577,5 +604,82 @@ Inference chain at the call site:
 def hashTreeRoot {H : Type} [Hasher H] (s : SSZType) (x : s.interp) :
     ByteArray :=
   SSZType.hashTreeRoot H s x
+
+/-! ### Merkleizer facts for the shape proofs
+
+The equations `Proofs/Merkleize.lean` reasons through, mirroring
+`Cache/MerkleTree/Zero.lean`'s zero-table block. `combineLayerAtAux` stays
+`private`; its behaviour is exported by the three `combineLayerAt` equations
+below. -/
+
+/-- One BFS layer, as an equation on the accumulator-free form. -/
+theorem combineLayerAt_nil (H : Type) [Hasher H] (lvl : Nat) :
+    combineLayerAt H lvl [] = [] := rfl
+
+theorem combineLayerAt_singleton (H : Type) [Hasher H] (lvl : Nat) (x : ByteArray) :
+    combineLayerAt H lvl [x] = [Hasher.combine (H := H) x (zeroHashAtDepth H lvl)] := rfl
+
+/-- The recursion only ever reverses the accumulator onto the front, so a run
+started mid-way equals the run started empty with the accumulator prepended.
+
+Induction runs on a `fuel` bound, because `combineLayerAtAux` consumes two
+elements per step. Plain `List.rec` gives an
+induction hypothesis about `y :: rs` where the step needs one about `rs`.
+Functional induction fixes the accumulator at the recursive call's value, which
+is the very generalisation this proof needs. -/
+private theorem combineLayerAtAux_acc (H : Type) [Hasher H] (lvl : Nat) :
+    ∀ (fuel : Nat) (cs : List ByteArray), cs.length ≤ fuel →
+      ∀ (acc : List ByteArray),
+        combineLayerAtAux H lvl cs acc
+          = acc.reverse ++ combineLayerAtAux H lvl cs [] := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro cs hlen acc
+      match cs with
+      | [] => simp [combineLayerAtAux]
+  | succ m ih =>
+      intro cs hlen acc
+      match cs with
+      | []  => simp [combineLayerAtAux]
+      | [x] => simp [combineLayerAtAux]
+      | x :: y :: rs =>
+          have hrs : rs.length ≤ m := by simp only [List.length_cons] at hlen; omega
+          -- Both sides step once: the `x, y` pair is combined onto the
+          -- accumulator and the tail carries on.
+          show combineLayerAtAux H lvl rs (Hasher.combine (H := H) x y :: acc)
+              = acc.reverse ++ combineLayerAtAux H lvl rs [Hasher.combine (H := H) x y]
+          rw [ih rs hrs (Hasher.combine (H := H) x y :: acc),
+              ih rs hrs [Hasher.combine (H := H) x y]]
+          simp
+
+theorem combineLayerAt_cons₂ (H : Type) [Hasher H] (lvl : Nat)
+    (x y : ByteArray) (rs : List ByteArray) :
+    combineLayerAt H lvl (x :: y :: rs)
+      = Hasher.combine (H := H) x y :: combineLayerAt H lvl rs := by
+  show combineLayerAtAux H lvl rs [Hasher.combine (H := H) x y]
+      = Hasher.combine (H := H) x y :: combineLayerAtAux H lvl rs []
+  rw [combineLayerAtAux_acc H lvl rs.length rs (Nat.le_refl _)]
+  simp
+
+/-- `promoteThroughZeros`, unfolded one level. -/
+theorem promoteThroughZeros_zero (H : Type) [Hasher H] (c : ByteArray) (lvl : Nat) :
+    promoteThroughZeros H c lvl 0 = c := rfl
+
+theorem promoteThroughZeros_succ (H : Type) [Hasher H]
+    (c : ByteArray) (lvl k : Nat) :
+    promoteThroughZeros H c lvl (k + 1)
+      = promoteThroughZeros H (Hasher.combine (H := H) c (zeroHashAtDepth H lvl))
+          (lvl + 1) k := rfl
+
+/-- `merkleize` is `merkleizeAt` started at level 0. This is the bridge the whole
+proof layer enters through. -/
+theorem merkleize_eq_merkleizeAt (H : Type) [Hasher H]
+    (chunks : List ByteArray) (depth : Nat) :
+    merkleize H chunks depth = merkleizeAt H chunks 0 depth := rfl
+
+/-- `mixInLength`, exported. -/
+theorem mixInLength_eq (H : Type) [Hasher H] (root : ByteArray) (n : Nat) :
+    mixInLength H root n = Hasher.combine (H := H) root (natToChunk n) := rfl
 
 end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/Interp.lean
+++ b/packages/SizzLean/SizzLean/Spec/Interp.lean
@@ -132,4 +132,25 @@ example : SSZType.interp (.uintN 32)       = UInt32        := rfl
 -- `Vector Bool 3`. The kernel performs both reductions to close `rfl`.
 example : SSZType.interp (.vector .bool 3) = Vector Bool 3 := rfl
 
+/-- Project field `k` out of a container value.
+
+`interpFields fs` is a right-nested `Prod` chain built by recursion on `fs`, so
+no generic projection exists. Each component's *type* depends on which field the
+caller names. This definition therefore recurses on `fs` and `k` together. Its
+result type mentions the indexed `(fs[k]).interp`, which is why the bound is a
+parameter and not a `getD`-style default.
+
+In-range only, deliberately. Out-of-range positions of a container tree are
+`ofSubtrees` padding, and the Merkle leaf bridge needs a `zeroLeaf` there rather
+than a junk field value. A total version with a default would export a
+meaningless answer at exactly the positions that need a different lemma.
+
+The empty-list case is absent because `hk : k < ([] : List SSZType).length` has
+no inhabitant, and Lean's pattern compiler sees that. -/
+def SSZType.fieldAt : (fs : List SSZType) → SSZType.interpFields fs →
+    (k : Nat) → (hk : k < fs.length) → (fs[k]).interp
+  | _ :: _,  vs, 0,     _  => vs.1
+  | _ :: ts, vs, k + 1, hk => SSZType.fieldAt ts vs.2 k (by
+      simp only [List.length_cons] at hk; omega)
+
 end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/SSZError.lean
+++ b/packages/SizzLean/SizzLean/Spec/SSZError.lean
@@ -49,7 +49,6 @@ namespace SizzLean.Spec
 * `outOfRange`: a length-derived count exceeded the type's static
   capacity (e.g. an offset-table size implied more list elements
   than `cap`).
-
 Tags are added on demand. Decoders introducing a new failure mode
 should extend this inductive rather than reusing an unrelated tag. -/
 inductive SSZError where


### PR DESCRIPTION
## Summary

The cache tree's root agrees with `SSZType.hashTreeRoot`, and the
generalized-index results now state their conclusion over that root. No
behaviour change.

Stacked on #66.

## What changed

- `SizzLean/Proofs/Merkleize.lean` (new): `merkleize_eq_ofLeaves`,
  `rootOf_ofSubtrees_eq_ofLeaves`.
- `SizzLean/Proofs/ShapeAgreement.lean` (new):
  `merkleRoot_ofShape_eq_hashTreeRoot`.
- `SizzLean/Spec/HashTreeRoot.lean`: unseals `merkleize`, `zeroHashAtDepth`,
  `combineLayerAt` and `promoteThroughZeros`, adds `merkleizeAt` with
  `merkleize_eq_merkleizeAt`, and the equation lemmas for all of them.
- `SizzLean/Spec/Interp.lean`: `SSZType.fieldAt`.
- `SizzLean/Cache/MerkleTree/Zero.lean`: unseals `zero32`, adds
  `zeroHashAt_zero`.
- `EthCLLib/Proofs/MerkleShape.lean` (new): `nodeAt_ofSubtrees`,
  `nodeAt_ofShape_container`.
- `EthCLLib/Proofs/GeneralizedIndexBranch.lean`:
  `isValidMerkleBranch_complete_containerField_specRoot`. The two-step witness
  takes `hfield` and `hval` in place of `hsub`.

## Test plan

- [x] `lake build` (full monorepo, on the pinned toolchain) is green.
- [x] Per-package test suites pass:
  - [x] `lake build LeanSha256Tests`
  - [x] `lake build SizzLeanTests`
  - [x] `just ethcl-test`
- [x] If this touches spec types or cache behaviour:
      `just ethcl-pyspec` is green.
- [ ] If this touches a bench-measured hot path: included
      before/after `lake exe ssz_bench` TSV (or relevant rows) in
      the PR description.
- [x] New SSZ shapes / cache cases come with a `native_decide` or
      property test that exercises them.

## Risk / trust footprint

- Unseals four definitions in `Spec/HashTreeRoot.lean` and `Cache.zero32`, so
  tactics may now unfold them.
- Adds and removes no axiom, `sorry`, `partial def`, `native_decide`, `unsafe`
  block or `@[extern]` declaration.

## Notes for reviewers

The two-step witness swapping `hsub` for `hfield` and `hval` changes what a
caller has to supply.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.

