### PR TITLE
fix(sizzlean): count offset-table bytes in maxByteLength for variable-element collections

### DIFF
--- a/packages/SizzLean/SizzLean/Proofs/ListFixed.lean
+++ b/packages/SizzLean/SizzLean/Proofs/ListFixed.lean
@@ -113,7 +113,8 @@ theorem decode_encode_listFixed
   simp only [h_arr_sz, dite_true]
 
 /-- Size bound for `.list t cap`. `(serialize …).size = xs.val.size * sz`;
-`maxByteLength = cap * maxByteLength t`.
+`maxByteLength = cap * maxByteLength t` (the fixed-element
+branch of the bound).
 
 For the empty list (`xs.val.size = 0`) the bound is trivial: LHS
 is 0. For a non-empty list, we use `xs.val[0]` to derive
@@ -139,7 +140,7 @@ theorem encode_size_le_max_listFixed
     rw [serializeFixedElems_size_aux t t.fixedByteSize h_size_t xs.val.toList, h_list_len]
   rw [h_size]
   show xs.val.size * t.fixedByteSize ≤ SSZType.maxByteLength (.list t cap)
-  simp only [SSZType.maxByteLength]
+  simp only [SSZType.maxByteLength, h_t_fixed, if_true]
   -- Case-split on `xs.val.size = 0` to avoid needing an `Inhabited` instance.
   by_cases h_empty : xs.val.size = 0
   · rw [h_empty]; simp

--- a/packages/SizzLean/SizzLean/Proofs/ListFixed.lean
+++ b/packages/SizzLean/SizzLean/Proofs/ListFixed.lean
@@ -112,9 +112,9 @@ theorem decode_encode_listFixed
     rw [List.size_toArray, h_list_len]; exact xs.property
   simp only [h_arr_sz, dite_true]
 
-/-- Size bound for `.list t cap`. `(serialize …).size = xs.val.size * sz`;
-`maxByteLength = cap * maxByteLength t` (the fixed-element
-branch of the bound).
+/-- Size bound for `.list t cap`. `(serialize …).size = xs.val.size * sz`.
+`maxByteLength` takes the fixed-element branch `cap * maxByteLength t`
+here.
 
 For the empty list (`xs.val.size = 0`) the bound is trivial: LHS
 is 0. For a non-empty list, we use `xs.val[0]` to derive

--- a/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
+++ b/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
@@ -99,7 +99,8 @@ theorem decode_encode_vectorFixed
 
 /-- Size bound for `.vector t n` with `t` fixed-size, `n > 0`.
 The serialized buffer has size `n * t.fixedByteSize`, which
-is ≤ `maxByteLength (.vector t n) = maxByteLength t * n`. The
+is ≤ `maxByteLength (.vector t n) = maxByteLength t * n` (the
+fixed-element branch of the bound). The
 `n > 0` precondition lets us pick `v[0]` as a witness for
 deriving `fixedByteSize t ≤ maxByteLength t`. -/
 theorem encode_size_le_max_vectorFixed
@@ -130,7 +131,7 @@ theorem encode_size_le_max_vectorFixed
     rw [Nat.mul_comm]
   rw [h_size]
   show n * t.fixedByteSize ≤ SSZType.maxByteLength (.vector t n)
-  simp only [SSZType.maxByteLength]
+  simp only [SSZType.maxByteLength, h_t_fixed, if_true]
   rw [Nat.mul_comm (SSZType.maxByteLength t) n]
   exact Nat.mul_le_mul_left n h_fixed_le_max
 

--- a/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
+++ b/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
@@ -98,11 +98,11 @@ theorem decode_encode_vectorFixed
     simp [Array.toArray_toList]
 
 /-- Size bound for `.vector t n` with `t` fixed-size, `n > 0`.
-The serialized buffer has size `n * t.fixedByteSize`, which
-is ≤ `maxByteLength (.vector t n) = n * maxByteLength t` (the
-fixed-element branch of the bound). The
-`n > 0` precondition lets us pick `v[0]` as a witness for
-deriving `fixedByteSize t ≤ maxByteLength t`. -/
+The serialized buffer has size `n * t.fixedByteSize`. That is
+≤ `maxByteLength (.vector t n)`, which takes the fixed-element
+branch `n * maxByteLength t` here. The `n > 0` precondition lets
+us pick `v[0]` as a witness for deriving
+`fixedByteSize t ≤ maxByteLength t`. -/
 theorem encode_size_le_max_vectorFixed
     (t : SSZType) (n : Nat) (h_pos : 0 < n)
     (h_t : SSZType.BasicSupported t)

--- a/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
+++ b/packages/SizzLean/SizzLean/Proofs/VectorFixed.lean
@@ -99,7 +99,7 @@ theorem decode_encode_vectorFixed
 
 /-- Size bound for `.vector t n` with `t` fixed-size, `n > 0`.
 The serialized buffer has size `n * t.fixedByteSize`, which
-is ≤ `maxByteLength (.vector t n) = maxByteLength t * n` (the
+is ≤ `maxByteLength (.vector t n) = n * maxByteLength t` (the
 fixed-element branch of the bound). The
 `n > 0` precondition lets us pick `v[0]` as a witness for
 deriving `fixedByteSize t ≤ maxByteLength t`. -/
@@ -132,7 +132,6 @@ theorem encode_size_le_max_vectorFixed
   rw [h_size]
   show n * t.fixedByteSize ≤ SSZType.maxByteLength (.vector t n)
   simp only [SSZType.maxByteLength, h_t_fixed, if_true]
-  rw [Nat.mul_comm (SSZType.maxByteLength t) n]
   exact Nat.mul_le_mul_left n h_fixed_le_max
 
 end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
+++ b/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
@@ -81,4 +81,38 @@ def SSZType.maxByteLengthFields : List SSZType → Nat
 
 end
 
+/-! ### Worked bounds
+
+Both branches of the `.vector` / `.list` arms, pinned by `rfl` so the
+build rejects a drift in the arithmetic. `rfl` suffices because
+`maxByteLength` is structural recursion over a closed `SSZType`: the
+kernel reduces each arm, decides the `isFixedSize` condition, and
+evaluates the `Nat` multiplication. `SSZType.maxByteLength (.bitlist 8)`
+is `(8 + 1 + 7) / 8 = 2`, the figure the variable-element lines below
+multiply against.
+
+The fixed-element branches are the ones `encode_size_le_max` already
+proves (`Proofs/VectorFixed.lean`, `Proofs/ListFixed.lean`). The
+variable-element branches carry the offset table, and no proof reaches
+them until `BasicSupported` grows its `vectorVar` / `listVar`
+constructors. Until then these examples are their only check. -/
+
+-- Fixed-size elements: no offset table, `n` bodies of 1 byte each.
+example : SSZType.maxByteLength (.vector (.uintN 8) 4) = 4  := rfl
+example : SSZType.maxByteLength (.list (.uintN 8) 4)   = 4  := rfl
+
+-- Variable-size elements: `BYTES_PER_LENGTH_OFFSET` per element on top
+-- of each body, so `2 * (4 + 2)` and `4 * (4 + 2)`.
+example : SSZType.maxByteLength (.vector (.bitlist 8) 2) = 12 := rfl
+example : SSZType.maxByteLength (.list (.bitlist 8) 4)   = 24 := rfl
+
+-- A nested variable collection: the inner `.list (.uintN 8) 4` is
+-- variable-size and bounded by 4, so the outer vector pays
+-- `2 * (4 + 4)`.
+example : SSZType.maxByteLength (.vector (.list (.uintN 8) 4) 2) = 16 := rfl
+
+-- A container field pays the same offset-table term, `4 + 2` for the
+-- `bitlist` on top of the 1-byte `uintN 8`.
+example : SSZType.maxByteLength (.container [.uintN 8, .bitlist 8]) = 7 := rfl
+
 end SizzLean.Spec

--- a/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
+++ b/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
@@ -24,8 +24,13 @@ in a `mutual` block, same shape as `Spec/Serialize.lean`'s
 * **`bitlist cap`**: `⌈(cap + 1)/8⌉`, the `+1` is the trailing
   delimiter bit. See `Spec/Serialize.lean`'s `bitlistToBytes`.
 * **`vector t n`**: `n` elements, each at most `maxByteLength t`.
+  If `t` is variable-size the wire form also carries an offset
+  table, so the bound is `n * (BYTES_PER_LENGTH_OFFSET +
+  maxByteLength t)` rather than `n * maxByteLength t`.
 * **`list t cap`**: `cap` elements (the *cap*, not the actual length,
-  this is a static upper bound), each at most `maxByteLength t`.
+  this is a static upper bound), each at most `maxByteLength t`,
+  plus the same per-element offset-table term when `t` is
+  variable-size.
 * **`container fs`**: sum of per-field contributions. Fixed-size
   fields contribute their own `maxByteLength`. Variable-size fields
   contribute `BYTES_PER_LENGTH_OFFSET + maxByteLength` (one
@@ -52,8 +57,12 @@ from the schema `s`. -/
 def SSZType.maxByteLength : SSZType → Nat
   | .uintN n      => (n + 7) / 8
   | .bool         => 1
-  | .vector t n   => SSZType.maxByteLength t * n
-  | .list t cap   => cap * SSZType.maxByteLength t
+  | .vector t n   =>
+      if t.isFixedSize then SSZType.maxByteLength t * n
+      else n * (BYTES_PER_LENGTH_OFFSET + SSZType.maxByteLength t)
+  | .list t cap   =>
+      if t.isFixedSize then cap * SSZType.maxByteLength t
+      else cap * (BYTES_PER_LENGTH_OFFSET + SSZType.maxByteLength t)
   | .bitvector n  => (n + 7) / 8
   | .bitlist cap  => (cap + 1 + 7) / 8
   | .container fs => SSZType.maxByteLengthFields fs

--- a/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
+++ b/packages/SizzLean/SizzLean/Spec/MaxByteLength.lean
@@ -58,7 +58,7 @@ def SSZType.maxByteLength : SSZType → Nat
   | .uintN n      => (n + 7) / 8
   | .bool         => 1
   | .vector t n   =>
-      if t.isFixedSize then SSZType.maxByteLength t * n
+      if t.isFixedSize then n * SSZType.maxByteLength t
       else n * (BYTES_PER_LENGTH_OFFSET + SSZType.maxByteLength t)
   | .list t cap   =>
       if t.isFixedSize then cap * SSZType.maxByteLength t


### PR DESCRIPTION
## Summary

First slice of #68. `maxByteLength` for `.vector t n` / `.list t cap` was `n * maxByteLength t`, which is exact only when `t` is fixed-size. Variable-size elements also write an offset table of `n` uint32s, so the encoded size can exceed that bound by up to `n * 4`. Then `encode_size_le_max` as stated is false for `vectorVar` / `listVar`.

Containers already count the placeholder (`BYTES_PER_LENGTH_OFFSET + maxByteLength t` in `maxByteLengthFields`). This makes the collection formulas match:

```lean
| .vector t n =>
    if t.isFixedSize then maxByteLength t * n
    else n * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)
| .list t cap =>
    if t.isFixedSize then cap * maxByteLength t
    else cap * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)
```

No runtime codec change. Existing `vectorFixed` / `listFixed` proofs dispatch on `t.isFixedSize = true`, so they take the old branch; they now reduce the `if` explicitly.

## Test plan

- [x] `lake build SizzLean SizzLeanTests`
