### PR TITLE
feat(sizzlean): perfect combine-trees, and seal the root walkers

### DIFF
--- a/packages/SizzLean/SizzLean.lean
+++ b/packages/SizzLean/SizzLean.lean
@@ -15,6 +15,7 @@ import SizzLean.Cache.Update
 import SizzLean.Proofs.SSZListPush
 import SizzLean.Proofs.SSZListGetElem
 import SizzLean.Proofs.SSZListSet
+import SizzLean.Proofs.Perfect
 
 /-!
 # `SizzLean`: library root

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Merkle.lean
@@ -64,6 +64,31 @@ call sites that just need the digest. -/
 def Node.merkleRoot (H : Type) [Hasher H] (n : Node) : ByteArray :=
   (n.merkleRootWithCache H).1
 
+/-! ### The three arms, stated before the seal
+
+`Node.merkleRoot` and `Node.rootOf` are the same structural recursion
+(`Proofs/Perfect.lean`'s `rootOf_eq_merkleRoot`), and they carry the same
+unfolding hazard. Both are therefore sealed. `Node.merkleRootWithCache` is the
+recursion, and `Node.merkleRoot` returns its first component, so the seal covers
+both. See `Cache/MerkleTree/Zero.lean`'s `Node.rootOf` for the reasoning and for
+why the attribute sits after the equations. -/
+
+/-- `merkleRoot` on a leaf is the leaf's bytes. -/
+theorem Node.merkleRoot_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.merkleRoot H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, honest or not. -/
+theorem Node.merkleRoot_pair_some (H : Type) [Hasher H]
+    (l r : Node) (root : ByteArray) :
+    Node.merkleRoot H (.pair l r (some root)) = root := rfl
+
+/-- An empty slot recurses and combines. -/
+theorem Node.merkleRoot_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.merkleRoot H (.pair l r none)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := rfl
+
+attribute [irreducible] Node.merkleRoot Node.merkleRootWithCache
+
 /-! ### Acceptance: cached path matches the spec oracle
 
 Two small hand-built trees, each compared against

--- a/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
+++ b/packages/SizzLean/SizzLean/Cache/MerkleTree/Zero.lean
@@ -141,12 +141,39 @@ slot at construction time.
 Not a substitute for `merkleRootWithCache`, since it doesn't fill
 cache slots in the input tree. Use when you only need the root
 *value* and the input is expected to be already cached (in which
-case it's O(1)). -/
-partial def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
+case it's O(1)).
+
+**Do not unfold this in a tactic.** Reason about it through
+`rootOf_eq_merkleRoot`, or through the equation lemmas below. See the seal note
+there for what the `@[irreducible]` attribute does and does not stop. -/
+def Node.rootOf (H : Type) [Hasher H] : Node → ByteArray
   | .leaf b               => b
   | .pair _ _ (some r)    => r
   | .pair l r none        =>
       Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r)
+
+/-! ### `Node.rootOf`'s equations, then the seal
+
+The three arms, stated before `Node.rootOf` goes irreducible. Proofs reach the
+recursion through these (or, better, through `rootOf_eq_merkleRoot`) instead of
+unfolding the definition and walking a real tree. -/
+
+/-- A leaf is its own root. -/
+theorem Node.rootOf_leaf (H : Type) [Hasher H] (b : ByteArray) :
+    Node.rootOf H (.leaf b) = b := rfl
+
+/-- A populated cache slot comes back as it stands, with no descent. This arm
+makes `rootOf` O(1) on a committed tree, and it is why `rootOf` cannot notice a
+poisoned cache. -/
+theorem Node.rootOf_pair_some (H : Type) [Hasher H] (l r : Node) (root : ByteArray) :
+    Node.rootOf H (.pair l r (some root)) = root := rfl
+
+/-- An empty cache slot combines the children's roots. -/
+theorem Node.rootOf_pair_none (H : Type) [Hasher H] (l r : Node) :
+    Node.rootOf H (.pair l r none)
+      = Hasher.combine (H := H) (Node.rootOf H l) (Node.rootOf H r) := rfl
+
+attribute [irreducible] Node.rootOf
 
 /-- A `Node` whose root is the all-zero subtree of depth `d`. Used
 by `Node.ofLeaves` to pad the right of an underfilled tree, and by

--- a/packages/SizzLean/SizzLean/Hasher/Class.lean
+++ b/packages/SizzLean/SizzLean/Hasher/Class.lean
@@ -63,4 +63,16 @@ Naming it explicitly resolves the ambiguity. Downstream files
 example {H : Type} [Hasher H] (b₁ b₂ : ByteArray) : ByteArray :=
   Hasher.combine (H := H) (Hasher.hash (H := H) b₁) b₂
 
+/-- The 32-byte-output contract of `Hasher.combine`, as a class the Merkle-proof
+lemmas take instead of threading `∀ a b, (combine a b).size = 32` through every
+statement.
+
+The class introduces no axiom of its own. Discharging the binder pulls in
+whatever the chosen instance rests on, so add an instance resting on an
+`@[extern]` bridge deliberately. `Prop` rather than `Type` keeps the witness
+proof-irrelevant and erased from compiled code. -/
+class CombineWidth32 (H : Type) [Hasher H] : Prop where
+  /-- `combine` returns exactly 32 bytes on any two inputs. -/
+  size : ∀ a b : ByteArray, (Hasher.combine (H := H) a b).size = 32
+
 end SizzLean

--- a/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
+++ b/packages/SizzLean/SizzLean/Hasher/CombineWidth.lean
@@ -1,0 +1,35 @@
+import SizzLean.Hasher.Sha256Spec
+import SizzLean.Hasher.Sha256Equiv
+
+/-!
+# `SizzLean.Hasher.CombineWidth`: the combine-width witnesses
+
+`CombineWidth32` instances for both concrete hashers. The class itself is in
+`Hasher/Class.lean`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Hasher
+
+/-- `Sha256Spec.combine` always returns a 32-byte digest, by
+`LeanSha256.combine_size_eq_32`. No axiom. -/
+theorem sha256Spec_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256Spec) a b).size = 32 :=
+  LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the pure-Lean hasher. -/
+instance : CombineWidth32 Sha256Spec := ⟨sha256Spec_combine_size⟩
+
+/-- `Sha256.combine` always returns a 32-byte digest, by `sha256Combine_eq_spec`
+then `LeanSha256.combine_size_eq_32`. -/
+theorem sha256_combine_size (a b : ByteArray) :
+    (Hasher.combine (H := Sha256) a b).size = 32 := by
+  show (LeanHazmat.Sha256.sha256Combine a b).size = 32
+  rw [sha256Combine_eq_spec]
+  exact LeanSha256.combine_size_eq_32 a b
+
+/-- The `CombineWidth32` witness for the FFI hasher. -/
+instance : CombineWidth32 Sha256 := ⟨sha256_combine_size⟩
+
+end SizzLean.Hasher

--- a/packages/SizzLean/SizzLean/Proofs/Perfect.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Perfect.lean
@@ -1,0 +1,113 @@
+import SizzLean.Cache.MerkleTree.Merkle
+import SizzLean.Hasher.CombineWidth
+
+/-!
+# `SizzLean.Proofs.Perfect`: perfect combine-trees
+
+The tree-shape vocabulary Merkle-proof theorems quantify over. `IsPerfect` says a
+`Node` is a perfect binary combine-tree of a given depth under a hasher. Three
+shape facts follow. `merkleRoot_pair` collapses the cached and uncached readings
+of a pair. `rootOf_eq_merkleRoot` licenses reading any cache observation as the
+honest root. `merkleRoot_size` gives every root in such a tree 32 bytes.
+
+The path vocabulary sits one layer up, in `EthCLLib.Proofs.MerkleOpening`.
+`IsOpenable`, `leafAt` and `siblingPath` all route by a convention that
+`is_valid_merkle_branch` owns, and that check is a consensus-spec function rather
+than an SSZ-document one. SizzLean therefore states shape and width, and the
+framework states openings.
+
+Pure `Node` vocabulary, hasher-generic. The declarations sit in the
+`SizzLean.Cache.MerkleTree` namespace, where `Node` and the cache walkers live,
+while the file sits under `SizzLean/Proofs/`.
+-/
+
+set_option autoImplicit false
+
+namespace SizzLean.Cache.MerkleTree
+
+open SizzLean.Hasher
+
+/-- A `Node` that is a *perfect* binary combine-tree of depth `d` under hasher
+`H`. Leaves at depth `0` carry exactly 32 bytes. Interior nodes at depth `d+1`
+are pairs of depth-`d` perfect subtrees whose cache slot, *if populated*, holds
+the honest `combine` of the children's roots.
+
+The cache-validity side condition (`hc`) lets these theorems reach cached trees.
+For an uncached pair (`c = none`) `hc` is vacuous. For a cached pair it pins the
+stored root to `combine (merkleRoot H l) (merkleRoot H r)`, the value
+`merkleRootWithCache` computes. `Node.merkleRoot` therefore agrees either way
+(`merkleRoot_pair`).
+
+Two shapes fall outside the predicate. A `zeroLeaf`-padded subtree caches
+Sha256-specific zero-hash bytes, so it meets `hc` only for that hasher.
+`Node.mixInLength` pairs a depth-`d` subtree with a depth-0 length leaf. Above
+`d = 0` its two children sit at different depths, so it is not `IsPerfect`. At
+`d = 0` both children are depth-0 leaves and it is, which nothing here depends
+on.
+
+The hasher `H` is a parameter because the invariant refers to
+`Node.merkleRoot H`. -/
+inductive IsPerfect (H : Type) [Hasher H] : Node → Nat → Prop where
+  | leaf (b : ByteArray) (hsz : b.size = 32) : IsPerfect H (.leaf b) 0
+  | pair {l r : Node} {d : Nat} {c : Option ByteArray}
+      (hl : IsPerfect H l d) (hr : IsPerfect H r d)
+      (hc : ∀ root, c = some root →
+        root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+      IsPerfect H (.pair l r c) (d + 1)
+
+/-- The root of a valid perfect pair is the honest `combine` of the children's
+roots, at a populated cache slot and an empty one alike. For `none` this is
+`merkleRootWithCache`'s own recursion. For `some root` the cache-validity witness
+`hc` pins the stored value.
+
+The tree-walking proofs go through this bridge instead of unfolding
+`merkleRootWithCache` on an uncached node. They therefore apply unchanged to the
+cached trees the constructors emit. -/
+theorem merkleRoot_pair (H : Type) [Hasher H] {l r : Node} {c : Option ByteArray}
+    (hc : ∀ root, c = some root →
+      root = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r)) :
+    Node.merkleRoot H (.pair l r c)
+      = Hasher.combine (H := H) (Node.merkleRoot H l) (Node.merkleRoot H r) := by
+  cases c with
+  | none => exact Node.merkleRoot_pair_none H l r
+  | some root =>
+      rw [Node.merkleRoot_pair_some H l r root]
+      exact hc root rfl
+
+/-- `Node.rootOf` agrees with `Node.merkleRoot` on **every** `Node`, with no
+shape or cache-validity hypothesis: the two are the same structural recursion.
+Neither inspects whether a populated cache slot is honest, so this holds for a
+tree carrying poisoned caches too, both read the same poison.
+
+Both walkers are `@[irreducible]`, since unfolding either in a tactic walks a
+real 262144-leaf tree. Every arm therefore enters by its named equation lemma,
+and not by `simp [Node.rootOf]` or `simp [Node.merkleRoot]`. -/
+theorem rootOf_eq_merkleRoot (H : Type) [Hasher H] (n : Node) :
+    Node.rootOf H n = Node.merkleRoot H n := by
+  induction n with
+  | leaf b => rw [Node.rootOf_leaf, Node.merkleRoot_leaf]
+  | pair l r c ihl ihr =>
+      cases c with
+      | some x => rw [Node.rootOf_pair_some, Node.merkleRoot_pair_some]
+      | none =>
+          rw [Node.rootOf_pair_none, Node.merkleRoot_pair_none, ihl, ihr]
+
+/-- Every root in a perfect tree is 32 bytes. Leaves are 32 by `IsPerfect.leaf`.
+Interior nodes are `combine` outputs, 32 by the `CombineWidth32` contract. The
+proof reaches that contract through `merkleRoot_pair`, which covers a cached pair
+and an uncached one alike.
+
+The contract arrives as a `[CombineWidth32 H]` instance, so this theorem
+introduces no axiom of its own. An instantiation costs whatever the supplied
+instance rests on (see `SizzLean/Hasher/Class.lean`). -/
+theorem merkleRoot_size (H : Type) [Hasher H] [CombineWidth32 H] :
+    ∀ {n : Node} {depth : Nat}, IsPerfect H n depth →
+      (Node.merkleRoot H n).size = 32 := by
+  intro n depth hp
+  induction hp with
+  | leaf b hsz => simpa [Node.merkleRoot_leaf] using hsz
+  | @pair l r d c hl hr hc ihl ihr =>
+      rw [merkleRoot_pair H hc]
+      exact CombineWidth32.size _ _
+
+end SizzLean.Cache.MerkleTree


### PR DESCRIPTION
## Summary

Adds `IsPerfect` to SizzLean, with the facts about it that the Merkle-proof
theorems need, and seals the two root walkers against unfolding. No behaviour
change.

Stacked on #71.

## What changed

- `IsPerfect`, with `merkleRoot_pair`, `rootOf_eq_merkleRoot` and
  `merkleRoot_size`, in a new `SizzLean/Proofs/Perfect.lean`.
- `CombineWidth32` in `Hasher/Class.lean`, with instances for `Sha256Spec` and
  `Sha256` in a new `Hasher/CombineWidth.lean`.
- `Node.rootOf` becomes a structural `def`.
- Equation lemmas for `Node.rootOf` and `Node.merkleRoot`, then `@[irreducible]`
  on both.

## Test plan

- [x] `lake build` (full monorepo, on the pinned toolchain) is green.
- [x] Per-package test suites pass:
  - [x] `lake build LeanSha256Tests`
  - [x] `lake build SizzLeanTests`
  - [x] `just ethcl-test`
- [x] If this touches spec types or cache behaviour:
      `just ethcl-pyspec` is green.
- [ ] If this touches a bench-measured hot path: included
      before/after `lake exe ssz_bench` TSV (or relevant rows) in
      the PR description.
- [ ] New SSZ shapes / cache cases come with a `native_decide` or
      property test that exercises them.

## Risk / trust footprint

- Removes one `partial def`: `Node.rootOf` becomes structural.
- Adds `@[irreducible]` to `Node.rootOf` and `Node.merkleRoot`.
- Adds one axiom-carrying instance. `CombineWidth32 Sha256` rests on
  `sha256Combine_eq_spec`. The `Sha256Spec` instance rests on
  `LeanSha256.combine_size_eq_32` and carries no axiom.
- Adds and removes no `sorry`, `native_decide`, `unsafe` block or `@[extern]`
  declaration.

## Notes for reviewers

The `@[irreducible]` pair restricts what a tactic may do with two existing
definitions. No proof in the tree unfolds either one.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.

