### PR TITLE
feat(ethcllib): compute_merkle_branch_root and the length guard

### DIFF
--- a/packages/EthCLLib/EthCLLib.lean
+++ b/packages/EthCLLib/EthCLLib.lean
@@ -1,6 +1,7 @@
 import EthCLLib.Internal.Capture
 import EthCLLib.Internal.ProofLedger
 import EthCLLib.Spec
+import EthCLLib.Proofs
 import EthCLLib.PySpecTests.Interface
 import EthCLLib.PySpecTests.Driver
 

--- a/packages/EthCLLib/EthCLLib.lean
+++ b/packages/EthCLLib/EthCLLib.lean
@@ -17,7 +17,8 @@ the generic `PySpecTests` driver. It names no fork; a separate package
 
 The author-facing surface is gathered under `EthCLLib.Spec`, so a spec file
 opens exactly one namespace (`open EthCLLib.Spec`). Internals live under
-`EthCLLib.Internal`; the generic pyspec driver under `EthCLLib.PySpecTests`.
+`EthCLLib.Internal`; the generic pyspec driver under `EthCLLib.PySpecTests`;
+the theorems about the `Spec` functions under `EthCLLib.Proofs`.
 
 One internal module is author-facing all the same: `Internal.ProofLedger` defines
 the `characterizes` attribute a proof carries to claim it states a spec

--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -1,0 +1,5 @@
+import EthCLLib.Proofs.MerkleBranch
+
+/-!
+# `EthCLLib.Proofs`: framework proof modules
+-/

--- a/packages/EthCLLib/EthCLLib/Proofs.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs.lean
@@ -2,4 +2,12 @@ import EthCLLib.Proofs.MerkleBranch
 
 /-!
 # `EthCLLib.Proofs`: framework proof modules
+
+The theorems about the spec functions `EthCLLib.Spec` declares. A fork body's
+theorems live in `EthCLSpecs/Proofs/<Fork>/` instead, one directory per fork,
+because each fork re-elaborates its own declarations.
+
+Nothing here carries `@[characterizes]`. That attribute claims a `forkdef`'s
+contract, and the framework declares no `forkdef`, so `scripts/ProofCoverage.lean`
+counts none of these modules.
 -/

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -1,0 +1,124 @@
+import EthCLLib.Spec.SigningRoot
+
+/-!
+# `EthCLLib.Proofs.MerkleBranch`: what `isValidMerkleBranch` accepts
+
+`EthCLLib.Spec.isValidMerkleBranch` is `is_valid_merkle_branch`
+(`specs/phase0/beacon-chain.md:800-812`).
+
+Past the length guard, the check reduces to a plain fold of `branch` over `leaf`,
+compared to `root`.
+
+Bit ordering: `branch` runs bottom-to-top and entry `i` is the level-`i` sibling.
+The routing convention lives in `EthCLLib.Spec.MerklePath`. The shipped check and
+this fold both call `routeRight`, so the two agree by definition.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Proofs
+
+open SizzLean
+open SizzLean.Hasher
+open EthCLLib.Spec
+
+/-! ### The proof-side fold
+
+`computeMerkleBranchRoot` runs its fold in `Except` and wraps the result, neither
+of which an induction can peel. `branchFold` is the same walk as a plain
+`ByteArray` function, `private` and proof-local. It models nothing the spec
+declares, and `computeMerkleBranchRoot_eq_branchFold` is the only way in. -/
+
+/-- The branch walk as a bare fold, reading siblings straight out of `branch`. -/
+private def branchFold [HasherTag] (leaf : ByteArray)
+    (branch : Array (Vector UInt8 32)) (depth index : Nat) : ByteArray :=
+  (List.range depth).foldl (init := leaf) fun value i =>
+    if routeRight index i
+    then Hasher.combine (H := HasherTag.H) (vecToBytes branch[i]!) value
+    else Hasher.combine (H := HasherTag.H) value (vecToBytes branch[i]!)
+
+/-- One level off the top: the `d+1` walk is the `d` walk followed by level `d`. -/
+private theorem branchFold_succ [HasherTag] (leaf : ByteArray)
+    (branch : Array (Vector UInt8 32)) (d index : Nat) :
+    branchFold leaf branch (d + 1) index
+      = (let value := branchFold leaf branch d index
+         if routeRight index d
+         then Hasher.combine (H := HasherTag.H) (vecToBytes branch[d]!) value
+         else Hasher.combine (H := HasherTag.H) value (vecToBytes branch[d]!)) := by
+  unfold branchFold
+  rw [List.range_succ, List.foldl_append]
+  rfl
+
+/-- The checked fold itself, in range: every `branch[i]` read hits, so the
+`IndexError` arm never fires. The statement sits on the inner `foldlM`, since the
+induction has to step the fold without `computeMerkleBranchRoot`'s closing wrap
+in the way. It generalises over the accumulator for the same reason. -/
+private theorem branchFoldM_ok [HasherTag] (branch : Array (Vector UInt8 32)) (index : Nat) :
+    ∀ (depth : Nat), depth ≤ branch.size → ∀ (leaf : ByteArray),
+      (List.range depth).foldlM (m := Except SizzLean.Cache.IndexError) (init := leaf)
+          (fun value i => do
+            let sibling ←
+              if h : i < branch.size then pure (vecToBytes branch[i])
+              else throw (.indexError i branch.size)
+            return if routeRight index i
+              then Hasher.combine (H := HasherTag.H) sibling value
+              else Hasher.combine (H := HasherTag.H) value sibling)
+        = .ok (branchFold leaf branch depth index) := by
+  intro depth
+  induction depth with
+  | zero => intro _ leaf; rfl
+  | succ d ih =>
+      intro hb leaf
+      rw [List.range_succ, List.foldlM_append, ih (by omega) leaf, branchFold_succ]
+      simp [dif_pos (show d < branch.size by omega),
+        getElem!_pos branch d (show d < branch.size by omega)]
+      rfl
+
+/-- In range, the checked walk is the plain one. -/
+private theorem computeMerkleBranchRoot_eq_branchFold [HasherTag]
+    (leaf : Vector UInt8 32) (branch : Array (Vector UInt8 32)) (depth index : Nat)
+    (hb : depth ≤ branch.size) :
+    computeMerkleBranchRoot leaf branch depth index
+      = .ok (bytesToRoot (branchFold (vecToBytes leaf) branch depth index)) := by
+  unfold computeMerkleBranchRoot
+  rw [branchFoldM_ok branch index depth hb (vecToBytes leaf)]
+  rfl
+
+/-! ### Past the guard -/
+
+/-- A well-formed branch has `branch.size = depth`, which the honest opening
+satisfies. The length guard then passes, and `isValidMerkleBranch` is the
+byte-root of the branch walk compared to `root`. -/
+theorem isValidMerkleBranch_eq_beq [HasherTag] (leaf : Vector UInt8 32)
+    (branch : Array (Vector UInt8 32)) (depth index : Nat) (root : Vector UInt8 32)
+    (hsize : branch.size = depth) :
+    isValidMerkleBranch leaf branch depth index root
+      = (bytesToRoot (branchFold (vecToBytes leaf) branch depth index) == root) := by
+  unfold isValidMerkleBranch
+  rw [if_pos hsize,
+    computeMerkleBranchRoot_eq_branchFold leaf branch depth index (Nat.le_of_eq hsize.symm)]
+
+/-- **Reconstruction (acceptance #1).** Given `hsize : branch.size = depth`, the
+check accepts iff the left/right fold of `branch` over `leaf` reconstructs
+`root`. The fold reads `index`'s bits to pick each side.
+
+`hsize` is what the length guard enforces. Without it the statement fails on a
+length mismatch, where the check returns `false` whatever the fold produces.
+
+The proof closes symbolically, so no compiler axiom enters. -/
+theorem isValidMerkleBranch_iff [HasherTag] (leaf : Vector UInt8 32)
+    (branch : Array (Vector UInt8 32)) (depth index : Nat) (root : Vector UInt8 32)
+    (hsize : branch.size = depth) :
+    isValidMerkleBranch leaf branch depth index root = true
+      ↔ bytesToRoot (branchFold (vecToBytes leaf) branch depth index) = root := by
+  rw [isValidMerkleBranch_eq_beq _ _ _ _ _ hsize]
+  exact beq_iff_eq
+
+/-- Root-typing a sibling array preserves its length. Named so the statement
+below can cite it, rather than carrying `(by rw [Array.size_map]; exact hsize)`
+inline where a reader expects a term. -/
+theorem size_map_bytesToRoot {sibs : Array ByteArray} {depth : Nat}
+    (hsize : sibs.size = depth) : (sibs.map bytesToRoot).size = depth := by
+  rw [Array.size_map]; exact hsize
+
+end EthCLLib.Proofs

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -84,12 +84,17 @@ private theorem computeMerkleBranchRoot_eq_branchFold [HasherTag]
   rw [branchFoldM_ok branch index depth hb (vecToBytes leaf)]
   rfl
 
-/-! ### Past the guard -/
+/-! ### Past the guard
+
+Both theorems below state their right-hand side with `branchFold`, which is
+`private`. They are `private` too: outside this module the helper carries no
+name, so no goal could ever match them. They serve the theorems in this module
+that state the check's contract over shipped functions alone. -/
 
 /-- A well-formed branch has `branch.size = depth`, which the honest opening
 satisfies. The length guard then passes, and `isValidMerkleBranch` is the
 byte-root of the branch walk compared to `root`. -/
-theorem isValidMerkleBranch_eq_beq [HasherTag] (leaf : Vector UInt8 32)
+private theorem isValidMerkleBranch_eq_beq [HasherTag] (leaf : Vector UInt8 32)
     (branch : Array (Vector UInt8 32)) (depth index : Nat) (root : Vector UInt8 32)
     (hsize : branch.size = depth) :
     isValidMerkleBranch leaf branch depth index root
@@ -106,7 +111,7 @@ check accepts iff the left/right fold of `branch` over `leaf` reconstructs
 length mismatch, where the check returns `false` whatever the fold produces.
 
 The proof closes symbolically, so no compiler axiom enters. -/
-theorem isValidMerkleBranch_iff [HasherTag] (leaf : Vector UInt8 32)
+private theorem isValidMerkleBranch_iff [HasherTag] (leaf : Vector UInt8 32)
     (branch : Array (Vector UInt8 32)) (depth index : Nat) (root : Vector UInt8 32)
     (hsize : branch.size = depth) :
     isValidMerkleBranch leaf branch depth index root = true

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -4,7 +4,7 @@ import EthCLLib.Spec.SigningRoot
 # `EthCLLib.Proofs.MerkleBranch`: what `isValidMerkleBranch` accepts
 
 `EthCLLib.Spec.isValidMerkleBranch` is `is_valid_merkle_branch`
-(`specs/phase0/beacon-chain.md:800-812`).
+(`phase0/beacon-chain.md:800-812`).
 
 Past the length guard, the check reduces to a plain fold of `branch` over `leaf`,
 compared to `root`.
@@ -27,7 +27,7 @@ open EthCLLib.Spec
 `computeMerkleBranchRoot` runs its fold in `Except` and wraps the result, neither
 of which an induction can peel. `branchFold` is the same walk as a plain
 `ByteArray` function, `private` and proof-local. It models nothing the spec
-declares, and `computeMerkleBranchRoot_eq_branchFold` is the only way in. -/
+declares, and `computeMerkleBranchRoot_eq_branchFold` is the only bridge to it. -/
 
 /-- The branch walk as a bare fold, reading siblings straight out of `branch`. -/
 private def branchFold [HasherTag] (leaf : ByteArray)

--- a/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
+++ b/packages/EthCLLib/EthCLLib/Proofs/MerkleBranch.lean
@@ -19,7 +19,6 @@ set_option autoImplicit false
 namespace EthCLLib.Proofs
 
 open SizzLean
-open SizzLean.Hasher
 open EthCLLib.Spec
 
 /-! ### The proof-side fold
@@ -55,7 +54,7 @@ induction has to step the fold without `computeMerkleBranchRoot`'s closing wrap
 in the way. It generalises over the accumulator for the same reason. -/
 private theorem branchFoldM_ok [HasherTag] (branch : Array (Vector UInt8 32)) (index : Nat) :
     ∀ (depth : Nat), depth ≤ branch.size → ∀ (leaf : ByteArray),
-      (List.range depth).foldlM (m := Except SizzLean.Cache.IndexError) (init := leaf)
+      (List.range depth).foldlM (m := Except Cache.IndexError) (init := leaf)
           (fun value i => do
             let sibling ←
               if h : i < branch.size then pure (vecToBytes branch[i])

--- a/packages/EthCLLib/EthCLLib/Spec.lean
+++ b/packages/EthCLLib/EthCLLib/Spec.lean
@@ -2,6 +2,7 @@ import EthCLLib.Spec.Errors
 import EthCLLib.Spec.Hasher
 import EthCLLib.Spec.State
 import EthCLLib.Spec.Arith
+import EthCLLib.Spec.MerklePath
 import EthCLLib.Spec.SigningRoot
 import EthCLLib.Spec.Loop
 import EthCLLib.Spec.FiniteMap

--- a/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
@@ -1,0 +1,43 @@
+/-!
+# `EthCLLib.Spec.MerklePath`: the path-routing convention
+
+Which side the walk mixes a sibling in on at each level of a Merkle path. The
+spec's branch walk routes by this, and so do the honest openers in
+`EthCLLib.Proofs.MerkleOpening`. The pyspec spells the same bit
+`index // (2**i) % 2`.
+
+Level `i` reads bit `i` of `index`. A set bit puts the opened node on the right,
+so its sibling goes on the left.
+
+The convention belongs to `is_valid_merkle_branch`, which is a consensus-spec
+function rather than an SSZ-document one. It therefore lives framework-side, and
+SizzLean never sees it. A leaf module with no imports, so any layer can take it.
+-/
+
+set_option autoImplicit false
+
+namespace EthCLLib.Spec
+
+/-- Merkle path routing at level `i`: `true` when `index` has bit `i` set. The
+opened node then sits in the right subtree at that level, and the walk mixes the
+sibling in on the left.
+
+`computeMerkleBranchRoot` and the honest openers both route by this one
+definition, so the shipped check and the proofs agree by definition. -/
+def routeRight (index i : Nat) : Bool := (index >>> i) &&& 1 == 1
+
+/-! The two spellings, `(index >>> i) &&& 1 == 1` here against the pyspec's
+`index // (2**i) % 2`, are equal but not syntactically equal. The theorem below
+is the only thing that ties our spelling to the spec's, so keep it even when no
+proof needs it to typecheck.
+
+The convention is worth pinning because inverting it is root-preserving on a
+shape-symmetric perfect tree. The walk opens the mirror leaf, mixes the sibling
+in on the mirror side, and reconstructs an identical root. Round-trip proofs
+therefore stay green under an inverted convention. Asymmetric shapes do notice. -/
+theorem routeRight_eq_div_mod (index i : Nat) :
+    routeRight index i = (index / 2 ^ i % 2 == 1) := by
+  show ((index >>> i) &&& 1 == 1) = (index / 2 ^ i % 2 == 1)
+  rw [Nat.shiftRight_eq_div_pow, Nat.and_one_is_mod]
+
+end EthCLLib.Spec

--- a/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/MerklePath.lean
@@ -1,17 +1,17 @@
 /-!
 # `EthCLLib.Spec.MerklePath`: the path-routing convention
 
-Which side the walk mixes a sibling in on at each level of a Merkle path. The
-spec's branch walk routes by this, and so do the honest openers in
-`EthCLLib.Proofs.MerkleOpening`. The pyspec spells the same bit
+A Merkle path mixes each sibling in on one side at each level, and this module
+picks that side. The spec's branch walk routes by it, and so do the honest
+openers in `EthCLLib.Proofs.MerkleOpening`. The pyspec spells the same bit
 `index // (2**i) % 2`.
 
 Level `i` reads bit `i` of `index`. A set bit puts the opened node on the right,
 so its sibling goes on the left.
 
-The convention belongs to `is_valid_merkle_branch`, which is a consensus-spec
-function rather than an SSZ-document one. It therefore lives framework-side, and
-SizzLean never sees it. A leaf module with no imports, so any layer can take it.
+The convention belongs to `is_valid_merkle_branch`, a consensus-spec function
+that the SSZ document never defines. It therefore lives framework-side, and
+SizzLean never sees it. The module imports nothing, so any layer can take it.
 -/
 
 set_option autoImplicit false
@@ -31,10 +31,11 @@ def routeRight (index i : Nat) : Bool := (index >>> i) &&& 1 == 1
 is the only thing that ties our spelling to the spec's, so keep it even when no
 proof needs it to typecheck.
 
-The convention is worth pinning because inverting it is root-preserving on a
+The convention is worth pinning because inverting it preserves the root on a
 shape-symmetric perfect tree. The walk opens the mirror leaf, mixes the sibling
-in on the mirror side, and reconstructs an identical root. Round-trip proofs
-therefore stay green under an inverted convention. Asymmetric shapes do notice. -/
+in on the mirror side, and rebuilds an identical root. Round-trip proofs
+therefore still pass under an inverted convention. An asymmetric shape
+reconstructs a different root, and there the convention shows. -/
 theorem routeRight_eq_div_mod (index i : Nat) :
     routeRight index i = (index / 2 ^ i % 2 == 1) := by
   show ((index >>> i) &&& 1 == 1) = (index / 2 ^ i % 2 == 1)

--- a/packages/EthCLLib/EthCLLib/Spec/SigningRoot.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/SigningRoot.lean
@@ -1,6 +1,7 @@
 import EthCLLib.Spec.Arith
 import EthCLLib.Spec.Hasher
 import EthCLLib.Spec.Crypto
+import EthCLLib.Spec.MerklePath
 
 /-!
 # `EthCLLib.Spec.SigningRoot`: the hashing-based crypto primitives
@@ -62,18 +63,47 @@ def computeSigningRoot [HasherTag] {T : Type} [SSZRepr T] (obj : T)
     (domain : Vector UInt8 32) : Vector UInt8 32 :=
   htr { objectRoot := htr obj, domain : SigningData }
 
-/-- `is_valid_merkle_branch(leaf, branch, depth, index, root)`: walk `depth`
-sibling hashes from `leaf`, mixing each in on the left or right by `index`'s bit,
-and compare to `root`. Used by `processDeposit` against `eth1Data.depositRoot`. -/
+/-- `compute_merkle_branch_root(leaf, branch, depth, index)`
+(`beacon-chain.md:782-798`): fold `branch` into `leaf`. Level `i` mixes its
+sibling in on the side that bit `i` of `index` picks.
+
+`routeRight` names that side. The pyspec spells the bit `index // (2**i) % 2`
+inline, and `routeRight_eq_div_mod` holds the two spellings together. One
+definition therefore carries the convention for this check and for the honest
+openers both.
+
+A `branch[i]` read past the end raises `IndexError`, which the reference runner's
+`expect_assertion_error` catches. The read is therefore a checked reject and not
+a defaulted one. The carrier is `IndexError` rather than either machine's reject,
+because this function reads no state. A caller routes the miss through `liftErr`
+to whichever machine it runs on. -/
+def computeMerkleBranchRoot [HasherTag] (leaf : Vector UInt8 32)
+    (branch : Array (Vector UInt8 32)) (depth index : Nat) :
+    Except SizzLean.Cache.IndexError (Vector UInt8 32) := do
+  let value ← (List.range depth).foldlM (init := vecToBytes leaf) fun value i => do
+    let sibling ←
+      if h : i < branch.size then pure (vecToBytes branch[i])
+      else throw (.indexError i branch.size)
+    return if routeRight index i
+      then Hasher.combine (H := HasherTag.H) sibling value
+      else Hasher.combine (H := HasherTag.H) value sibling
+  return bytesToRoot value
+
+/-- `is_valid_merkle_branch(leaf, branch, depth, index, root)` (`:800-812`):
+reject on `depth != len(branch)`, else compare the reconstructed root. Used by
+`processDeposit` against `eth1Data.depositRoot`.
+
+The guard runs first, so the fold reads `branch` only in range. The reject arm is
+therefore unreachable from here. The spec returns `False` on the guard and never
+reaches its raise either. -/
 def isValidMerkleBranch [HasherTag] (leaf : Vector UInt8 32)
     (branch : Array (Vector UInt8 32)) (depth : Nat) (index : Nat)
     (root : Vector UInt8 32) : Bool :=
-  let value : ByteArray := (List.range depth).foldl (init := vecToBytes leaf) fun acc i =>
-    let sibling := vecToBytes (branch[i]!)
-    if (index >>> i) &&& 1 == 1
-    then Hasher.combine (H := HasherTag.H) sibling acc
-    else Hasher.combine (H := HasherTag.H) acc sibling
-  bytesToRoot value == root
+  if branch.size = depth then
+    match computeMerkleBranchRoot leaf branch depth index with
+    | .ok value => value == root
+    | .error _  => false
+  else false
 
 /-- Verify a signature over an SSZ object's signing root: `blsVerify pubkey
 (computeSigningRoot obj domain) signature`. The common signature-gate shape, folding the

--- a/packages/EthCLLib/EthCLLib/Spec/SigningRoot.lean
+++ b/packages/EthCLLib/EthCLLib/Spec/SigningRoot.lean
@@ -64,8 +64,8 @@ def computeSigningRoot [HasherTag] {T : Type} [SSZRepr T] (obj : T)
   htr { objectRoot := htr obj, domain : SigningData }
 
 /-- `compute_merkle_branch_root(leaf, branch, depth, index)`
-(`beacon-chain.md:782-798`): fold `branch` into `leaf`. Level `i` mixes its
-sibling in on the side that bit `i` of `index` picks.
+(`phase0/beacon-chain.md:782-798`): fold `branch` into `leaf`. Level `i` mixes
+its sibling in on the side that bit `i` of `index` picks.
 
 `routeRight` names that side. The pyspec spells the bit `index // (2**i) % 2`
 inline, and `routeRight_eq_div_mod` holds the two spellings together. One
@@ -73,10 +73,10 @@ definition therefore carries the convention for this check and for the honest
 openers both.
 
 A `branch[i]` read past the end raises `IndexError`, which the reference runner's
-`expect_assertion_error` catches. The read is therefore a checked reject and not
-a defaulted one. The carrier is `IndexError` rather than either machine's reject,
-because this function reads no state. A caller routes the miss through `liftErr`
-to whichever machine it runs on. -/
+`expect_assertion_error` catches. The read is therefore a checked reject. The
+carrier is `IndexError`, which belongs to no machine, because this function reads
+no state. A caller routes the miss through `liftErr` to whichever machine it runs
+on. -/
 def computeMerkleBranchRoot [HasherTag] (leaf : Vector UInt8 32)
     (branch : Array (Vector UInt8 32)) (depth index : Nat) :
     Except SizzLean.Cache.IndexError (Vector UInt8 32) := do
@@ -89,13 +89,14 @@ def computeMerkleBranchRoot [HasherTag] (leaf : Vector UInt8 32)
       else Hasher.combine (H := HasherTag.H) value sibling
   return bytesToRoot value
 
-/-- `is_valid_merkle_branch(leaf, branch, depth, index, root)` (`:800-812`):
-reject on `depth != len(branch)`, else compare the reconstructed root. Used by
-`processDeposit` against `eth1Data.depositRoot`.
+/-- `is_valid_merkle_branch(leaf, branch, depth, index, root)`
+(`phase0/beacon-chain.md:800-812`): reject on `depth != len(branch)`, else
+compare the reconstructed root. Used by `processDeposit` against
+`eth1Data.depositRoot`.
 
 The guard runs first, so the fold reads `branch` only in range. The reject arm is
-therefore unreachable from here. The spec returns `False` on the guard and never
-reaches its raise either. -/
+therefore unreachable from here. The spec returns `False` on the guard, so it
+never reaches the out-of-range read either. -/
 def isValidMerkleBranch [HasherTag] (leaf : Vector UInt8 32)
     (branch : Array (Vector UInt8 32)) (depth : Nat) (index : Nat)
     (root : Vector UInt8 32) : Bool :=

--- a/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
+++ b/packages/EthCLLib/EthCLLib/Tests/FrameworkUtils.lean
@@ -96,4 +96,24 @@ example : (@computeDomain fastHasherTag ⟨#[0,0,0,1]⟩ v0 r0).toArray.size = 3
 example : @isValidMerkleBranch fastHasherTag r0 #[] 0 0 r0 = true := by native_decide
 example : @isValidMerkleBranch fastHasherTag r0 #[] 0 0 (Vector.replicate 32 1) = false := by native_decide
 
+-- The length guard (`depth != len(branch)`) rejects on either mismatch, before
+-- the walk hashes anything. The second case is the one a defaulting read would
+-- get wrong: at depth 0 the walk never touches the extra sibling, so it would
+-- reconstruct `r0` and accept.
+example : @isValidMerkleBranch fastHasherTag r0 #[] 1 0 r0 = false := by native_decide
+example : @isValidMerkleBranch fastHasherTag r0 #[r0] 0 0 r0 = false := by native_decide
+
+-- `computeMerkleBranchRoot` reports an out-of-range sibling read as an
+-- `IndexError` carrying the real index and bound. The walk reads levels 0 and 1
+-- from the two siblings, then asks for level 2 against a size-2 array. Only a
+-- direct caller reaches this arm; `isValidMerkleBranch`'s guard runs first.
+--
+-- The result is projected to a `Nat` pair because `Except IndexError (Vector
+-- UInt8 32)` carries no `DecidableEq` instance, so the equation cannot be
+-- stated on the `Except` value itself.
+example :
+    (match @computeMerkleBranchRoot fastHasherTag r0 #[r0, r0] 3 0 with
+     | .error (.indexError idx bound) => some (idx, bound)
+     | .ok _ => none) = some (2, 2) := by native_decide
+
 end EthCLLib.Tests.FrameworkUtils

--- a/packages/EthCLSpecs/docs/PROOF_LEDGER.md
+++ b/packages/EthCLSpecs/docs/PROOF_LEDGER.md
@@ -76,7 +76,11 @@ Three claims rest on another row:
 
 - The committee partition rests on the shuffle bijection.
 - Plausible liveness rests on accountable safety.
-- Both `processDeposit` rows rest on the Merkle branch check that
+- Both `processDeposit` rows rest on the Merkle branch check. Its proof module is
+  [`EthCLLib/Proofs/MerkleBranch.lean`](../../EthCLLib/EthCLLib/Proofs/MerkleBranch.lean),
+  which reduces `isValidMerkleBranch` past its length guard to a fold of `branch`
+  over `leaf`. Reading that fold as a statement about a cached SSZ tree still needs
+  the merkleization agreement that
   [`../../SizzLean/docs/PLAN.md`](../../SizzLean/docs/PLAN.md) Phase 5 tracks.
 
 ---

--- a/packages/SizzLean/SizzLean/Proofs/BitPack.lean
+++ b/packages/SizzLean/SizzLean/Proofs/BitPack.lean
@@ -2,6 +2,7 @@ import SizzLean.Spec.Supported
 import SizzLean.Spec.BasicSupported
 import SizzLean.Spec.MaxByteLength
 import SizzLean.Proofs.SimpAttrs
+import SizzLean.Proofs.Util
 
 /-!
 # `SizzLean.Proofs.BitPack`: the bit-packing inverse and the bit-shape arms
@@ -75,17 +76,10 @@ open SizzLean.Spec
 -- bring them into scope; request the two decoders explicitly.
 open SizzLean.Spec (deserializeBitvector deserializeBitlist)
 
-/-! ### ByteArray indexing bridges -/
+/-! ### ByteArray indexing bridges
 
-/-- `get!` agrees with the bounds-checked `b[i]` when in range.
-`get!` unfolds to `b.data[i]!`, whose panicking branch is
-irrelevant here; `getElem!_pos` (core) discharges it against the
-supplied bound. -/
-theorem get!_eq_getElem (b : ByteArray) (i : Nat) (h : i < b.size) :
-    b.get! i = b[i] := by
-  show b.data[i]! = b[i]
-  rw [ByteArray.getElem_eq_getElem_data]
-  exact getElem!_pos b.data i h
+`get!_eq_getElem` comes from `SizzLean.Proofs.Util`, in this same namespace, so
+the uses below read unqualified. -/
 
 /-- Reading index 0 of a single-byte array returns that byte. -/
 theorem get!_push_zero (x : UInt8) : (ByteArray.empty.push x).get! 0 = x := by

--- a/packages/SizzLean/SizzLean/Proofs/UIntWide.lean
+++ b/packages/SizzLean/SizzLean/Proofs/UIntWide.lean
@@ -4,6 +4,7 @@ import SizzLean.Spec.Supported
 import SizzLean.Spec.BasicSupported
 import SizzLean.Spec.MaxByteLength
 import SizzLean.Proofs.SimpAttrs
+import SizzLean.Proofs.Util
 
 /-!
 # `SizzLean.Proofs.UIntWide`: `decode_encode` and size bound for `uintN 128 / 256`
@@ -80,18 +81,11 @@ open SizzLean.Spec (natToLEBytes readNatLE readNatLEAux)
 
 /-! ### ByteArray indexing bridges
 
-`get!` (total) is convenient for stating byte facts without bounds
-proofs; the reader fold uses the bounds-checked `b[i]'h`. These three
-bridge the two forms and read a pushed byte back. -/
-
-/-- `get!` agrees with the bounds-checked `b[i]` when in range.
-`get!` unfolds to `b.data[i]!`, whose panic branch is discharged by
-`getElem!_pos` against the supplied bound. -/
-theorem get!_eq_getElem (b : ByteArray) (i : Nat) (h : i < b.size) :
-    b.get! i = b[i] := by
-  show b.data[i]! = b[i]
-  rw [ByteArray.getElem_eq_getElem_data]
-  exact getElem!_pos b.data i h
+`get!` is total, so it states byte facts without bounds proofs. The
+reader fold uses the bounds-checked `b[i]'h`. The two lemmas below
+bridge the forms and read a pushed byte back, on top of
+`get!_eq_getElem` from `SizzLean.Proofs.Util`. That lemma sits in this
+same namespace, so the uses below read unqualified. -/
 
 /-- Reading a pushed byte below the push point ignores it. -/
 theorem get!_push_lt (a : ByteArray) (b : UInt8) (i : Nat) (h : i < a.size) :

--- a/packages/SizzLean/SizzLean/Proofs/Util.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Util.lean
@@ -1,0 +1,43 @@
+/-!
+# `SizzLean.Proofs.Util`: elementary container bridges
+
+Generic, dependency-free lemmas shared across the proof layers: the `getElem!` /
+`get!` bridges for `Array` and `ByteArray` push/reads. A leaf module (no
+SizzLean imports), so both the `Spec` proof files and the `Cache/MerkleTree`
+shape modules can import it without layering concerns.
+
+The `Array` pair lives here and not in the Merkle-tree shapes module. The
+completeness proof then reaches a generic array fact without importing tree
+vocabulary. `Proofs/BitPack.lean` and `Proofs/UIntWide.lean` import
+`get!_eq_getElem` from here. All three declared it once each before, in this one
+namespace, so any change to the statement broke whichever module loaded second.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Proofs
+
+/-- `get!` agrees with the bounds-checked `b[i]` when in range.
+`get!` unfolds to `b.data[i]!`, and `getElem!_pos` discharges its panic branch
+against the supplied bound. -/
+theorem get!_eq_getElem (b : ByteArray) (i : Nat) (h : i < b.size) :
+    b.get! i = b[i] := by
+  show b.data[i]! = b[i]
+  rw [ByteArray.getElem_eq_getElem_data]
+  exact getElem!_pos b.data i h
+
+/-- `(a.push x)[i]!` for `i < a.size` reads `a[i]!`: the push is invisible below
+the old length. Collapses the recurring three-rewrite elimination block. -/
+theorem getElem!_push_lt {α} [Inhabited α] (a : Array α) (x : α) (i : Nat)
+    (h : i < a.size) : (a.push x)[i]! = a[i]! := by
+  rw [getElem!_pos (a.push x) i (by rw [Array.size_push]; omega),
+      Array.getElem_push_lt h, getElem!_pos a i h]
+
+/-- `(a.push x)[a.size]!` reads the pushed element. The companion top-index case. -/
+theorem getElem!_push_size {α} [Inhabited α] (a : Array α) (x : α) :
+    (a.push x)[a.size]! = x := by
+  rw [getElem!_pos (a.push x) a.size (by rw [Array.size_push]; omega),
+      Array.getElem_push]
+  simp
+
+end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Proofs/Util.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Util.lean
@@ -7,9 +7,8 @@ SizzLean imports), so any proof module can import it whatever layer it sits on.
 `Proofs/BitPack.lean` and `Proofs/UIntWide.lean` take `get!_eq_getElem`, which
 therefore has one home in this namespace.
 
-The `Array` pair lives here and not in the Merkle-tree shapes module. The
-completeness proof then reaches a generic array fact without importing tree
-vocabulary.
+The `Array` pair lives here so the completeness proof reaches a generic array
+fact without importing the Merkle-tree vocabulary.
 -/
 
 set_option autoImplicit false

--- a/packages/SizzLean/SizzLean/Proofs/Util.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Util.lean
@@ -3,13 +3,13 @@
 
 Generic, dependency-free lemmas shared across the proof layers: the `getElem!` /
 `get!` bridges for `Array` and `ByteArray` push/reads. A leaf module (no
-SizzLean imports), so both the `Spec` proof files and the `Cache/MerkleTree`
-shape modules can import it without layering concerns.
+SizzLean imports), so any proof module can import it whatever layer it sits on.
+`Proofs/BitPack.lean` and `Proofs/UIntWide.lean` take `get!_eq_getElem`, which
+therefore has one home in this namespace.
 
 The `Array` pair lives here and not in the Merkle-tree shapes module. The
 completeness proof then reaches a generic array fact without importing tree
-vocabulary. `Proofs/BitPack.lean` and `Proofs/UIntWide.lean` import
-`get!_eq_getElem` from here, so the statement has one home in this namespace.
+vocabulary.
 -/
 
 set_option autoImplicit false

--- a/packages/SizzLean/SizzLean/Proofs/Util.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Util.lean
@@ -9,8 +9,7 @@ shape modules can import it without layering concerns.
 The `Array` pair lives here and not in the Merkle-tree shapes module. The
 completeness proof then reaches a generic array fact without importing tree
 vocabulary. `Proofs/BitPack.lean` and `Proofs/UIntWide.lean` import
-`get!_eq_getElem` from here. All three declared it once each before, in this one
-namespace, so any change to the statement broke whichever module loaded second.
+`get!_eq_getElem` from here, so the statement has one home in this namespace.
 -/
 
 set_option autoImplicit false


### PR DESCRIPTION
## Summary

`isValidMerkleBranch` rejects a `branch` whose size differs from `depth`. The
walk over `branch` moves into `computeMerkleBranchRoot`, which reads each
sibling with a bounds check. That guard is the only behaviour change here.

## What changed

- `computeMerkleBranchRoot`, the pyspec's `compute_merkle_branch_root`
  (`beacon-chain.md:782-798`). Out-of-range sibling reads raise `IndexError`.
- `isValidMerkleBranch` guards on `branch.size = depth`.
- `routeRight` and `routeRight_eq_div_mod`, in a new
  `EthCLLib/Spec/MerklePath.lean`.
- `isValidMerkleBranch_eq_beq`, `isValidMerkleBranch_iff` and
  `size_map_bytesToRoot`.
- `get!_eq_getElem` moves to `SizzLean/Proofs/Util.lean`. The `BitPack.lean` and
  `UIntWide.lean` copies go.

## Test plan

- [x] `lake build` (full monorepo, on the pinned toolchain) is green.
- [x] Per-package test suites pass:
  - [x] `lake build LeanSha256Tests`
  - [x] `lake build SizzLeanTests`
  - [x] `just ethcl-test`
- [x] If this touches spec types or cache behaviour:
      `just ethcl-pyspec` is green.
- [ ] If this touches a bench-measured hot path: included
      before/after `lake exe ssz_bench` TSV (or relevant rows) in
      the PR description.
- [x] New SSZ shapes / cache cases come with a `native_decide` or
      property test that exercises them.

## Risk / trust footprint

None. This pull request adds and removes no axiom, `sorry`, `partial def`,
`native_decide`, `unsafe` block or `@[extern]` declaration.

## Notes for reviewers

`routeRight` sits in EthCLLib and not in SizzLean. `is_valid_merkle_branch` is a
consensus-spec function, and the SSZ document defines no such convention.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.

