### PR TITLE
feat(sizzlean): groundwork for variable-element vector/list proofs

### DIFF
--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -20,12 +20,11 @@ a follow-up, once this file's lemmas are available to build on and
 once `containerVar` is on `main` (the `BasicSupported` matchers grow
 two constructors; that arm must already be exhaustive).
 
-Homogeneous collections, so this is closer to `Proofs/FixedElems.lean`
-than to `Proofs/ContainerVar.lean`: one element type `t`, induction
-on the element list. No new heterogeneous mutual predicate. The
-uint32 codec bridge (`readUInt32LE_uint32LE_append`,
-`readUInt32LE_append_shift`, `toNat_toUInt32_of_lt`) is reused from
-`ContainerVar` rather than re-proved.
+Homogeneous collections have one element type `t`, so the proof
+inducts on the element list as `Proofs/FixedElems.lean` does. The
+existing uint32 codec bridge from `ContainerVar`
+(`readUInt32LE_uint32LE_append`, `readUInt32LE_append_shift`,
+`toNat_toUInt32_of_lt`) supplies the byte-level inverse.
 
 ## Wire format (what the lemmas below characterize)
 
@@ -59,9 +58,10 @@ them):
    order). Homogeneous analogue of `varOffsetsOf`.
 2. **Encoder accounting** (`size_serializeVarElemsAux_offs`):
    `(serializeVarElemsAux t xs varOff).1.size = xs.length * 4`.
-   Independent of `varOff` and of the bodies. The vector decoder's
-   first-offset guard (`off₀ = n * 4`) is this fact at the
-   encoder's seed `varOff = n * 4`.
+   Independent of `varOff` and of the bodies. At the encoder's seed
+   `varOff = n * 4`, the first encoded offset is `n * 4`. The vector
+   decoder takes `count = n` from the schema. The later roundtrip
+   proof uses the encoder's canonical offset.
 3. **Size walker** (`size_serializeVarElemsAux_le_max`):
    `(serializeVarElemsAux t xs varOff).1.size + .2.size ≤
    xs.length * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`.
@@ -81,10 +81,9 @@ them):
 
 ## Trust
 
-Every lemma here closes with the three standard kernel axioms.
-The uint32 bridge it cites from `ContainerVar` is one `bv_decide`
-call, the same trust class as the narrow `uintN` arms in
-`Proofs/UInt.lean`.
+The lemmas use at most the standard kernel axioms. The uint32 bridge
+from `ContainerVar` carries one `bv_decide` certificate, the same
+trust class as the narrow `uintN` arms in `Proofs/UInt.lean`.
 -/
 
 set_option autoImplicit false
@@ -123,9 +122,9 @@ theorem collOffsetsOf_length
 
 /-- The first placeholder a non-empty collection writes is the
 seeded `varOff`. At the encoder's call site that seed is
-`xs.length * BYTES_PER_LENGTH_OFFSET`, which is the vector
-decoder's first-offset guard and the list decoder's
-`count = firstOff / 4` recovery. -/
+`xs.length * BYTES_PER_LENGTH_OFFSET`. The vector roundtrip uses
+this canonical encoder value. The list decoder uses it to recover
+`count = firstOff / 4`. -/
 theorem collOffsetsOf_head_cons
     (t : SSZType) (x : t.interp) (xs : List t.interp) (varOff : Nat) :
     (collOffsetsOf t (x :: xs) varOff).head? = some varOff := rfl
@@ -139,7 +138,7 @@ theorem collOffsetsOf_head_cons
 theorem size_serializeVarElemsAux_offs
     (t : SSZType) (xs : List t.interp) (varOff : Nat) :
     (SSZType.serializeVarElemsAux t xs varOff).1.size =
-      xs.length * SizzLean.Spec.BYTES_PER_LENGTH_OFFSET := by
+      xs.length * BYTES_PER_LENGTH_OFFSET := by
   induction xs generalizing varOff with
   | nil =>
     unfold SSZType.serializeVarElemsAux
@@ -152,8 +151,7 @@ theorem size_serializeVarElemsAux_offs
               (varOff + (SSZType.serialize t x).size)).1 := by
       simp only [SSZType.serializeVarElemsAux]
     rw [h_enc, ByteArray.size_append, size_uint32LE, ih, List.length_cons]
-    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
-    rw [hBPLO, Nat.add_mul, Nat.one_mul, Nat.add_comm]
+    simp only [BYTES_PER_LENGTH_OFFSET, Nat.add_mul, Nat.one_mul, Nat.add_comm]
 
 /-- Reading the first offset placeholder back off the front of a
 non-empty collection's own encoded output recovers the seeded
@@ -190,7 +188,7 @@ theorem size_serializeVarElemsAux_le_max
       (SSZType.serialize t y).size ≤ SSZType.maxByteLength t) :
     (SSZType.serializeVarElemsAux t xs varOff).1.size +
       (SSZType.serializeVarElemsAux t xs varOff).2.size ≤
-      xs.length * (SizzLean.Spec.BYTES_PER_LENGTH_OFFSET +
+      xs.length * (BYTES_PER_LENGTH_OFFSET +
         SSZType.maxByteLength t) := by
   induction xs generalizing varOff with
   | nil =>
@@ -213,8 +211,7 @@ theorem size_serializeVarElemsAux_le_max
         size_uint32LE]
     have h_tail := ih (varOff + (SSZType.serialize t x).size)
     have h_head := h_max x
-    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
-    rw [hBPLO] at h_tail ⊢
+    simp only [BYTES_PER_LENGTH_OFFSET] at h_tail ⊢
     rw [List.length_cons, Nat.add_mul, Nat.one_mul]
     omega
 
@@ -345,8 +342,8 @@ theorem extractCollOffsets_serializeVarElemsAux
       rw [hshift, readUInt32LE_uint32LE_append]
     rw [h_read]
     dsimp only
-    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
-    rw [hBPLO, show pre.size + 4 = (pre ++ uint32LE (Nat.toUInt32 varOff)).size
+    rw [show BYTES_PER_LENGTH_OFFSET = 4 from rfl,
+        show pre.size + 4 = (pre ++ uint32LE (Nat.toUInt32 varOff)).size
           from h_presize.symm, h_ih]
     dsimp only
     have h_toNat : (Nat.toUInt32 varOff).toNat = varOff :=

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -1,0 +1,357 @@
+import SizzLean.Spec.Serialize
+import SizzLean.Spec.Deserialize
+import SizzLean.Spec.MaxByteLength
+import SizzLean.Proofs.ContainerVar
+
+/-!
+# `SizzLean.Proofs.CollectionVar`: groundwork for variable-element `.vector` / `.list`
+
+Variable-element collections (`.vector t n` / `.list t cap` with
+`t.isFixedSize = false`) are the remaining composite gap in
+`SSZType.Supported` once mixed-field containers land: the codec
+([`Spec/Serialize.lean`](../Spec/Serialize.lean)'s
+`serializeVarElemsAux`, [`Spec/Deserialize.lean`](../Spec/Deserialize.lean)'s
+non-`isFixedSize` `.vector` / `.list` branches) fully implements the
+offset-table wire format, but no `BasicSupported` constructor claims
+it yet, and no theorem closes it. This module lays the groundwork;
+the predicates (`vectorVar` / `listVar` on `BasicSupported` /
+`Supported` / `SupportedBounded`) and the roundtrip walkers land in
+a follow-up, once this file's lemmas are available to build on and
+once `containerVar` is on `main` (the `BasicSupported` matchers grow
+two constructors; that arm must already be exhaustive).
+
+Homogeneous collections, so this is closer to `Proofs/FixedElems.lean`
+than to `Proofs/ContainerVar.lean`: one element type `t`, induction
+on the element list. No new heterogeneous mutual predicate. The
+uint32 codec bridge (`readUInt32LE_uint32LE_append`,
+`readUInt32LE_append_shift`, `toNat_toUInt32_of_lt`) is reused from
+`ContainerVar` rather than re-proved.
+
+## Wire format (what the lemmas below characterize)
+
+```
+offset table                         body region
+┌────────┬────────┬────────┐         ┌────────┬────────┐
+│ off₀   │ off₁   │ off₂   │   …     │ body₀  │ body₁  │ …
+│(uint32)│(uint32)│(uint32)│         │        │        │
+└────────┴────────┴────────┘         └────────┴────────┘
+```
+
+`serializeVarElemsAux` builds this by walking the element list once,
+threading a running `varOff` (seeded at `xs.length * BYTES_PER_LENGTH_OFFSET`,
+the total width of the offset table): each element appends a
+`uint32LE varOff` placeholder to the `.1` accumulator and its own
+body to the `.2` accumulator, then advances `varOff` by the body's
+size. The decoder's `extractCollOffsets` reads `count` placeholders
+back out, before `deserializeVarElems` uses them to slice each
+body. Vectors take `count = n` and reject `n = 0`; lists recover
+`count` from `off₀ / 4`, with the empty buffer the empty list.
+
+## Lemma path
+
+The groundwork, in the order it composes (proven facts, plus the
+plumbing `def` of item 1 that threads the running offsets through
+them):
+
+1. **Offset-list plumbing** (`collOffsetsOf`): the list the
+   encoder's placeholders *should* decode back to, mirroring
+   `serializeVarElemsAux`'s own walk (one entry per element, in
+   order). Homogeneous analogue of `varOffsetsOf`.
+2. **Encoder accounting** (`size_serializeVarElemsAux_offs`):
+   `(serializeVarElemsAux t xs varOff).1.size = xs.length * 4`.
+   Independent of `varOff` and of the bodies. The vector decoder's
+   first-offset guard (`off₀ = n * 4`) is this fact at the
+   encoder's seed `varOff = n * 4`.
+3. **Size walker** (`size_serializeVarElemsAux_le_max`):
+   `(serializeVarElemsAux t xs varOff).1.size + .2.size ≤
+   xs.length * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`.
+   Specializes to `maxByteLength (.vector t n)` / `(.list t cap)`
+   once `t.isFixedSize = false` (and `xs.length = n` /
+   `xs.length ≤ cap`). Needed for the `encode_size_le_max` arms,
+   and for the uint32-overflow guard every offset placeholder
+   depends on.
+4. **Offset-extraction inverse**
+   (`extractCollOffsets_serializeVarElemsAux`): reading
+   `extractCollOffsets` back off the encoder's own output recovers
+   exactly the running offsets `serializeVarElemsAux` wrote
+   (`collOffsetsOf`). Same `pre` / `suf` invariant as
+   `extractFieldOffsets_serializeFieldsAux`: the extractor never
+   reads past the offset table, so the buffer's tail can be
+   anything.
+
+## Trust
+
+Every lemma here closes with the three standard kernel axioms.
+The uint32 bridge it cites from `ContainerVar` is one `bv_decide`
+call, the same trust class as the narrow `uintN` arms in
+`Proofs/UInt.lean`.
+-/
+
+set_option autoImplicit false
+set_option maxHeartbeats 4000000
+
+namespace SizzLean.Proofs
+
+open SizzLean.Spec
+-- `extractCollOffsets` is `protected` in `Spec/Deserialize.lean`
+-- (proof-internal, kept off the general `SizzLean.Spec` surface, same
+-- convention as `extractFieldOffsets` / `natToLEBytes` / `readNatLE`),
+-- so the wildcard `open` above does not bring it into scope; request
+-- it explicitly.
+open SizzLean.Spec (extractCollOffsets)
+
+/-! ### Offset-list plumbing -/
+
+/-- Expected running element offsets: the list the encoder's
+placeholders *should* decode back to, mirroring
+`serializeVarElemsAux`'s own walk exactly (one entry per element,
+in order). Homogeneous analogue of `varOffsetsOf`. -/
+def collOffsetsOf (t : SSZType) : List t.interp → Nat → List Nat
+  | [],      _      => []
+  | x :: xs, varOff =>
+      varOff :: collOffsetsOf t xs (varOff + (SSZType.serialize t x).size)
+
+/-- `collOffsetsOf` produces one offset per element. -/
+theorem collOffsetsOf_length
+    (t : SSZType) (xs : List t.interp) (varOff : Nat) :
+    (collOffsetsOf t xs varOff).length = xs.length := by
+  induction xs generalizing varOff with
+  | nil => rfl
+  | cons _ xs ih =>
+    unfold collOffsetsOf
+    simp [ih]
+
+/-- The first placeholder a non-empty collection writes is the
+seeded `varOff`. At the encoder's call site that seed is
+`xs.length * BYTES_PER_LENGTH_OFFSET`, which is the vector
+decoder's first-offset guard and the list decoder's
+`count = firstOff / 4` recovery. -/
+theorem collOffsetsOf_head_cons
+    (t : SSZType) (x : t.interp) (xs : List t.interp) (varOff : Nat) :
+    (collOffsetsOf t (x :: xs) varOff).head? = some varOff := rfl
+
+/-! ### Encoder accounting and the size walker -/
+
+/-- **Encoder accounting**: the offset-table output of
+`serializeVarElemsAux` has size exactly `xs.length * 4`, one
+`uint32` placeholder per element (`size_uint32LE`). Independent of
+`varOff` and of the bodies. Structural induction on `xs`. -/
+theorem size_serializeVarElemsAux_offs
+    (t : SSZType) (xs : List t.interp) (varOff : Nat) :
+    (SSZType.serializeVarElemsAux t xs varOff).1.size =
+      xs.length * SizzLean.Spec.BYTES_PER_LENGTH_OFFSET := by
+  induction xs generalizing varOff with
+  | nil =>
+    unfold SSZType.serializeVarElemsAux
+    simp [ByteArray.size_empty]
+  | cons x xs ih =>
+    have h_enc :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).1 =
+          uint32LE (Nat.toUInt32 varOff) ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).1 := by
+      simp only [SSZType.serializeVarElemsAux]
+    rw [h_enc, ByteArray.size_append, size_uint32LE, ih, List.length_cons]
+    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
+    rw [hBPLO, Nat.add_mul, Nat.one_mul, Nat.add_comm]
+
+/-- Reading the first offset placeholder back off the front of a
+non-empty collection's own encoded output recovers the seeded
+`varOff`. The list decoder's `readUInt32LE b 0` is this lemma at
+`pre = .empty`; combined with `toNat_toUInt32_of_lt` it yields
+`count = firstOff / 4`. -/
+theorem readUInt32LE_serializeVarElemsAux_cons
+    (t : SSZType) (x : t.interp) (xs : List t.interp) (varOff : Nat) :
+    readUInt32LE
+      ((SSZType.serializeVarElemsAux t (x :: xs) varOff).1 ++
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).2) 0
+      = some (Nat.toUInt32 varOff) := by
+  have h_enc :
+      (SSZType.serializeVarElemsAux t (x :: xs) varOff).1 =
+        uint32LE (Nat.toUInt32 varOff) ++
+          (SSZType.serializeVarElemsAux t xs
+            (varOff + (SSZType.serialize t x).size)).1 := by
+    simp only [SSZType.serializeVarElemsAux]
+  rw [h_enc, ByteArray.append_assoc]
+  exact readUInt32LE_uint32LE_append _ _
+
+/-- **Size walker**: the total serialized output of
+`serializeVarElemsAux` (offset table plus bodies combined) fits
+within `xs.length * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`.
+Every element contributes `≤ maxByteLength t` to the body side and
+exactly 4 bytes to the offset table. Feeds both the
+`encode_size_le_max` `vectorVar` / `listVar` arms and the
+uint32-overflow guard the offset-extraction inverse below depends
+on. The per-element bound is taken on all of `t.interp` (the shape
+`encode_size_le_max` will supply), not merely the elements of `xs`. -/
+theorem size_serializeVarElemsAux_le_max
+    (t : SSZType) (xs : List t.interp) (varOff : Nat)
+    (h_max : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t) :
+    (SSZType.serializeVarElemsAux t xs varOff).1.size +
+      (SSZType.serializeVarElemsAux t xs varOff).2.size ≤
+      xs.length * (SizzLean.Spec.BYTES_PER_LENGTH_OFFSET +
+        SSZType.maxByteLength t) := by
+  induction xs generalizing varOff with
+  | nil =>
+    unfold SSZType.serializeVarElemsAux
+    simp [ByteArray.size_empty]
+  | cons x xs ih =>
+    have h_enc :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).1 =
+          uint32LE (Nat.toUInt32 varOff) ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).1 := by
+      simp only [SSZType.serializeVarElemsAux]
+    have h_enc2 :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).2 =
+          SSZType.serialize t x ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).2 := by
+      simp only [SSZType.serializeVarElemsAux]
+    rw [h_enc, h_enc2, ByteArray.size_append, ByteArray.size_append,
+        size_uint32LE]
+    have h_tail := ih (varOff + (SSZType.serialize t x).size)
+    have h_head := h_max x
+    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
+    rw [hBPLO] at h_tail ⊢
+    rw [List.length_cons, Nat.add_mul, Nat.one_mul]
+    omega
+
+/-- Size walker specialized to `.vector t n`: once `t` is
+variable-size and the element list has length `n`, the aux bound
+is definitionally `maxByteLength (.vector t n)`. -/
+theorem size_serializeVarElemsAux_le_maxByteLength_vector
+    (t : SSZType) (n : Nat) (xs : List t.interp) (varOff : Nat)
+    (h_var : t.isFixedSize = false)
+    (h_len : xs.length = n)
+    (h_max : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t) :
+    (SSZType.serializeVarElemsAux t xs varOff).1.size +
+      (SSZType.serializeVarElemsAux t xs varOff).2.size ≤
+      SSZType.maxByteLength (.vector t n) := by
+  have h := size_serializeVarElemsAux_le_max t xs varOff h_max
+  simp only [SSZType.maxByteLength, h_var, if_false, Bool.false_eq_true]
+  rwa [h_len] at h
+
+/-- Size walker specialized to `.list t cap`: once `t` is
+variable-size and the element list is within cap, the aux bound
+scales up to `maxByteLength (.list t cap)` by
+`Nat.mul_le_mul_right`. Empty lists (size 0) are in-bounds. -/
+theorem size_serializeVarElemsAux_le_maxByteLength_list
+    (t : SSZType) (cap : Nat) (xs : List t.interp) (varOff : Nat)
+    (h_var : t.isFixedSize = false)
+    (h_len : xs.length ≤ cap)
+    (h_max : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t) :
+    (SSZType.serializeVarElemsAux t xs varOff).1.size +
+      (SSZType.serializeVarElemsAux t xs varOff).2.size ≤
+      SSZType.maxByteLength (.list t cap) := by
+  have h := size_serializeVarElemsAux_le_max t xs varOff h_max
+  simp only [SSZType.maxByteLength, h_var, if_false, Bool.false_eq_true]
+  exact Nat.le_trans h (Nat.mul_le_mul_right _ h_len)
+
+/-! ### Offset-extraction inverse -/
+
+/-- **Offset-extraction inverse**: reading `extractCollOffsets`
+back off the encoder's own offset-table output recovers exactly
+the running offsets `serializeVarElemsAux` wrote (`collOffsetsOf`).
+
+Generalized over an arbitrary already-consumed prefix `pre` (so
+induction can peel one placeholder off the front via the
+append-shift bridges in `ContainerVar`) and an arbitrary suffix
+`suf` following the offset table. The `suf` generality is what
+keeps this proof tractable: `extractCollOffsets` never reads past
+the offset table (every `uint32` placeholder it decodes lies
+entirely within `.1`, by `size_serializeVarElemsAux_offs`), so
+the buffer's tail can be *anything*, in particular `.2 ++ (whatever
+came after the whole collection)`, without the invariant ever
+having to track where the body region physically sits.
+
+The `h_bound` hypothesis is the uint32-overflow guard: every offset
+the encoder writes is `varOff ≤ o ≤ varOff + (total body bytes
+written so far)`, so bounding that sum by `2 ^ 32` keeps every
+offset's `UInt32` round-trip exact (`toNat_toUInt32_of_lt`).
+Specializes to `pre = .empty` for the top-level statement the
+(later) roundtrip walker needs. -/
+theorem extractCollOffsets_serializeVarElemsAux
+    (t : SSZType) :
+    ∀ (xs : List t.interp) (varOff : Nat) (pre : ByteArray),
+    varOff + (SSZType.serializeVarElemsAux t xs varOff).2.size < 2 ^ 32 →
+    ∀ (suf : ByteArray),
+    extractCollOffsets
+      (pre ++ ((SSZType.serializeVarElemsAux t xs varOff).1 ++ suf))
+      xs.length pre.size
+      = .ok (collOffsetsOf t xs varOff) := by
+  intro xs
+  induction xs with
+  | nil =>
+    intro varOff pre _ suf
+    unfold SSZType.serializeVarElemsAux collOffsetsOf extractCollOffsets
+    rfl
+  | cons x xs ih =>
+    intro varOff pre h_bound suf
+    have h_enc :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).1 =
+          uint32LE (Nat.toUInt32 varOff) ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).1 := by
+      simp only [SSZType.serializeVarElemsAux]
+    have h_enc2 :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).2 =
+          SSZType.serialize t x ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).2 := by
+      simp only [SSZType.serializeVarElemsAux]
+    rw [h_enc2] at h_bound
+    have h_bound_tail :
+        (varOff + (SSZType.serialize t x).size) +
+          (SSZType.serializeVarElemsAux t xs
+            (varOff + (SSZType.serialize t x).size)).2.size < 2 ^ 32 := by
+      rw [ByteArray.size_append] at h_bound; omega
+    have h_ih :=
+      ih (varOff + (SSZType.serialize t x).size)
+        (pre ++ uint32LE (Nat.toUInt32 varOff)) h_bound_tail suf
+    have h_presize :
+        (pre ++ uint32LE (Nat.toUInt32 varOff)).size = pre.size + 4 := by
+      rw [ByteArray.size_append, size_uint32LE]
+    rw [h_enc]
+    have h_reassoc :
+        pre ++
+            (uint32LE (Nat.toUInt32 varOff) ++
+              (SSZType.serializeVarElemsAux t xs
+                (varOff + (SSZType.serialize t x).size)).1 ++ suf)
+          = (pre ++ uint32LE (Nat.toUInt32 varOff)) ++
+              ((SSZType.serializeVarElemsAux t xs
+                (varOff + (SSZType.serialize t x).size)).1 ++ suf) := by
+      simp only [ByteArray.append_assoc]
+    rw [h_reassoc]
+    simp only [List.length_cons]
+    unfold extractCollOffsets
+    have h_read :
+        readUInt32LE
+            ((pre ++ uint32LE (Nat.toUInt32 varOff)) ++
+              ((SSZType.serializeVarElemsAux t xs
+                (varOff + (SSZType.serialize t x).size)).1 ++ suf))
+            pre.size
+          = some (Nat.toUInt32 varOff) := by
+      rw [ByteArray.append_assoc]
+      have hshift := readUInt32LE_append_shift pre
+        (uint32LE (Nat.toUInt32 varOff) ++
+          ((SSZType.serializeVarElemsAux t xs
+            (varOff + (SSZType.serialize t x).size)).1 ++ suf))
+        0 (by rw [ByteArray.size_append, size_uint32LE]; omega)
+      simp only [Nat.add_zero] at hshift
+      rw [hshift, readUInt32LE_uint32LE_append]
+    rw [h_read]
+    dsimp only
+    have hBPLO : SizzLean.Spec.BYTES_PER_LENGTH_OFFSET = 4 := rfl
+    rw [hBPLO, show pre.size + 4 = (pre ++ uint32LE (Nat.toUInt32 varOff)).size
+          from h_presize.symm, h_ih]
+    dsimp only
+    have h_toNat : (Nat.toUInt32 varOff).toNat = varOff :=
+      toNat_toUInt32_of_lt varOff (by omega)
+    rw [h_toNat]
+    rfl
+
+end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -12,13 +12,15 @@ Variable-element collections (`.vector t n` / `.list t cap` with
 ([`Spec/Serialize.lean`](../Spec/Serialize.lean)'s
 `serializeVarElemsAux`, [`Spec/Deserialize.lean`](../Spec/Deserialize.lean)'s
 non-`isFixedSize` `.vector` / `.list` branches) fully implements the
-offset-table wire format, but no `BasicSupported` constructor claims
-it yet, and no theorem closes it. This module lays the groundwork;
-the predicates (`vectorVar` / `listVar` on `BasicSupported` /
+offset-table wire format. No `BasicSupported` constructor claims it
+yet, and no theorem closes it. This module holds the codec-level
+groundwork.
+
+The predicates (`vectorVar` / `listVar` on `BasicSupported` /
 `Supported` / `SupportedBounded`) and the roundtrip walkers land in
-a follow-up, once this file's lemmas are available to build on and
-once `containerVar` is on `main` (the `BasicSupported` matchers grow
-two constructors; that arm must already be exhaustive).
+a follow-up. That follow-up builds on this file's lemmas and needs
+`containerVar` on `main`. Its `BasicSupported` matchers grow two
+constructors, and that match must already be exhaustive.
 
 Homogeneous collections have one element type `t`, so the proof
 inducts on the element list as `Proofs/FixedElems.lean` does. The
@@ -43,8 +45,8 @@ the total width of the offset table): each element appends a
 body to the `.2` accumulator, then advances `varOff` by the body's
 size. The decoder's `extractCollOffsets` reads `count` placeholders
 back out, before `deserializeVarElems` uses them to slice each
-body. Vectors take `count = n` and reject `n = 0`; lists recover
-`count` from `off₀ / 4`, with the empty buffer the empty list.
+body. Vectors take `count = n` and reject `n = 0`. Lists recover
+`count` from `off₀ / 4`; an empty buffer decodes to the empty list.
 
 ## Lemma path
 
@@ -58,10 +60,9 @@ them):
    order). Homogeneous analogue of `varOffsetsOf`.
 2. **Encoder accounting** (`size_serializeVarElemsAux_offs`):
    `(serializeVarElemsAux t xs varOff).1.size = xs.length * 4`.
-   Independent of `varOff` and of the bodies. At the encoder's seed
-   `varOff = n * 4`, the first encoded offset is `n * 4`. The vector
-   decoder takes `count = n` from the schema. The later roundtrip
-   proof uses the encoder's canonical offset.
+   The size is independent of `varOff` and of the bodies. The vector
+   decoder takes `count = n` from the schema, and the roundtrip proof
+   uses the encoder's canonical first offset `n * 4`.
 3. **Size walker** (`size_serializeVarElemsAux_le_max`):
    `(serializeVarElemsAux t xs varOff).1.size + .2.size ≤
    xs.length * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`.
@@ -101,10 +102,9 @@ open SizzLean.Spec (extractCollOffsets)
 
 /-! ### Offset-list plumbing -/
 
-/-- Expected running element offsets: the list the encoder's
-placeholders *should* decode back to, mirroring
-`serializeVarElemsAux`'s own walk exactly (one entry per element,
-in order). Homogeneous analogue of `varOffsetsOf`. -/
+/-- Expected running element offsets: entry `i` holds the `varOff`
+value live when the encoder wrote element `i`. Homogeneous analogue
+of `varOffsetsOf`. -/
 def collOffsetsOf (t : SSZType) : List t.interp → Nat → List Nat
   | [],      _      => []
   | x :: xs, varOff =>
@@ -155,8 +155,8 @@ theorem size_serializeVarElemsAux_offs
 
 /-- Reading the first offset placeholder back off the front of a
 non-empty collection's own encoded output recovers the seeded
-`varOff`. The list decoder's `readUInt32LE b 0` is this lemma at
-`pre = .empty`; combined with `toNat_toUInt32_of_lt` it yields
+`varOff`. The list decoder performs the same read (`readUInt32LE b
+0`); combined with `toNat_toUInt32_of_lt` it yields
 `count = firstOff / 4`. -/
 theorem readUInt32LE_serializeVarElemsAux_cons
     (t : SSZType) (x : t.interp) (xs : List t.interp) (varOff : Nat) :
@@ -180,8 +180,8 @@ Every element contributes `≤ maxByteLength t` to the body side and
 exactly 4 bytes to the offset table. Feeds both the
 `encode_size_le_max` `vectorVar` / `listVar` arms and the
 uint32-overflow guard the offset-extraction inverse below depends
-on. The per-element bound is taken on all of `t.interp` (the shape
-`encode_size_le_max` will supply), not merely the elements of `xs`. -/
+on. The hypothesis `h_max` quantifies over all of `t.interp`,
+matching the shape `encode_size_le_max` supplies. -/
 theorem size_serializeVarElemsAux_le_max
     (t : SSZType) (xs : List t.interp) (varOff : Nat)
     (h_max : ∀ y : t.interp,

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -171,15 +171,23 @@ the head of a *variable-size-element collection* (`vector` / `list`
 wire form is `[ off₀ off₁ … off_{n-1} | body₀ body₁ … ]`, where each
 `off_i` is a `uint32`-LE and the count `n` is recovered from
 `off₀ / 4` (the first body starts where the offset table ends).
-`extractCollOffsets` reads `count` offsets starting at `off`. -/
-private def extractCollOffsets (b : ByteArray) :
+`extractCollOffsets` reads `count` offsets starting at `off`.
+
+`protected` (was `private`): the variable-element collection
+roundtrip proof reasons through this walker's branches, so it must
+be reachable, but it is proof-internal, not part of the general
+`SizzLean.Spec` surface. Same convention as `extractFieldOffsets`;
+the proof file names it with an explicit
+`open SizzLean.Spec (extractCollOffsets)`. -/
+protected def extractCollOffsets (b : ByteArray) :
     (count : Nat) → (off : Nat) → Except SSZError (List Nat)
   | 0,     _   => .ok []
   | k + 1, off =>
       match readUInt32LE b off with
       | .none => .error .tooShort
       | .some o =>
-          match extractCollOffsets b k (off + BYTES_PER_LENGTH_OFFSET) with
+          match SizzLean.Spec.extractCollOffsets b k
+              (off + BYTES_PER_LENGTH_OFFSET) with
           | .ok rest  => .ok (o.toNat :: rest)
           | .error e  => .error e
 
@@ -352,7 +360,7 @@ def SSZType.deserialize : (s : SSZType) → ByteArray → Except SSZError (s.int
         -- `n` entries. First offset must equal `n * 4`.
         if b.size < n * BYTES_PER_LENGTH_OFFSET then .error .tooShort
         else
-          match extractCollOffsets b n 0 with
+          match SizzLean.Spec.extractCollOffsets b n 0 with
           | .error e => .error e
           | .ok offs =>
               match SSZType.deserializeVarElems t offs b.size b with
@@ -392,7 +400,7 @@ def SSZType.deserialize : (s : SSZType) → ByteArray → Except SSZError (s.int
                 let count := firstOffN / BYTES_PER_LENGTH_OFFSET
                 if count > cap then .error .outOfRange
                 else
-                  match extractCollOffsets b count 0 with
+                  match SizzLean.Spec.extractCollOffsets b count 0 with
                   | .error e => .error e
                   | .ok offs =>
                       match SSZType.deserializeVarElems t offs b.size b with

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -169,9 +169,10 @@ protected def extractFieldOffsets (b : ByteArray) :
 the head of a *variable-size-element collection* (`vector` / `list`
 / `progList` whose element type is variable-size). The collection's
 wire form is `[ off₀ off₁ … off_{n-1} | body₀ body₁ … ]`, where each
-`off_i` is a `uint32`-LE and the count `n` is recovered from
-`off₀ / 4` (the first body starts where the offset table ends).
-`extractCollOffsets` reads `count` offsets starting at `off`.
+`off_i` is a `uint32`-LE. Vectors take the count from the schema.
+Non-empty lists recover it from `off₀ / 4`; the encoder puts the
+first body after the offset table. `extractCollOffsets` reads the
+supplied `count` offsets starting at `off`.
 
 `protected` (was `private`): the variable-element collection
 roundtrip proof reasons through this walker's branches, so it must
@@ -356,8 +357,8 @@ def SSZType.deserialize : (s : SSZType) → ByteArray → Except SSZError (s.int
             if h : arr.size = n then .ok (⟨arr, h⟩, used)
             else .error .tooShort
       else
-        -- Variable-size element vector: the offset table has exactly
-        -- `n` entries. First offset must equal `n * 4`.
+        -- Variable-size element vector: read the schema's `n` offsets.
+        -- The body walker checks each resulting slice against `b.size`.
         if b.size < n * BYTES_PER_LENGTH_OFFSET then .error .tooShort
         else
           match SizzLean.Spec.extractCollOffsets b n 0 with

--- a/packages/SizzLean/SizzLean/Spec/Deserialize.lean
+++ b/packages/SizzLean/SizzLean/Spec/Deserialize.lean
@@ -176,7 +176,7 @@ supplied `count` offsets starting at `off`.
 
 `protected` (was `private`): the variable-element collection
 roundtrip proof reasons through this walker's branches, so it must
-be reachable, but it is proof-internal, not part of the general
+be reachable. It stays proof-internal and off the general
 `SizzLean.Spec` surface. Same convention as `extractFieldOffsets`;
 the proof file names it with an explicit
 `open SizzLean.Spec (extractCollOffsets)`. -/


### PR DESCRIPTION
## Summary

Second of three PRs for #68. This PR adds proof groundwork in `Proofs/CollectionVar.lean`. Predicate and dispatcher changes remain in #75, so this slice builds on its own.

#69 is already on `main`. Homogeneous collections have one element type `t`. The proofs induct on the element list and reuse the existing uint32 codec bridge from `ContainerVar`.

- **Offset-list plumbing** (`collOffsetsOf`): records the running offsets written by `serializeVarElemsAux`.
- **Encoder accounting** (`size_serializeVarElemsAux_offs`): proves that the offset table has size `xs.length * 4`. At the encoder seed, the first encoded offset is `n * 4`. The vector decoder takes `count` from `n`. Roundtrip uses the encoder's canonical first offset. Decoder canonicity remains outside #68.
- **First-offset read** (`readUInt32LE_serializeVarElemsAux_cons`): proves that the list decoder reads the seeded `varOff`. Together with `toNat_toUInt32_of_lt`, this recovers `count = firstOff / 4`.
- **Size walker** (`size_serializeVarElemsAux_le_max` and its collection specializations): bounds the encoded size using the formula from #69. The later roundtrip proofs use this bound for uint32 offsets.
- **Offset-extraction inverse** (`extractCollOffsets_serializeVarElemsAux`): proves that extraction from encoder output recovers the running offsets.

The PR also changes `extractCollOffsets` from `private` to `protected`, matching `extractFieldOffsets`.

## Verification

- `lake build SizzLean SizzLeanTests`
- Axiom audit on every new theorem
- Accounting and size lemmas use only their standard kernel dependencies
- Placeholder-reading lemmas reuse one existing `bv_decide` axiom from the uint32 bridge

## Test plan

- [x] SizzLean and SizzLeanTests build
- [x] New theorem axioms checked
- [x] CI passes
- [x] #69 is on `main`

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.