### PR TITLE
feat(sizzlean): prove vectorVar and listVar central-theorem arms

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ package stands.
 | Package | What a proof covers here | Where it stands |
 | --- | --- | --- |
 | `EthCLSpecs` | the spec functions the fork bodies declare | 8 characterized, 29 touched, of 585 |
-| `SizzLean` | SSZ properties over the whole `SSZType` universe, gated by a predicate | 3 of 5 properties, over 13 admitted arms; open: any `hashTreeRoot` property, cached tree ≡ uncached `hashTreeRoot` |
+| `SizzLean` | SSZ properties over the whole `SSZType` universe, gated by a predicate | 3 of 5 properties, over 15 admitted arms; open: any `hashTreeRoot` property, cached tree ≡ uncached `hashTreeRoot` |
 | `LeanSha256`, `LeanHazmat*` | nothing to cover: `@[extern]` bindings, and a spec side pinned by the NIST CAVP vectors | 3 named equivalence axioms: `sha256Hash_eq_spec`, `sha256Combine_eq_spec`, `sha256BatchCombine_eq_spec` |
 | `LeanPoseidon` | `permute_eq_permuteRef`, in the standalone `LeanPoseidonProofs` package | outside this run: it pins mathlib of its own |
 | `EthCLLib` | out of scope: elaborators and an effect monad | the replay tests and the pyspec vectors are its claim |

--- a/packages/SizzLean/README.md
+++ b/packages/SizzLean/README.md
@@ -7,9 +7,10 @@
 > Garden Fellowship; not an EF release.** The library passes the upstream
 > consensus-spec test corpus and the three central theorems are
 > landed on the `BasicSupported` cut, which now covers mixed-field
-> containers whose schema max stays under `MAX_LENGTH` (remaining
-> open work toward the universally-quantified `Supported` form is
-> tracked in [`docs/PLAN.md`](docs/PLAN.md) Phase 5). Reviews,
+> containers and variable-element `vector` / `list` whose schema
+> max stays under `MAX_LENGTH` (remaining open work toward the
+> universally-quantified `Supported` form is tracked in
+> [`docs/PLAN.md`](docs/PLAN.md) Phase 5). Reviews,
 > issues, and pull requests are welcome; production-grade stability
 > and a stable release line are not implied.
 
@@ -65,11 +66,10 @@ theorems.
   `uintN 8 / 16 / 32 / 64 / 128 / 256`, `bool`, fixed-size
   `vector` and `list`, `bitvector`, `bitlist`, and `container`
   over any field list (fixed-only, or mixed fixed/variable via
-  the offset-table codec), with two exceptions still open:
-  `vector` / `list` over a variable-size element type, and
-  mixed-field containers whose schema-level
-  `maxByteLengthFields fs` is not strictly below `MAX_LENGTH`
-  (the uint32-offset guard; real `BeaconState` /
+  the offset-table codec), and `vector` / `list` over a
+  variable-size element type, with one exception still open:
+  schemas whose static `maxByteLength` is not strictly below
+  `MAX_LENGTH` (the uint32-offset guard; real `BeaconState` /
   `BeaconBlockBody` shapes sit outside it, see
   [etheorem#61](https://github.com/etheorem/etheorem/issues/61)).
   See [Proof coverage](#proof-coverage) for the per-constructor
@@ -216,8 +216,10 @@ per constructor and with the proof technique for each arm.
 | `.uintN 128` | ✅ ⁵ | ✅ ⁵ | ✅ | `Nat`-digit induction on the `natToLEBytes` / `readNatLE` codec; no `bv_decide` axiom |
 | `.uintN 256` | ✅ ⁵ | ✅ ⁵ | ✅ | same codec proof as `.uintN 128` (e.g. `base_fee_per_gas`) |
 | `.bool` | ✅ | ✅ | ✅ | exhaustive `cases` + `rfl` |
-| `.vector t n` | ✅ ² | ✅ ² | ✅ ² | needs `0 < n` + `BasicSupported t` + `t.isFixedSize = true` |
-| `.list t cap` | ✅ ³ | ✅ ³ | ✅ ³ | needs `BasicSupported t` + `t.isFixedSize = true` + `0 < t.fixedByteSize` |
+| `.vector t n`, fixed-size `t` | ✅ ² | ✅ ² | ✅ ² | needs `0 < n` + `BasicSupported t` + `t.isFixedSize = true` |
+| `.vector t n`, variable-size `t` | ✅ ⁶ | ✅ ⁶ | ✅ | needs `0 < n` + `BasicSupported t` + `t.isFixedSize = false` + `maxByteLength (.vector t n) < MAX_LENGTH`; offset-table codec, `Proofs/CollectionVar.lean` |
+| `.list t cap`, fixed-size `t` | ✅ ³ | ✅ ³ | ✅ ³ | needs `BasicSupported t` + `t.isFixedSize = true` + `0 < t.fixedByteSize` |
+| `.list t cap`, variable-size `t` | ✅ ⁶ | ✅ ⁶ | ✅ | needs `BasicSupported t` + `t.isFixedSize = false` + `maxByteLength (.list t cap) < MAX_LENGTH`; offset-table codec, empty list is the empty buffer |
 | `.bitvector n` | ✅ ⁴ | ✅ ⁴ | ✅ | needs `0 < n`; bit-packing inverse in `Proofs/BitPack.lean` |
 | `.bitlist cap` | ✅ ⁴ | ✅ ⁴ | ✅ | bit-packing inverse + `msbPos` delimiter recovery |
 | `.container fs`, all fields fixed-size | ✅ ² | ✅ ² | ✅ ² | see [per-field type](#container-fs-per-field-type) |
@@ -242,13 +244,11 @@ little-endian codec inverse `readNatLE (natToLEBytes w n) 0 w =
 n mod 256ʷ` by induction on the width (the digit step is
 `Nat.mod_mul`). Unlike the narrow arms they use no `bv_decide`, so
 they add **no axioms** beyond the standard kernel three.
-⁶ Mixed-field containers (`containerVar`, `Proofs/ContainerVar.lean`
-+ `Proofs/Roundtrip.lean`'s `decode_encode_containerVar_aux`) decode
-through the offset table: fixed fields read straight from the
-prefix, variable fields read from `[offset, nextOffset)` slices.
-The one `uint32` codec bridge lemma (offset placeholders round-trip
-through `UInt32`) uses `bv_decide`; every other step is `Nat`/
-`ByteArray` reasoning, so the arm's trust footprint is that one
+⁶ Mixed-field containers (`containerVar`) and variable-element
+collections (`vectorVar` / `listVar`) decode through an offset
+table. The one `uint32` codec bridge lemma (offset placeholders
+round-trip through `UInt32`) uses `bv_decide`; every other step is
+`Nat` / `ByteArray` reasoning, so those arms share that one
 `bv_decide` axiom plus the standard kernel three.
 
 `serialize_injective` is a direct corollary of `decode_encode`
@@ -272,7 +272,7 @@ offset-table walker). Allowed and excluded field types:
 |---|:---:|---|
 | `.uintN 8 / 16 / 32 / 64 / 128 / 256` | ✅ | basic + fixed |
 | `.bool` | ✅ | basic + fixed |
-| `.vector t' n` (with `n > 0`, fixed-size `t'`, `BasicSupported t'`) | ✅ | nested vector, `(.vector t' n).isFixedSize = t'.isFixedSize` |
+| `.vector t' n` (with `n > 0`, `BasicSupported t'`) | ✅ ᵛ* | nested vector; ᵛ* when `t'` is variable-size (`vectorVar`), since `(.vector t' n).isFixedSize = t'.isFixedSize` |
 | `.list t' cap` (with fixed-size `t'`, `BasicSupported t'`, `0 < t'.fixedByteSize`) | ✅ ᵛ | variable-size field, needs `containerVar` |
 | `.container fs'` (with `BasicSupported (.container fs')`, via `containerFixed` / `containerVar`) | ✅ ᵛ* | nested container; ᵛ* when the nested shape itself uses `containerVar` |
 | `.bitvector n` (with `n > 0`) | ✅ | bit-packed + fixed, `(.bitvector n).fixedByteSize = ⌈n/8⌉` |
@@ -288,25 +288,25 @@ allows.
 
 In one line: containers with any field drawn from `{uintN8,
 uintN16, uintN32, uintN64, uintN128, uintN256, bool, vectorFixed,
-listFixed, bitvector, bitlist, container (recursively)}` are
-proved, whether every field is fixed-size or the list mixes fixed-
-and variable-size fields, provided a `containerVar` schema also
-satisfies `maxByteLengthFields fs < MAX_LENGTH`.
+vectorVar, listFixed, listVar, bitvector, bitlist, container
+(recursively)}` are proved, whether every field is fixed-size or
+the list mixes fixed- and variable-size fields, provided a
+`containerVar` / `vectorVar` / `listVar` schema also satisfies
+`maxByteLength s < MAX_LENGTH`.
 
 ### Track in progress
 
 **Phase 5 formal-verification widening:** the three central
 theorems (roundtrip, non-malleability, size bound) are landed on
 the `BasicSupported` cut, which now covers `uintN 8 / 16 / 32 /
-64 / 128 / 256`, `bool`, `vector` and `list` over fixed-size
-elements, `bitvector`, `bitlist`, and `container` over any field
-list (fixed-only, recursively, or mixed fixed/variable via the
-offset-table codec).
-Two gaps remain toward a universal statement over
-`SSZType.Supported`: `vector` / `list` over a variable-size
-element type (`vectorVar` / `listVar`, no proof arm yet), and the
-schema-level `maxByteLengthFields fs < MAX_LENGTH` guard on
-`containerVar` (see [etheorem#61](https://github.com/etheorem/etheorem/issues/61)
+64 / 128 / 256`, `bool`, `vector` and `list` over fixed-size or
+variable-size elements, `bitvector`, `bitlist`, and `container`
+over any field list (fixed-only, recursively, or mixed
+fixed/variable via the offset-table codec).
+One gap remains toward a universal statement over
+`SSZType.Supported`: the schema-level `maxByteLength s < MAX_LENGTH`
+guard on `containerVar` / `vectorVar` / `listVar` (see
+[etheorem#61](https://github.com/etheorem/etheorem/issues/61)
 for the value-level relaxation). The library itself is complete
 for every shape; this track only closes the proof obligation.
 

--- a/packages/SizzLean/README.md
+++ b/packages/SizzLean/README.md
@@ -8,9 +8,9 @@
 > consensus-spec test corpus and the three central theorems are
 > landed on the `BasicSupported` cut, which now covers mixed-field
 > containers and variable-element `vector` / `list` whose schema
-> max stays under `MAX_LENGTH` (remaining open work toward the
-> universally-quantified `Supported` form is tracked in
-> [`docs/PLAN.md`](docs/PLAN.md) Phase 5). Reviews,
+> max stays under `MAX_LENGTH`. The theorem gate remains
+> `BasicSupported`; [`docs/PLAN.md`](docs/PLAN.md) Phase 5 tracks
+> further widening. Reviews,
 > issues, and pull requests are welcome; production-grade stability
 > and a stable release line are not implied.
 
@@ -67,11 +67,12 @@ theorems.
   `vector` and `list`, `bitvector`, `bitlist`, and `container`
   over any field list (fixed-only, or mixed fixed/variable via
   the offset-table codec), and `vector` / `list` over a
-  variable-size element type, with one exception still open:
-  schemas whose static `maxByteLength` is not strictly below
-  `MAX_LENGTH` (the uint32-offset guard; real `BeaconState` /
-  `BeaconBlockBody` shapes sit outside it, see
-  [etheorem#61](https://github.com/etheorem/etheorem/issues/61)).
+  variable-size element type. Variable-offset constructors carry
+  a static `maxByteLength < MAX_LENGTH` guard. Value-level
+  relaxations are tracked for
+  [`containerVar`](https://github.com/etheorem/etheorem/issues/61)
+  and for
+  [`vectorVar` / `listVar`](https://github.com/etheorem/etheorem/issues/77).
   See [Proof coverage](#proof-coverage) for the per-constructor
   table.
 
@@ -256,10 +257,9 @@ round-trip through `UInt32`) uses `bv_decide`; every other step is
 `serialize_injective` is a direct corollary of `decode_encode`
 (via `Except.ok.inj` + `Prod.mk.inj`), so its coverage tracks
 `decode_encode` exactly. It says distinct values produce distinct
-encodings; it does not say the decoder rejects every non-canonical
-byte sequence (offset tables that tile a buffer differently, for
-instance). The `ssz_generic containers/invalid` vectors are the
-current cover for that direction.
+encodings. Decoder canonicity is a separate property. The
+`ssz_generic containers/invalid` vectors currently cover that
+direction.
 
 #### `.container fs`: per-field type
 
@@ -305,12 +305,14 @@ the `BasicSupported` cut, which now covers `uintN 8 / 16 / 32 /
 variable-size elements, `bitvector`, `bitlist`, and `container`
 over any field list (fixed-only, recursively, or mixed
 fixed/variable via the offset-table codec).
-One gap remains toward a universal statement over
-`SSZType.Supported`: the schema-level `maxByteLength s < MAX_LENGTH`
-guard on `containerVar` / `vectorVar` / `listVar` (see
-[etheorem#61](https://github.com/etheorem/etheorem/issues/61)
-for the value-level relaxation). The library itself is complete
-for every shape; this track only closes the proof obligation.
+Every current `BasicSupported` constructor has all three theorem
+arms. `SSZType.Supported` remains broader: it admits zero-width
+schemas that the decoder rejects, and it omits the proof guards
+carried by `BasicSupported`. Further widening includes value-level
+offset guards for
+[`containerVar`](https://github.com/etheorem/etheorem/issues/61)
+and
+[`vectorVar` / `listVar`](https://github.com/etheorem/etheorem/issues/77).
 
 See [`docs/PLAN.md`](docs/PLAN.md) for the staged plan and
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the design
@@ -442,9 +444,8 @@ subpackages stay on declarative TOML.
   `Proofs/Roundtrip.lean`, `Proofs/Injective.lean`, and
   `Proofs/SizeBound.lean` respectively. All three are landed on
   the `SSZType.BasicSupported` cut (defined in
-  `Spec/BasicSupported.lean`); the universally-quantified
-  `Supported` form is open work, see
-  [`docs/PLAN.md`](docs/PLAN.md) Phase 5.
+  `Spec/BasicSupported.lean`). `Supported` remains a broader
+  codec predicate; see [`docs/PLAN.md`](docs/PLAN.md) Phase 5.
 * `Conformance/`: SSZ-library property-test gates (Sha256
   vectors, hasher equivalence, `setAt` randomised tests, cache
   machinery on example containers).

--- a/packages/SizzLean/README.md
+++ b/packages/SizzLean/README.md
@@ -232,8 +232,10 @@ uint32-offset bridge, `decode_encode`'s and
 four `bv_decide` axioms plus the standard kernel axioms
 (`propext`, `Classical.choice`, `Quot.sound`); `encode_size_le_max`
 adds none.
-² Recurses on the element type's `BasicSupported` witness via
-the mutual `decode_encode` ↔ `decode_encode_containerFixed_aux`
+² Recurses on the element or field type's `BasicSupported`
+witness. Vector and list arms pass `fun y => decode_encode h_t y`
+into a parameterised helper. The `containerFixed` arm uses the
+mutual `decode_encode` ↔ `decode_encode_containerFixed_aux`
 block.
 ³ Same recursion shape as `.vector`.
 ⁴ Byte-level bit identities close by kernel `decide` over the
@@ -273,7 +275,7 @@ offset-table walker). Allowed and excluded field types:
 | `.uintN 8 / 16 / 32 / 64 / 128 / 256` | ✅ | basic + fixed |
 | `.bool` | ✅ | basic + fixed |
 | `.vector t' n` (with `n > 0`, `BasicSupported t'`) | ✅ ᵛ* | nested vector; ᵛ* when `t'` is variable-size (`vectorVar`), since `(.vector t' n).isFixedSize = t'.isFixedSize` |
-| `.list t' cap` (with fixed-size `t'`, `BasicSupported t'`, `0 < t'.fixedByteSize`) | ✅ ᵛ | variable-size field, needs `containerVar` |
+| `.list t' cap` (with `BasicSupported t'`) | ✅ ᵛ | variable-size field, needs `containerVar`; `listFixed` when `t'` is fixed-size with `0 < t'.fixedByteSize`, `listVar` when `t'` is variable-size |
 | `.container fs'` (with `BasicSupported (.container fs')`, via `containerFixed` / `containerVar`) | ✅ ᵛ* | nested container; ᵛ* when the nested shape itself uses `containerVar` |
 | `.bitvector n` (with `n > 0`) | ✅ | bit-packed + fixed, `(.bitvector n).fixedByteSize = ⌈n/8⌉` |
 | `.bitlist cap` | ✅ ᵛ | bit-packed, variable-size field, needs `containerVar` |

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -1,26 +1,19 @@
 import SizzLean.Spec.Serialize
 import SizzLean.Spec.Deserialize
 import SizzLean.Spec.MaxByteLength
+import SizzLean.Spec.Constants
 import SizzLean.Proofs.ContainerVar
 
 /-!
-# `SizzLean.Proofs.CollectionVar`: groundwork for variable-element `.vector` / `.list`
+# `SizzLean.Proofs.CollectionVar`: variable-element `.vector` / `.list`
 
-Variable-element collections (`.vector t n` / `.list t cap` with
-`t.isFixedSize = false`) are the remaining composite gap in
-`SSZType.Supported` once mixed-field containers land: the codec
-([`Spec/Serialize.lean`](../Spec/Serialize.lean)'s
-`serializeVarElemsAux`, [`Spec/Deserialize.lean`](../Spec/Deserialize.lean)'s
-non-`isFixedSize` `.vector` / `.list` branches) fully implements the
-offset-table wire format. No `BasicSupported` constructor claims it
-yet, and no theorem closes it. This module holds the codec-level
-groundwork.
-
-The predicates (`vectorVar` / `listVar` on `BasicSupported` /
-`Supported` / `SupportedBounded`) and the roundtrip walkers land in
-a follow-up. That follow-up builds on this file's lemmas and needs
-`containerVar` on `main`. Its `BasicSupported` matchers grow two
-constructors, and that match must already be exhaustive.
+Closes `decode_encode` and `encode_size_le_max` for `.vector t n` /
+`.list t cap` when `t` is `BasicSupported` and variable-size, via
+the offset-table codec (`serializeVarElemsAux` /
+`deserializeVarElems`). The predicates (`vectorVar` / `listVar` on
+`BasicSupported` / `Supported` / `SupportedBounded`) live in
+`Spec/`. This file ships the codec-level lemmas and the
+parameterised walkers the Roundtrip / SizeBound dispatchers call.
 
 Homogeneous collections have one element type `t`, so the proof
 inducts on the element list as `Proofs/FixedElems.lean` does. The
@@ -79,6 +72,15 @@ them):
    `extractFieldOffsets_serializeFieldsAux`: the extractor never
    reads past the offset table, so the buffer's tail can be
    anything.
+5. **Element-list walker** (`deserializeVarElems_collOffsetsOf`):
+   `deserializeVarElems` recovers the encoded list, given the
+   body-region extract invariant. Parameterised by the element
+   roundtrip.
+6. **Top-level arms** (`decode_encode_vectorVar` /
+   `decode_encode_listVar`, `encode_size_le_max_vectorVar` /
+   `encode_size_le_max_listVar`): the dispatcher-facing wrappers.
+   Vectors reject `n = 0`; lists split on the empty-buffer
+   identity, then recover `count` from `off₀ / 4`.
 
 ## Trust
 
@@ -350,5 +352,383 @@ theorem extractCollOffsets_serializeVarElemsAux
       toNat_toUInt32_of_lt varOff (by omega)
     rw [h_toNat]
     rfl
+
+/-! ### Roundtrip-walker helpers -/
+
+/-- **Running-offset lookahead**: the "next offset, or `bufEnd` if
+none remain" that `deserializeVarElems` computes
+(`rest.head?.getD bufEnd`) always lands on the running `varOff`
+itself. If `xs` is non-empty, `collOffsetsOf`'s list starts with
+`varOff` directly. If `xs` is empty, the list is empty and `.getD`
+falls back to `bufEnd`, which the hypothesis pins to `varOff`
+exactly (no body bytes remain). Homogeneous analogue of
+`varOffsetsOf_head_getD`. -/
+theorem collOffsetsOf_head_getD
+    (t : SSZType) (xs : List t.interp) (varOff bufEnd : Nat)
+    (h : bufEnd = varOff + (SSZType.serializeVarElemsAux t xs varOff).2.size) :
+    (collOffsetsOf t xs varOff).head?.getD bufEnd = varOff := by
+  cases xs with
+  | nil =>
+    unfold SSZType.serializeVarElemsAux at h
+    simp only [ByteArray.size_empty, Nat.add_zero] at h
+    unfold collOffsetsOf
+    simpa using h
+  | cons _ _ =>
+    unfold collOffsetsOf
+    rfl
+
+/-- **Element-list walker**: `deserializeVarElems` recovers exactly
+the element list the encoder wrote, given that `b`'s body-region
+slice `[varOff, bufEnd)` matches `serializeVarElemsAux`'s `.2` and
+the offset list is `collOffsetsOf`. Parameterised by the
+element-type roundtrip so `Proofs/Roundtrip.lean` can supply
+`fun y => decode_encode h_t y` without this file joining the
+mutual block. Uses `extract_split` at each cons, same as the
+variable-field branch of `decode_encode_containerVar_aux`. -/
+theorem deserializeVarElems_collOffsetsOf
+    (t : SSZType)
+    (h_decode_encode_t : ∀ y : t.interp,
+      SSZType.deserialize t (SSZType.serialize t y) =
+        .ok (y, (SSZType.serialize t y).size)) :
+    ∀ (xs : List t.interp) (varOff : Nat) (b : ByteArray) (bufEnd : Nat),
+    varOff ≤ bufEnd → bufEnd ≤ b.size →
+    b.extract varOff bufEnd = (SSZType.serializeVarElemsAux t xs varOff).2 →
+    SSZType.deserializeVarElems t (collOffsetsOf t xs varOff) bufEnd b = .ok xs := by
+  intro xs
+  induction xs with
+  | nil =>
+    intro varOff b bufEnd _ _ _
+    unfold collOffsetsOf SSZType.deserializeVarElems
+    rfl
+  | cons x xs ih =>
+    intro varOff b bufEnd h_ve h_vb h_V
+    have h_enc2 :
+        (SSZType.serializeVarElemsAux t (x :: xs) varOff).2 =
+          SSZType.serialize t x ++
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).2 := by
+      simp only [SSZType.serializeVarElemsAux]
+    rw [h_enc2] at h_V
+    have hq : varOff + (SSZType.serialize t x).size ≤ bufEnd := by
+      have hVsize : (b.extract varOff bufEnd).size =
+          (SSZType.serialize t x).size +
+            (SSZType.serializeVarElemsAux t xs
+              (varOff + (SSZType.serialize t x).size)).2.size := by
+        rw [h_V, ByteArray.size_append]
+      rw [ByteArray.size_extract, Nat.min_eq_left h_vb] at hVsize
+      omega
+    have h_split :=
+      extract_split (b := b) (p := varOff) (q := bufEnd)
+        (u := SSZType.serialize t x)
+        (v := (SSZType.serializeVarElemsAux t xs
+          (varOff + (SSZType.serialize t x).size)).2)
+        h_V (by omega) h_vb
+    have h_body : b.extract varOff (varOff + (SSZType.serialize t x).size) =
+        SSZType.serialize t x := h_split.1
+    have h_V' :
+        b.extract (varOff + (SSZType.serialize t x).size) bufEnd =
+          (SSZType.serializeVarElemsAux t xs
+            (varOff + (SSZType.serialize t x).size)).2 := h_split.2
+    have h_bufEnd_eq :
+        bufEnd = (varOff + (SSZType.serialize t x).size) +
+          (SSZType.serializeVarElemsAux t xs
+            (varOff + (SSZType.serialize t x).size)).2.size := by
+      have h_sz := congrArg ByteArray.size h_V'
+      rw [ByteArray.size_extract, Nat.min_eq_left h_vb] at h_sz
+      omega
+    have h_nextOff :
+        (collOffsetsOf t xs (varOff + (SSZType.serialize t x).size)).head?.getD bufEnd =
+          varOff + (SSZType.serialize t x).size :=
+      collOffsetsOf_head_getD t xs (varOff + (SSZType.serialize t x).size) bufEnd
+        h_bufEnd_eq
+    have h_de := h_decode_encode_t x
+    unfold collOffsetsOf
+    unfold SSZType.deserializeVarElems
+    rw [h_nextOff]
+    have h_guard : ¬ (varOff > varOff + (SSZType.serialize t x).size ||
+        varOff + (SSZType.serialize t x).size > bufEnd) := by
+      simp only [Bool.or_eq_true, decide_eq_true_eq, not_or]
+      omega
+    simp only [h_guard]
+    rw [h_body, h_de]
+    rw [ih (varOff + (SSZType.serialize t x).size) b bufEnd (by omega) h_vb h_V']
+    rfl
+
+/-- Size bound for `.vector t n` with `t` variable-size. Unfolds
+the encoder's `offs ++ bodies` and cites
+`size_serializeVarElemsAux_le_maxByteLength_vector`. -/
+theorem encode_size_le_max_vectorVar
+    (t : SSZType) (n : Nat)
+    (h_var : t.isFixedSize = false)
+    (h_max_t : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t)
+    (v : Vector t.interp n) :
+    (SSZType.serialize (.vector t n) v).size ≤
+      SSZType.maxByteLength (.vector t n) := by
+  have h_len : v.toList.length = n := by rw [Vector.length_toList]
+  have h_serialize_eq :
+      SSZType.serialize (.vector t n) v =
+        (SSZType.serializeVarElemsAux t v.toList
+          (v.toList.length * BYTES_PER_LENGTH_OFFSET)).1 ++
+        (SSZType.serializeVarElemsAux t v.toList
+          (v.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
+    unfold SSZType.serialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+  rw [h_serialize_eq, ByteArray.size_append]
+  have h := size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList
+      (v.toList.length * BYTES_PER_LENGTH_OFFSET) h_var h_len h_max_t
+  exact h
+
+/-- Size bound for `.list t cap` with `t` variable-size. Empty
+lists (size 0) are in-bounds; non-empty lists scale the aux bound
+up to the cap via `size_serializeVarElemsAux_le_maxByteLength_list`. -/
+theorem encode_size_le_max_listVar
+    (t : SSZType) (cap : Nat)
+    (h_var : t.isFixedSize = false)
+    (h_max_t : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t)
+    (xs : { ys : Array t.interp // ys.size ≤ cap }) :
+    (SSZType.serialize (.list t cap) xs).size ≤
+      SSZType.maxByteLength (.list t cap) := by
+  have h_len : xs.val.toList.length ≤ cap := by
+    simpa using xs.property
+  have h_serialize_eq :
+      SSZType.serialize (.list t cap) xs =
+        (SSZType.serializeVarElemsAux t xs.val.toList
+          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).1 ++
+        (SSZType.serializeVarElemsAux t xs.val.toList
+          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
+    unfold SSZType.serialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+  rw [h_serialize_eq, ByteArray.size_append]
+  exact size_serializeVarElemsAux_le_maxByteLength_list t cap xs.val.toList
+    (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET) h_var h_len h_max_t
+
+/-- Roundtrip for `.vector t n` with `t` variable-size and `n > 0`.
+Parameterised by the element-type roundtrip and the element-type
+size bound (the latter feeds the uint32-overflow guard, same
+dependence `decode_encode` already has on `encode_size_le_max`
+for `containerVar`). -/
+theorem decode_encode_vectorVar
+    (t : SSZType) (n : Nat) (h_pos : 0 < n)
+    (h_var : t.isFixedSize = false)
+    (h_max_lt : SSZType.maxByteLength (.vector t n) < MAX_LENGTH)
+    (h_decode_encode_t : ∀ y : t.interp,
+      SSZType.deserialize t (SSZType.serialize t y) =
+        .ok (y, (SSZType.serialize t y).size))
+    (h_max_t : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t)
+    (v : Vector t.interp n) :
+    SSZType.deserialize (.vector t n) (SSZType.serialize (.vector t n) v) =
+      .ok (v, (SSZType.serialize (.vector t n) v).size) := by
+  have h_len : v.toList.length = n := by rw [Vector.length_toList]
+  have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
+  let varOff : Nat := n * BYTES_PER_LENGTH_OFFSET
+  have h_varOff : v.toList.length * BYTES_PER_LENGTH_OFFSET = varOff := by
+    rw [h_len]
+  have h_serialize_eq :
+      SSZType.serialize (.vector t n) v =
+        (SSZType.serializeVarElemsAux t v.toList varOff).1 ++
+          (SSZType.serializeVarElemsAux t v.toList varOff).2 := by
+    unfold SSZType.serialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+    rw [h_varOff]
+  have h_offs_size :
+      (SSZType.serializeVarElemsAux t v.toList varOff).1.size = varOff := by
+    rw [size_serializeVarElemsAux_offs, h_len]
+  have h_bsize :
+      (SSZType.serialize (.vector t n) v).size =
+        varOff + (SSZType.serializeVarElemsAux t v.toList varOff).2.size := by
+    rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
+  have h_bound :=
+    size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList varOff
+      h_var h_len h_max_t
+  have hML : MAX_LENGTH = 2 ^ 32 := rfl
+  have h_uint32_bound :
+      varOff + (SSZType.serializeVarElemsAux t v.toList varOff).2.size < 2 ^ 32 := by
+    have h_le :
+        (SSZType.serializeVarElemsAux t v.toList varOff).1.size +
+          (SSZType.serializeVarElemsAux t v.toList varOff).2.size ≤
+          SSZType.maxByteLength (.vector t n) := h_bound
+    rw [h_offs_size] at h_le
+    omega
+  have h_offs :
+      extractCollOffsets (SSZType.serialize (.vector t n) v) n 0 =
+        .ok (collOffsetsOf t v.toList varOff) := by
+    have h_pre :=
+      extractCollOffsets_serializeVarElemsAux t v.toList varOff ByteArray.empty
+        h_uint32_bound (SSZType.serializeVarElemsAux t v.toList varOff).2
+    simpa [ByteArray.empty_append, h_serialize_eq, h_len] using h_pre
+  have h_V :
+      (SSZType.serialize (.vector t n) v).extract varOff
+          (SSZType.serialize (.vector t n) v).size =
+        (SSZType.serializeVarElemsAux t v.toList varOff).2 := by
+    rw [h_bsize, h_serialize_eq]
+    exact ByteArray.extract_append_eq_right h_offs_size.symm (by rw [h_offs_size])
+  have h_elems :=
+    deserializeVarElems_collOffsetsOf t h_decode_encode_t v.toList varOff
+      (SSZType.serialize (.vector t n) v)
+      (SSZType.serialize (.vector t n) v).size
+      (by omega) (by omega) h_V
+  have hn : ¬ n = 0 := Nat.ne_of_gt h_pos
+  have h_ge : ¬ (SSZType.serialize (.vector t n) v).size < n * BYTES_PER_LENGTH_OFFSET := by
+    rw [h_bsize]; omega
+  unfold SSZType.deserialize
+  simp only [hn, if_false]
+  simp only [h_var, if_false, Bool.false_eq_true]
+  simp only [h_ge, if_false]
+  rw [h_offs]
+  dsimp only
+  rw [h_elems]
+  have h_sz_arr : v.toList.toArray.size = n := by
+    rw [List.size_toArray, h_len]
+  simp only [h_sz_arr, dite_true]
+  cases v with
+  | mk arr h =>
+    simp [Array.toArray_toList]
+
+/-- Roundtrip for `.list t cap` with `t` variable-size.
+Empty lists take the decoder's `b.size = 0` branch; non-empty
+lists recover `count` from `off₀ / 4` then reuse the same walker
+as `decode_encode_vectorVar`. -/
+theorem decode_encode_listVar
+    (t : SSZType) (cap : Nat)
+    (h_var : t.isFixedSize = false)
+    (h_max_lt : SSZType.maxByteLength (.list t cap) < MAX_LENGTH)
+    (h_decode_encode_t : ∀ y : t.interp,
+      SSZType.deserialize t (SSZType.serialize t y) =
+        .ok (y, (SSZType.serialize t y).size))
+    (h_max_t : ∀ y : t.interp,
+      (SSZType.serialize t y).size ≤ SSZType.maxByteLength t)
+    (xs : { ys : Array t.interp // ys.size ≤ cap }) :
+    SSZType.deserialize (.list t cap) (SSZType.serialize (.list t cap) xs) =
+      .ok (xs, (SSZType.serialize (.list t cap) xs).size) := by
+  have h_list_len : xs.val.toList.length = xs.val.size := by simp
+  have h_len_le : xs.val.toList.length ≤ cap := by
+    simpa using xs.property
+  have h_serialize_eq :
+      SSZType.serialize (.list t cap) xs =
+        (SSZType.serializeVarElemsAux t xs.val.toList
+          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).1 ++
+        (SSZType.serializeVarElemsAux t xs.val.toList
+          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
+    unfold SSZType.serialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+  by_cases h_empty : xs.val.size = 0
+  · -- Empty list: encoder writes the empty buffer; decoder's
+    -- `b.size = 0` branch recovers `⟨#[], _⟩`.
+    have h_nil : xs.val.toList = [] :=
+      List.eq_nil_of_length_eq_zero (by rw [h_list_len, h_empty])
+    have h_ser_empty : SSZType.serialize (.list t cap) xs = ByteArray.empty := by
+      rw [h_serialize_eq, h_nil]
+      unfold SSZType.serializeVarElemsAux
+      rfl
+    rw [h_ser_empty]
+    unfold SSZType.deserialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+    have h_sz0 : (ByteArray.empty).size = 0 := ByteArray.size_empty
+    simp only [h_sz0, if_true]
+    have h_arr : xs.val = #[] := Array.eq_empty_of_size_eq_zero h_empty
+    have hx : xs = ⟨#[], by simp⟩ := Subtype.ext h_arr
+    rw [hx]
+  · -- Non-empty: first offset is n * 4, count = n, then the walker.
+    have h_pos : 0 < xs.val.size := Nat.pos_of_ne_zero h_empty
+    have h_cons : ∃ x ys, xs.val.toList = x :: ys := by
+      cases hxs : xs.val.toList with
+      | nil =>
+        have : xs.val.toList.length = 0 := by rw [hxs]; rfl
+        rw [h_list_len] at this
+        exact absurd this (Nat.ne_of_gt h_pos)
+      | cons x ys => exact ⟨x, ys, rfl⟩
+    obtain ⟨x, ys, h_cons_eq⟩ := h_cons
+    let varOff : Nat := xs.val.toList.length * BYTES_PER_LENGTH_OFFSET
+    have h_offs_size :
+        (SSZType.serializeVarElemsAux t xs.val.toList varOff).1.size = varOff :=
+      size_serializeVarElemsAux_offs t xs.val.toList varOff
+    have h_bsize :
+        (SSZType.serialize (.list t cap) xs).size =
+          varOff + (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size := by
+      rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
+    have h_bound :=
+      size_serializeVarElemsAux_le_maxByteLength_list t cap xs.val.toList varOff
+        h_var h_len_le h_max_t
+    have hML : MAX_LENGTH = 2 ^ 32 := rfl
+    have h_uint32_bound :
+        varOff + (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size < 2 ^ 32 := by
+      have h_le :
+          (SSZType.serializeVarElemsAux t xs.val.toList varOff).1.size +
+            (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size ≤
+            SSZType.maxByteLength (.list t cap) := h_bound
+      rw [h_offs_size] at h_le
+      omega
+    have h_first :=
+      readUInt32LE_serializeVarElemsAux_cons t x ys varOff
+    have h_cons_enc :
+        SSZType.serializeVarElemsAux t xs.val.toList varOff =
+          SSZType.serializeVarElemsAux t (x :: ys) varOff := by
+      rw [h_cons_eq]
+    have h_read :
+        readUInt32LE (SSZType.serialize (.list t cap) xs) 0 =
+          some (Nat.toUInt32 varOff) := by
+      rw [h_serialize_eq, h_cons_enc]
+      exact h_first
+    have h_toNat : (Nat.toUInt32 varOff).toNat = varOff :=
+      toNat_toUInt32_of_lt varOff (by omega)
+    have h_mod : varOff % BYTES_PER_LENGTH_OFFSET = 0 := by
+      unfold varOff
+      have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
+      rw [hBPLO]
+      exact Nat.mul_mod_left _ _
+    have h_div : varOff / BYTES_PER_LENGTH_OFFSET = xs.val.toList.length := by
+      unfold varOff
+      have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
+      have hpos : 0 < BYTES_PER_LENGTH_OFFSET := by rw [hBPLO]; decide
+      exact Nat.mul_div_cancel _ hpos
+    have h_count_le : ¬ xs.val.toList.length > cap := Nat.not_lt.mpr h_len_le
+    have h_offs :
+        extractCollOffsets (SSZType.serialize (.list t cap) xs)
+            (varOff / BYTES_PER_LENGTH_OFFSET) 0 =
+          .ok (collOffsetsOf t xs.val.toList varOff) := by
+      rw [h_div]
+      have h_pre :=
+        extractCollOffsets_serializeVarElemsAux t xs.val.toList varOff ByteArray.empty
+          h_uint32_bound (SSZType.serializeVarElemsAux t xs.val.toList varOff).2
+      simpa [ByteArray.empty_append, h_serialize_eq] using h_pre
+    have h_V :
+        (SSZType.serialize (.list t cap) xs).extract varOff
+            (SSZType.serialize (.list t cap) xs).size =
+          (SSZType.serializeVarElemsAux t xs.val.toList varOff).2 := by
+      rw [h_bsize, h_serialize_eq]
+      exact ByteArray.extract_append_eq_right h_offs_size.symm (by rw [h_offs_size])
+    have h_elems :=
+      deserializeVarElems_collOffsetsOf t h_decode_encode_t xs.val.toList varOff
+        (SSZType.serialize (.list t cap) xs)
+        (SSZType.serialize (.list t cap) xs).size
+        (by omega) (by omega) h_V
+    have h_sz_pos : ¬ (SSZType.serialize (.list t cap) xs).size = 0 := by
+      rw [h_bsize]
+      have hpos : 0 < varOff := by
+        change 0 < xs.val.toList.length * BYTES_PER_LENGTH_OFFSET
+        have hl : 0 < xs.val.toList.length := by rw [h_list_len]; exact h_pos
+        have hb : 0 < BYTES_PER_LENGTH_OFFSET := by decide
+        exact Nat.mul_pos hl hb
+      omega
+    unfold SSZType.deserialize
+    simp only [h_var, if_false, Bool.false_eq_true]
+    simp only [h_sz_pos, if_false]
+    rw [h_read]
+    dsimp only
+    have h_mod' : ¬ (Nat.toUInt32 varOff).toNat % BYTES_PER_LENGTH_OFFSET ≠ 0 := by
+      rw [h_toNat, h_mod]; intro h; exact h rfl
+    simp only [h_mod', if_false]
+    rw [h_toNat, h_div]
+    simp only [h_count_le, if_false]
+    rw [h_div] at h_offs
+    rw [h_offs]
+    dsimp only
+    rw [h_elems]
+    have h_arr_sz : xs.val.toList.toArray.size ≤ cap := by
+      rw [List.size_toArray, h_list_len]; exact xs.property
+    simp only [h_arr_sz, dite_true]
 
 end SizzLean.Proofs

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -78,7 +78,12 @@ them):
    `deserializeVarElems` recovers the encoded list, given the
    body-region extract invariant. Parameterised by the element
    roundtrip.
-6. **Top-level arms** (`decode_encode_vectorVar` /
+6. **Shared decode step** (`decode_serializeVarElemsAux`): items 2,
+   4 and 5 composed against the encoder's own buffer, yielding the
+   total size, the offset table, and the element list. Both
+   roundtrip arms call it; only the decoder's schema guards differ
+   between them.
+7. **Top-level arms** (`decode_encode_vectorVar` /
    `decode_encode_listVar`, `encode_size_le_max_vectorVar` /
    `encode_size_le_max_listVar`): the dispatcher-facing wrappers.
    Vectors reject `n = 0`; lists split on the empty-buffer
@@ -113,25 +118,6 @@ def collOffsetsOf (t : SSZType) : List t.interp → Nat → List Nat
   | [],      _      => []
   | x :: xs, varOff =>
       varOff :: collOffsetsOf t xs (varOff + (SSZType.serialize t x).size)
-
-/-- `collOffsetsOf` produces one offset per element. -/
-theorem collOffsetsOf_length
-    (t : SSZType) (xs : List t.interp) (varOff : Nat) :
-    (collOffsetsOf t xs varOff).length = xs.length := by
-  induction xs generalizing varOff with
-  | nil => rfl
-  | cons _ xs ih =>
-    unfold collOffsetsOf
-    simp [ih]
-
-/-- The first placeholder a non-empty collection writes is the
-seeded `varOff`. At the encoder's call site that seed is
-`xs.length * BYTES_PER_LENGTH_OFFSET`. The vector roundtrip uses
-this canonical encoder value. The list decoder uses it to recover
-`count = firstOff / 4`. -/
-theorem collOffsetsOf_head_cons
-    (t : SSZType) (x : t.interp) (xs : List t.interp) (varOff : Nat) :
-    (collOffsetsOf t (x :: xs) varOff).head? = some varOff := rfl
 
 /-! ### Encoder accounting and the size walker -/
 
@@ -458,6 +444,57 @@ theorem deserializeVarElems_collOffsetsOf
       (by omega) hEndLeSize hTailBody]
     rfl
 
+/-- **Shared decode step** for both variable-element collections.
+Given the encoder's own output, this recovers the three facts the
+`vectorVar` and `listVar` roundtrips both need before they part
+ways at the decoder's schema guards: the buffer's total size, the
+offset table read back as `collOffsetsOf`, and the element list
+read back by `deserializeVarElems`.
+
+The buffer `b` is passed as its own term (with `h_ser` pinning it
+to `offs ++ bodies`) so each caller can hand in its own
+`SSZType.serialize` application without unfolding it first.
+`h_varOff` fixes the seed to the encoder's canonical
+`xs.length * BYTES_PER_LENGTH_OFFSET`, which is what makes the
+offset table exactly `varOff` bytes wide, so the body region
+starts at `varOff`. `h_bound` is the uint32-overflow guard each
+caller derives from its own `maxByteLength` specialization. -/
+theorem decode_serializeVarElemsAux
+    (t : SSZType)
+    (h_decode_encode_t : ∀ y : t.interp,
+      SSZType.deserialize t (SSZType.serialize t y) =
+        .ok (y, (SSZType.serialize t y).size))
+    (xs : List t.interp) (varOff : Nat) (b : ByteArray)
+    (h_varOff : varOff = xs.length * BYTES_PER_LENGTH_OFFSET)
+    (h_ser : b = (SSZType.serializeVarElemsAux t xs varOff).1 ++
+                 (SSZType.serializeVarElemsAux t xs varOff).2)
+    (h_bound : varOff +
+      (SSZType.serializeVarElemsAux t xs varOff).2.size < 2 ^ 32) :
+    b.size = varOff + (SSZType.serializeVarElemsAux t xs varOff).2.size
+    ∧ extractCollOffsets b xs.length 0 =
+        .ok (collOffsetsOf t xs varOff)
+    ∧ SSZType.deserializeVarElems t (collOffsetsOf t xs varOff) b.size b
+        = .ok xs := by
+  have h_offs_size :
+      (SSZType.serializeVarElemsAux t xs varOff).1.size = varOff := by
+    rw [size_serializeVarElemsAux_offs, h_varOff]
+  have h_bsize :
+      b.size = varOff + (SSZType.serializeVarElemsAux t xs varOff).2.size := by
+    rw [h_ser, ByteArray.size_append, h_offs_size]
+  have h_offs :
+      extractCollOffsets b xs.length 0 = .ok (collOffsetsOf t xs varOff) := by
+    have h_pre :=
+      extractCollOffsets_serializeVarElemsAux t xs varOff ByteArray.empty
+        h_bound (SSZType.serializeVarElemsAux t xs varOff).2
+    simpa [ByteArray.empty_append, h_ser] using h_pre
+  have h_body : b.extract varOff b.size =
+      (SSZType.serializeVarElemsAux t xs varOff).2 := by
+    rw [h_bsize, h_ser]
+    exact ByteArray.extract_append_eq_right h_offs_size.symm (by rw [h_offs_size])
+  exact ⟨h_bsize, h_offs,
+    deserializeVarElems_collOffsetsOf t h_decode_encode_t xs varOff b b.size
+      (by omega) (by omega) h_body⟩
+
 /-- Size bound for `.vector t n` with `t` variable-size. Unfolds
 the encoder's `offs ++ bodies` and cites
 `size_serializeVarElemsAux_le_maxByteLength_vector`. -/
@@ -479,9 +516,8 @@ theorem encode_size_le_max_vectorVar
     simp only [h_var, if_false, Bool.false_eq_true]
     rfl
   rw [h_serialize_eq, ByteArray.size_append]
-  have h := size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList
-      varOff h_var h_len h_max_t
-  exact h
+  exact size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList
+    varOff h_var h_len h_max_t
 
 /-- Size bound for `.list t cap` with `t` variable-size. Empty
 lists (size 0) are in-bounds; non-empty lists scale the aux bound
@@ -541,10 +577,6 @@ theorem decode_encode_vectorVar
   have h_offs_size :
       (SSZType.serializeVarElemsAux t v.toList varOff).1.size = varOff := by
     rw [size_serializeVarElemsAux_offs, h_len]
-  have h_bsize :
-      (SSZType.serialize (.vector t n) v).size =
-        varOff + (SSZType.serializeVarElemsAux t v.toList varOff).2.size := by
-    rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
 
   -- Bound every running offset by the UInt32 range.
   have h_bound :=
@@ -561,25 +593,13 @@ theorem decode_encode_vectorVar
     -- `hMaxLength` unfolds `MAX_LENGTH` so `omega` can join `h_le` with `h_max_lt`.
     omega
 
-  -- Recover the encoder's offsets and body slice.
-  have h_offs :
-      extractCollOffsets (SSZType.serialize (.vector t n) v) n 0 =
-        .ok (collOffsetsOf t v.toList varOff) := by
-    have h_pre :=
-      extractCollOffsets_serializeVarElemsAux t v.toList varOff ByteArray.empty
-        h_uint32_bound (SSZType.serializeVarElemsAux t v.toList varOff).2
-    simpa [ByteArray.empty_append, h_serialize_eq, h_len] using h_pre
-  have hBodyRegion :
-      (SSZType.serialize (.vector t n) v).extract varOff
-          (SSZType.serialize (.vector t n) v).size =
-        (SSZType.serializeVarElemsAux t v.toList varOff).2 := by
-    rw [h_bsize, h_serialize_eq]
-    exact ByteArray.extract_append_eq_right h_offs_size.symm (by rw [h_offs_size])
-  have h_elems :=
-    deserializeVarElems_collOffsetsOf t h_decode_encode_t v.toList varOff
-      (SSZType.serialize (.vector t n) v)
-      (SSZType.serialize (.vector t n) v).size
-      (by omega) (by omega) hBodyRegion
+  -- Recover the total size, the encoder's offsets, and the element list.
+  obtain ⟨h_bsize, h_offs, h_elems⟩ :=
+    decode_serializeVarElemsAux t h_decode_encode_t v.toList varOff
+      (SSZType.serialize (.vector t n) v) h_varOff.symm h_serialize_eq
+      h_uint32_bound
+  -- The vector decoder takes its count from the schema, not from `off₀`.
+  rw [h_len] at h_offs
 
   -- Discharge the decoder's schema and size guards.
   have hn : ¬ n = 0 := Nat.ne_of_gt h_pos
@@ -601,9 +621,10 @@ theorem decode_encode_vectorVar
     simp [Array.toArray_toList]
 
 /-- Roundtrip for `.list t cap` with `t` variable-size.
-Empty lists take the decoder's `b.size = 0` branch; non-empty
-lists recover `count` from `off₀ / 4` then reuse the same walker
-as `decode_encode_vectorVar`. -/
+Empty lists take the decoder's `b.size = 0` branch. Non-empty
+lists recover `count` from `off₀ / 4`, then call the same
+`decode_serializeVarElemsAux` step `decode_encode_vectorVar`
+does. -/
 theorem decode_encode_listVar
     (t : SSZType) (cap : Nat)
     (h_var : t.isFixedSize = false)
@@ -662,10 +683,6 @@ theorem decode_encode_listVar
     have h_offs_size :
         (SSZType.serializeVarElemsAux t xs.val.toList varOff).1.size = varOff :=
       size_serializeVarElemsAux_offs t xs.val.toList varOff
-    have h_bsize :
-        (SSZType.serialize (.list t cap) xs).size =
-          varOff + (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size := by
-      rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
 
     -- Bound every running offset by the UInt32 range.
     have h_bound :=
@@ -707,27 +724,10 @@ theorem decode_encode_listVar
       exact Nat.mul_div_cancel _ hpos
     have h_count_le : ¬ xs.val.toList.length > cap := Nat.not_lt.mpr h_len_le
 
-    -- Recover the encoder's offsets and body slice.
-    have h_offs :
-        extractCollOffsets (SSZType.serialize (.list t cap) xs)
-            (varOff / BYTES_PER_LENGTH_OFFSET) 0 =
-          .ok (collOffsetsOf t xs.val.toList varOff) := by
-      rw [h_div]
-      have h_pre :=
-        extractCollOffsets_serializeVarElemsAux t xs.val.toList varOff ByteArray.empty
-          h_uint32_bound (SSZType.serializeVarElemsAux t xs.val.toList varOff).2
-      simpa [ByteArray.empty_append, h_serialize_eq] using h_pre
-    have hBodyRegion :
-        (SSZType.serialize (.list t cap) xs).extract varOff
-            (SSZType.serialize (.list t cap) xs).size =
-          (SSZType.serializeVarElemsAux t xs.val.toList varOff).2 := by
-      rw [h_bsize, h_serialize_eq]
-      exact ByteArray.extract_append_eq_right h_offs_size.symm (by rw [h_offs_size])
-    have h_elems :=
-      deserializeVarElems_collOffsetsOf t h_decode_encode_t xs.val.toList varOff
-        (SSZType.serialize (.list t cap) xs)
-        (SSZType.serialize (.list t cap) xs).size
-        (by omega) (by omega) hBodyRegion
+    -- Recover the total size, the encoder's offsets, and the element list.
+    obtain ⟨h_bsize, h_offs, h_elems⟩ :=
+      decode_serializeVarElemsAux t h_decode_encode_t xs.val.toList varOff
+        (SSZType.serialize (.list t cap) xs) rfl h_serialize_eq h_uint32_bound
 
     -- Discharge the decoder's size and capacity guards.
     have h_sz_pos : ¬ (SSZType.serialize (.list t cap) xs).size = 0 := by
@@ -748,7 +748,6 @@ theorem decode_encode_listVar
     simp only [h_mod', if_false]
     rw [h_toNat, h_div]
     simp only [h_count_le, if_false]
-    rw [h_div] at h_offs
     rw [h_offs]
     dsimp only
     rw [h_elems]

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -55,7 +55,9 @@ them):
    `(serializeVarElemsAux t xs varOff).1.size = xs.length * 4`.
    The size is independent of `varOff` and of the bodies. The vector
    decoder takes `count = n` from the schema, and the roundtrip proof
-   uses the encoder's canonical first offset `n * 4`.
+   uses the encoder's canonical first offset `n * 4`. The list decoder
+   recovers `count` from `off₀ / 4`, so encoder output yields
+   `count = xs.length`.
 3. **Size walker** (`size_serializeVarElemsAux_le_max`):
    `(serializeVarElemsAux t xs varOff).1.size + .2.size ≤
    xs.length * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`.

--- a/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
+++ b/packages/SizzLean/SizzLean/Proofs/CollectionVar.lean
@@ -403,57 +403,59 @@ theorem deserializeVarElems_collOffsetsOf
     unfold collOffsetsOf SSZType.deserializeVarElems
     rfl
   | cons x xs ih =>
-    intro varOff b bufEnd h_ve h_vb h_V
-    have h_enc2 :
+    intro varOff b bufEnd hVarOffLeEnd hEndLeSize hBodyRegion
+    have hBodySerialize :
         (SSZType.serializeVarElemsAux t (x :: xs) varOff).2 =
           SSZType.serialize t x ++
             (SSZType.serializeVarElemsAux t xs
               (varOff + (SSZType.serialize t x).size)).2 := by
       simp only [SSZType.serializeVarElemsAux]
-    rw [h_enc2] at h_V
-    have hq : varOff + (SSZType.serialize t x).size ≤ bufEnd := by
-      have hVsize : (b.extract varOff bufEnd).size =
+    rw [hBodySerialize] at hBodyRegion
+    have hHeadEndLe : varOff + (SSZType.serialize t x).size ≤ bufEnd := by
+      have hBodySize : (b.extract varOff bufEnd).size =
           (SSZType.serialize t x).size +
             (SSZType.serializeVarElemsAux t xs
               (varOff + (SSZType.serialize t x).size)).2.size := by
-        rw [h_V, ByteArray.size_append]
-      rw [ByteArray.size_extract, Nat.min_eq_left h_vb] at hVsize
+        rw [hBodyRegion, ByteArray.size_append]
+      rw [ByteArray.size_extract, Nat.min_eq_left hEndLeSize] at hBodySize
       omega
-    have h_split :=
+    have hSplit :=
       extract_split (b := b) (p := varOff) (q := bufEnd)
         (u := SSZType.serialize t x)
         (v := (SSZType.serializeVarElemsAux t xs
           (varOff + (SSZType.serialize t x).size)).2)
-        h_V (by omega) h_vb
-    have h_body : b.extract varOff (varOff + (SSZType.serialize t x).size) =
-        SSZType.serialize t x := h_split.1
-    have h_V' :
+        hBodyRegion (by omega) hEndLeSize
+    have hHeadBody : b.extract varOff (varOff + (SSZType.serialize t x).size) =
+        SSZType.serialize t x := hSplit.1
+    have hTailBody :
         b.extract (varOff + (SSZType.serialize t x).size) bufEnd =
           (SSZType.serializeVarElemsAux t xs
-            (varOff + (SSZType.serialize t x).size)).2 := h_split.2
-    have h_bufEnd_eq :
+            (varOff + (SSZType.serialize t x).size)).2 := hSplit.2
+    have hBufEndEq :
         bufEnd = (varOff + (SSZType.serialize t x).size) +
           (SSZType.serializeVarElemsAux t xs
             (varOff + (SSZType.serialize t x).size)).2.size := by
-      have h_sz := congrArg ByteArray.size h_V'
-      rw [ByteArray.size_extract, Nat.min_eq_left h_vb] at h_sz
+      have hSize := congrArg ByteArray.size hTailBody
+      rw [ByteArray.size_extract, Nat.min_eq_left hEndLeSize] at hSize
       omega
-    have h_nextOff :
+    have hNextOff :
         (collOffsetsOf t xs (varOff + (SSZType.serialize t x).size)).head?.getD bufEnd =
           varOff + (SSZType.serialize t x).size :=
       collOffsetsOf_head_getD t xs (varOff + (SSZType.serialize t x).size) bufEnd
-        h_bufEnd_eq
-    have h_de := h_decode_encode_t x
+        hBufEndEq
+    have hElementRoundtrip := h_decode_encode_t x
+
     unfold collOffsetsOf
     unfold SSZType.deserializeVarElems
-    rw [h_nextOff]
-    have h_guard : ¬ (varOff > varOff + (SSZType.serialize t x).size ||
+    rw [hNextOff]
+    have hSliceGuard : ¬ (varOff > varOff + (SSZType.serialize t x).size ||
         varOff + (SSZType.serialize t x).size > bufEnd) := by
       simp only [Bool.or_eq_true, decide_eq_true_eq, not_or]
       omega
-    simp only [h_guard]
-    rw [h_body, h_de]
-    rw [ih (varOff + (SSZType.serialize t x).size) b bufEnd (by omega) h_vb h_V']
+    simp only [hSliceGuard]
+    rw [hHeadBody, hElementRoundtrip]
+    rw [ih (varOff + (SSZType.serialize t x).size) b bufEnd
+      (by omega) hEndLeSize hTailBody]
     rfl
 
 /-- Size bound for `.vector t n` with `t` variable-size. Unfolds
@@ -468,17 +470,17 @@ theorem encode_size_le_max_vectorVar
     (SSZType.serialize (.vector t n) v).size ≤
       SSZType.maxByteLength (.vector t n) := by
   have h_len : v.toList.length = n := by rw [Vector.length_toList]
+  let varOff : Nat := v.toList.length * BYTES_PER_LENGTH_OFFSET
   have h_serialize_eq :
       SSZType.serialize (.vector t n) v =
-        (SSZType.serializeVarElemsAux t v.toList
-          (v.toList.length * BYTES_PER_LENGTH_OFFSET)).1 ++
-        (SSZType.serializeVarElemsAux t v.toList
-          (v.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
+        (SSZType.serializeVarElemsAux t v.toList varOff).1 ++
+          (SSZType.serializeVarElemsAux t v.toList varOff).2 := by
     unfold SSZType.serialize
     simp only [h_var, if_false, Bool.false_eq_true]
+    rfl
   rw [h_serialize_eq, ByteArray.size_append]
   have h := size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList
-      (v.toList.length * BYTES_PER_LENGTH_OFFSET) h_var h_len h_max_t
+      varOff h_var h_len h_max_t
   exact h
 
 /-- Size bound for `.list t cap` with `t` variable-size. Empty
@@ -494,17 +496,17 @@ theorem encode_size_le_max_listVar
       SSZType.maxByteLength (.list t cap) := by
   have h_len : xs.val.toList.length ≤ cap := by
     simpa using xs.property
+  let varOff : Nat := xs.val.toList.length * BYTES_PER_LENGTH_OFFSET
   have h_serialize_eq :
       SSZType.serialize (.list t cap) xs =
-        (SSZType.serializeVarElemsAux t xs.val.toList
-          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).1 ++
-        (SSZType.serializeVarElemsAux t xs.val.toList
-          (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
+        (SSZType.serializeVarElemsAux t xs.val.toList varOff).1 ++
+          (SSZType.serializeVarElemsAux t xs.val.toList varOff).2 := by
     unfold SSZType.serialize
     simp only [h_var, if_false, Bool.false_eq_true]
+    rfl
   rw [h_serialize_eq, ByteArray.size_append]
   exact size_serializeVarElemsAux_le_maxByteLength_list t cap xs.val.toList
-    (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET) h_var h_len h_max_t
+    varOff h_var h_len h_max_t
 
 /-- Roundtrip for `.vector t n` with `t` variable-size and `n > 0`.
 Parameterised by the element-type roundtrip and the element-type
@@ -524,10 +526,11 @@ theorem decode_encode_vectorVar
     SSZType.deserialize (.vector t n) (SSZType.serialize (.vector t n) v) =
       .ok (v, (SSZType.serialize (.vector t n) v).size) := by
   have h_len : v.toList.length = n := by rw [Vector.length_toList]
-  have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
   let varOff : Nat := n * BYTES_PER_LENGTH_OFFSET
   have h_varOff : v.toList.length * BYTES_PER_LENGTH_OFFSET = varOff := by
     rw [h_len]
+
+  -- Pin the encoder output to its offset table and body region.
   have h_serialize_eq :
       SSZType.serialize (.vector t n) v =
         (SSZType.serializeVarElemsAux t v.toList varOff).1 ++
@@ -542,10 +545,12 @@ theorem decode_encode_vectorVar
       (SSZType.serialize (.vector t n) v).size =
         varOff + (SSZType.serializeVarElemsAux t v.toList varOff).2.size := by
     rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
+
+  -- Bound every running offset by the UInt32 range.
   have h_bound :=
     size_serializeVarElemsAux_le_maxByteLength_vector t n v.toList varOff
       h_var h_len h_max_t
-  have hML : MAX_LENGTH = 2 ^ 32 := rfl
+  have hMaxLength : MAX_LENGTH = 2 ^ 32 := rfl
   have h_uint32_bound :
       varOff + (SSZType.serializeVarElemsAux t v.toList varOff).2.size < 2 ^ 32 := by
     have h_le :
@@ -553,7 +558,10 @@ theorem decode_encode_vectorVar
           (SSZType.serializeVarElemsAux t v.toList varOff).2.size ≤
           SSZType.maxByteLength (.vector t n) := h_bound
     rw [h_offs_size] at h_le
+    -- `hMaxLength` unfolds `MAX_LENGTH` so `omega` can join `h_le` with `h_max_lt`.
     omega
+
+  -- Recover the encoder's offsets and body slice.
   have h_offs :
       extractCollOffsets (SSZType.serialize (.vector t n) v) n 0 =
         .ok (collOffsetsOf t v.toList varOff) := by
@@ -561,7 +569,7 @@ theorem decode_encode_vectorVar
       extractCollOffsets_serializeVarElemsAux t v.toList varOff ByteArray.empty
         h_uint32_bound (SSZType.serializeVarElemsAux t v.toList varOff).2
     simpa [ByteArray.empty_append, h_serialize_eq, h_len] using h_pre
-  have h_V :
+  have hBodyRegion :
       (SSZType.serialize (.vector t n) v).extract varOff
           (SSZType.serialize (.vector t n) v).size =
         (SSZType.serializeVarElemsAux t v.toList varOff).2 := by
@@ -571,7 +579,9 @@ theorem decode_encode_vectorVar
     deserializeVarElems_collOffsetsOf t h_decode_encode_t v.toList varOff
       (SSZType.serialize (.vector t n) v)
       (SSZType.serialize (.vector t n) v).size
-      (by omega) (by omega) h_V
+      (by omega) (by omega) hBodyRegion
+
+  -- Discharge the decoder's schema and size guards.
   have hn : ¬ n = 0 := Nat.ne_of_gt h_pos
   have h_ge : ¬ (SSZType.serialize (.vector t n) v).size < n * BYTES_PER_LENGTH_OFFSET := by
     rw [h_bsize]; omega
@@ -585,6 +595,7 @@ theorem decode_encode_vectorVar
   have h_sz_arr : v.toList.toArray.size = n := by
     rw [List.size_toArray, h_len]
   simp only [h_sz_arr, dite_true]
+  -- The decoder rebuilds the vector through `toList.toArray`.
   cases v with
   | mk arr h =>
     simp [Array.toArray_toList]
@@ -616,6 +627,7 @@ theorem decode_encode_listVar
           (xs.val.toList.length * BYTES_PER_LENGTH_OFFSET)).2 := by
     unfold SSZType.serialize
     simp only [h_var, if_false, Bool.false_eq_true]
+
   by_cases h_empty : xs.val.size = 0
   · -- Empty list: encoder writes the empty buffer; decoder's
     -- `b.size = 0` branch recovers `⟨#[], _⟩`.
@@ -634,6 +646,7 @@ theorem decode_encode_listVar
     have hx : xs = ⟨#[], by simp⟩ := Subtype.ext h_arr
     rw [hx]
   · -- Non-empty: first offset is n * 4, count = n, then the walker.
+    -- Expose the first element so the decoder can read `off₀`.
     have h_pos : 0 < xs.val.size := Nat.pos_of_ne_zero h_empty
     have h_cons : ∃ x ys, xs.val.toList = x :: ys := by
       cases hxs : xs.val.toList with
@@ -644,6 +657,8 @@ theorem decode_encode_listVar
       | cons x ys => exact ⟨x, ys, rfl⟩
     obtain ⟨x, ys, h_cons_eq⟩ := h_cons
     let varOff : Nat := xs.val.toList.length * BYTES_PER_LENGTH_OFFSET
+
+    -- Pin the encoder output and its total size.
     have h_offs_size :
         (SSZType.serializeVarElemsAux t xs.val.toList varOff).1.size = varOff :=
       size_serializeVarElemsAux_offs t xs.val.toList varOff
@@ -651,10 +666,12 @@ theorem decode_encode_listVar
         (SSZType.serialize (.list t cap) xs).size =
           varOff + (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size := by
       rw [h_serialize_eq, ByteArray.size_append, h_offs_size]
+
+    -- Bound every running offset by the UInt32 range.
     have h_bound :=
       size_serializeVarElemsAux_le_maxByteLength_list t cap xs.val.toList varOff
         h_var h_len_le h_max_t
-    have hML : MAX_LENGTH = 2 ^ 32 := rfl
+    have hMaxLength : MAX_LENGTH = 2 ^ 32 := rfl
     have h_uint32_bound :
         varOff + (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size < 2 ^ 32 := by
       have h_le :
@@ -662,7 +679,10 @@ theorem decode_encode_listVar
             (SSZType.serializeVarElemsAux t xs.val.toList varOff).2.size ≤
             SSZType.maxByteLength (.list t cap) := h_bound
       rw [h_offs_size] at h_le
+      -- `hMaxLength` unfolds `MAX_LENGTH` so `omega` can join `h_le` with `h_max_lt`.
       omega
+
+    -- Recover the element count from the first encoded offset.
     have h_first :=
       readUInt32LE_serializeVarElemsAux_cons t x ys varOff
     have h_cons_enc :
@@ -678,15 +698,16 @@ theorem decode_encode_listVar
       toNat_toUInt32_of_lt varOff (by omega)
     have h_mod : varOff % BYTES_PER_LENGTH_OFFSET = 0 := by
       unfold varOff
-      have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
-      rw [hBPLO]
+      rw [show BYTES_PER_LENGTH_OFFSET = 4 from rfl]
       exact Nat.mul_mod_left _ _
     have h_div : varOff / BYTES_PER_LENGTH_OFFSET = xs.val.toList.length := by
       unfold varOff
-      have hBPLO : BYTES_PER_LENGTH_OFFSET = 4 := rfl
-      have hpos : 0 < BYTES_PER_LENGTH_OFFSET := by rw [hBPLO]; decide
+      have hOffsetWidth : BYTES_PER_LENGTH_OFFSET = 4 := rfl
+      have hpos : 0 < BYTES_PER_LENGTH_OFFSET := by rw [hOffsetWidth]; decide
       exact Nat.mul_div_cancel _ hpos
     have h_count_le : ¬ xs.val.toList.length > cap := Nat.not_lt.mpr h_len_le
+
+    -- Recover the encoder's offsets and body slice.
     have h_offs :
         extractCollOffsets (SSZType.serialize (.list t cap) xs)
             (varOff / BYTES_PER_LENGTH_OFFSET) 0 =
@@ -696,7 +717,7 @@ theorem decode_encode_listVar
         extractCollOffsets_serializeVarElemsAux t xs.val.toList varOff ByteArray.empty
           h_uint32_bound (SSZType.serializeVarElemsAux t xs.val.toList varOff).2
       simpa [ByteArray.empty_append, h_serialize_eq] using h_pre
-    have h_V :
+    have hBodyRegion :
         (SSZType.serialize (.list t cap) xs).extract varOff
             (SSZType.serialize (.list t cap) xs).size =
           (SSZType.serializeVarElemsAux t xs.val.toList varOff).2 := by
@@ -706,7 +727,9 @@ theorem decode_encode_listVar
       deserializeVarElems_collOffsetsOf t h_decode_encode_t xs.val.toList varOff
         (SSZType.serialize (.list t cap) xs)
         (SSZType.serialize (.list t cap) xs).size
-        (by omega) (by omega) h_V
+        (by omega) (by omega) hBodyRegion
+
+    -- Discharge the decoder's size and capacity guards.
     have h_sz_pos : ¬ (SSZType.serialize (.list t cap) xs).size = 0 := by
       rw [h_bsize]
       have hpos : 0 < varOff := by

--- a/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
@@ -48,12 +48,12 @@ recursive calls are written.
 
 ## The three-way mutual block
 
-For composite arms (`vectorFixed`, `listFixed`), `decode_encode`
-hands the per-arm helper a closure
+For composite arms (`vectorFixed`, `listFixed`, `vectorVar`,
+`listVar`), `decode_encode` hands the per-arm helper a closure
 `fun y => decode_encode h_t y`. The checker accepts this because
 `h_t` is the case-split's sub-witness, a *strict subterm* of the
-outer `h_sup`, extracted by the `BasicSupported.vectorFixed`
-pattern, so each recursive call descends.
+outer `h_sup`, extracted by the matching `BasicSupported`
+constructor, so each recursive call descends.
 
 For the `containerFixed` and `containerVar` arms, the helper would
 need `∀ t ∈ fs, decode_encode_t`. A closure abstracting `t`

--- a/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
+++ b/packages/SizzLean/SizzLean/Proofs/Roundtrip.lean
@@ -9,6 +9,7 @@ import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
 import SizzLean.Proofs.ContainerFixed
 import SizzLean.Proofs.ContainerVar
+import SizzLean.Proofs.CollectionVar
 import SizzLean.Proofs.SizeBound
 import SizzLean.Proofs.FixedElems
 import SizzLean.Proofs.BitPack
@@ -26,6 +27,7 @@ theorem. Per-arm proofs live in sibling modules:
 | `.bool` | `Proofs/Bool.lean` |
 | `.vectorFixed t n` | `Proofs/VectorFixed.lean` |
 | `.listFixed t cap` | `Proofs/ListFixed.lean` |
+| `.vectorVar t n` / `.listVar t cap` | `Proofs/CollectionVar.lean` |
 | `.bitvector n` / `.bitlist cap` | `Proofs/BitPack.lean` |
 | `.containerFixed fs` (helpers) | `Proofs/ContainerFixed.lean` |
 | `.containerVar fs` (groundwork) | `Proofs/ContainerVar.lean` |
@@ -87,7 +89,9 @@ The `containerVar` arm imports `Proofs/SizeBound.lean` and calls
 per-field size bound. That bound, plus the schema-level
 `maxByteLengthFields fs < MAX_LENGTH` guard on
 `BasicSupported.containerVar`, is how the offsets are shown not
-to overflow `uint32`. The dependence is one-way
+to overflow `uint32`. The `vectorVar` / `listVar` arms make the
+same call at element granularity (`fun y => encode_size_le_max h_t y`).
+The dependence is one-way
 (`decode_encode` → `encode_size_le_max`) and costs no axioms: the
 size theorem's footprint is only `propext` and `Quot.sound`.
 -/
@@ -132,9 +136,17 @@ theorem decode_encode : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .vectorFixed (t := t) (n := n) h_pos h_t h_t_fixed, v =>
       decode_encode_vectorFixed t n h_pos h_t h_t_fixed
         (fun y => decode_encode h_t y) v
+  | _, .vectorVar (t := t) (n := n) h_pos h_t h_var h_max_lt, v =>
+      decode_encode_vectorVar t n h_pos h_var h_max_lt
+        (fun y => decode_encode h_t y)
+        (fun y => encode_size_le_max h_t y) v
   | _, .listFixed (t := t) (cap := cap) h_t h_t_fixed h_sz_pos, xs =>
       decode_encode_listFixed t cap h_t h_t_fixed h_sz_pos
         (fun y => decode_encode h_t y) xs
+  | _, .listVar (t := t) (cap := cap) h_t h_var h_max_lt, xs =>
+      decode_encode_listVar t cap h_var h_max_lt
+        (fun y => decode_encode h_t y)
+        (fun y => encode_size_le_max h_t y) xs
   | _, .bitvector (n := n) h_pos, bv => decode_encode_bitvector n h_pos bv
   | _, .bitlist (cap := cap), xs => decode_encode_bitlist cap xs
   | _, .containerFixed (fs := fs) h_fs, vs => by

--- a/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SerializeSize.lean
@@ -135,8 +135,14 @@ theorem size_serialize_eq_fixedByteSize :
     -- Reduce `(.vector t n).fixedByteSize` to `t.fixedByteSize * n`, then mul_comm.
     simp only [SSZType.fixedByteSize]
     rw [Nat.mul_comm]
+  | vectorVar _ _ h_var _ =>
+    -- `(.vector t n).isFixedSize = t.isFixedSize = false`; absurd.
+    simp [SSZType.isFixedSize, h_var] at h_fixed
   | listFixed _ _ =>
     -- `(.list t cap).isFixedSize = false`; `h_fixed : false = true` is absurd.
+    simp [SSZType.isFixedSize] at h_fixed
+  | listVar _ _ _ =>
+    -- `(.list t cap).isFixedSize = false`; absurd like `listFixed`.
     simp [SSZType.isFixedSize] at h_fixed
   | bitvector _h_pos =>
     rename_i n

--- a/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
+++ b/packages/SizzLean/SizzLean/Proofs/SizeBound.lean
@@ -10,6 +10,7 @@ import SizzLean.Proofs.VectorFixed
 import SizzLean.Proofs.ListFixed
 import SizzLean.Proofs.ContainerFixed
 import SizzLean.Proofs.ContainerVar
+import SizzLean.Proofs.CollectionVar
 import SizzLean.Proofs.BitPack
 
 /-!
@@ -55,8 +56,14 @@ theorem encode_size_le_max : ∀ {s : SSZType}, SSZType.BasicSupported s →
   | _, .vectorFixed (t := t) (n := n) h_pos h_t h_t_fixed, v =>
       encode_size_le_max_vectorFixed t n h_pos h_t h_t_fixed
         (fun y => encode_size_le_max h_t y) v
+  | _, .vectorVar (t := t) (n := n) _h_pos h_t h_var _h_max_lt, v =>
+      encode_size_le_max_vectorVar t n h_var
+        (fun y => encode_size_le_max h_t y) v
   | _, .listFixed (t := t) (cap := cap) h_t h_t_fixed _h_sz_pos, xs =>
       encode_size_le_max_listFixed t cap h_t h_t_fixed
+        (fun y => encode_size_le_max h_t y) xs
+  | _, .listVar (t := t) (cap := cap) h_t h_var _h_max_lt, xs =>
+      encode_size_le_max_listVar t cap h_var
         (fun y => encode_size_le_max h_t y) xs
   | _, .bitvector (n := n) _h_pos, bv => encode_size_le_max_bitvector n bv
   | _, .bitlist (cap := cap), xs => encode_size_le_max_bitlist cap xs

--- a/packages/SizzLean/SizzLean/Repr/Class.lean
+++ b/packages/SizzLean/SizzLean/Repr/Class.lean
@@ -42,8 +42,11 @@ The library's `decode_encode` proof currently covers the
 * `.uintN 8 / 16 / 32 / 64` and `.uintN 128 / 256`, `.bool`:
   basic primitives (the wide integers close by the `Nat`-digit
   codec proof in `Proofs/UIntWide.lean`).
-* `.vector t n` / `.list t cap`: composites over fixed-size
-  element types (`BasicSupported t` with `t.isFixedSize = true`).
+* `.vector t n` / `.list t cap`: composites over a
+  `BasicSupported` element type, either fixed-size (`vectorFixed` /
+  `listFixed`) or variable-size via the offset-table codec
+  (`vectorVar` / `listVar`, with `t.isFixedSize = false` and
+  `maxByteLength s < MAX_LENGTH`; `vectorVar` also carries `0 < n`).
 * `.bitvector n` (`0 < n`) / `.bitlist cap`: bit-packed shapes,
   closed by the bit-packing inverse in `Proofs/BitPack.lean`.
 * `.container fs`: any field list whose fields are themselves
@@ -58,11 +61,11 @@ The library's `decode_encode` proof currently covers the
 
 The user-surface corollary inherits that gate: a user type whose
 shape sits inside `BasicSupported` enjoys verified roundtrip; a
-user type whose shape is outside it (variable-element `vector` /
-`list`, or a mixed-field container whose schema max exceeds
-`MAX_LENGTH`) enjoys total `serialize` / `deserialize` (the spec
-functions are total) but no verified roundtrip. The gate is honest
-about scope and grows automatically as the proof set widens.
+user type whose shape is outside it (a mixed-field container or
+variable-element collection whose schema max exceeds `MAX_LENGTH`)
+enjoys total `serialize` / `deserialize` (the spec functions are
+total) but no verified roundtrip. The gate is honest about scope
+and grows automatically as the proof set widens.
 
 ## Lean idioms used here (annotated on first appearance)
 

--- a/packages/SizzLean/SizzLean/Repr/Class.lean
+++ b/packages/SizzLean/SizzLean/Repr/Class.lean
@@ -54,10 +54,6 @@ The library's `decode_encode` proof currently covers the
   mixed fixed/variable via the offset-table codec (`containerVar`,
   with `allFixedSize fs = false` and
   `maxByteLengthFields fs < MAX_LENGTH`).
-* `.container [.bool, .bool]`: concrete two-`Bool` container,
-  exposed as a `def`-level alias of `containerFixed (.cons .bool
-  rfl (.cons .bool rfl .nil))` so the hand-written `Pair` example
-  can name the witness directly.
 
 The user-surface corollary inherits that gate: a user type whose
 shape sits inside `BasicSupported` enjoys verified roundtrip; a

--- a/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
+++ b/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
@@ -1,7 +1,7 @@
 import SizzLean.Spec.Type
 import SizzLean.Spec.Serialize  -- for isFixedSize / allFixedSize
 import SizzLean.Spec.Supported  -- for the subset theorem below
-import SizzLean.Spec.MaxByteLength  -- for the containerVar overflow guard
+import SizzLean.Spec.MaxByteLength  -- for the overflow guard on containerVar / vectorVar / listVar
 import SizzLean.Spec.Constants  -- for MAX_LENGTH
 
 /-!
@@ -32,11 +32,13 @@ Proofs/ reaches over to discharge the theorems).
   `Nat`-digit induction on the `natToLEBytes` / `readNatLE` codec,
   with no `bv_decide` axiom).
 * **Bool**: `.bool` (closed by `cases`, in `Proofs/Bool.lean`).
-* **Composites**: `.vector t n` / `.list t cap` /
-  `.container fs` over fixed-size element / field types
-  (closed in `Proofs/{VectorFixed,ListFixed,ContainerFixed}.lean`
-  via mutual induction with the shared prereq
-  `Proofs/SerializeSize.lean`).
+* **Composites**: `.vector t n` / `.list t cap` over
+  fixed-size element types (closed in
+  `Proofs/{VectorFixed,ListFixed}.lean`) and over variable-size
+  element types (closed in `Proofs/CollectionVar.lean` via the
+  offset-table codec); `.container fs` over fixed-size field
+  types (closed in `Proofs/ContainerFixed.lean` via mutual
+  induction with the shared prereq `Proofs/SerializeSize.lean`).
 * **Bit shapes**: `.bitvector n` (with `0 < n`) and
   `.bitlist cap` (closed in `Proofs/BitPack.lean` via the
   bit-packing inverse `packBitsLE_unpackBitsLEAux_inverse` plus
@@ -74,15 +76,29 @@ whose static max exceeds `MAX_LENGTH` (real `BeaconState` /
 `BeaconBlockBody` shapes among them) stay outside `BasicSupported`;
 etheorem#61 tracks the value-level relaxation.
 
-## Why `0 < n` on `vectorFixed` / `bitvector`
+## Why `vectorVar` / `listVar` carry `maxByteLength s < MAX_LENGTH`
 
-The spec rejects `n = 0` at *decode* time for both shapes
+Same uint32-overflow guard as `containerVar`. Variable-element
+collections write a running offset per element, seeded at
+`n * BYTES_PER_LENGTH_OFFSET` (vectors) or recovered from
+`off₀ / 4` (lists). Every offset is bounded by the total encoded
+size, which `Proofs/CollectionVar.lean`'s size walker bounds by
+`maxByteLength s`, so bounding *that* by `MAX_LENGTH = 2 ^ 32`
+keeps every offset's `UInt32` round-trip exact. Schemas whose
+static max exceeds `MAX_LENGTH` (large-cap lists of variable
+elements among them) stay outside `BasicSupported`; etheorem#61
+tracks the value-level relaxation.
+
+## Why `0 < n` on `vectorFixed` / `vectorVar` / `bitvector`
+
+The spec rejects `n = 0` at *decode* time for these shapes
 (`ssz_generic/basic_vector/invalid/vec_*_0` and
 `ssz_generic/bitvector/invalid/bitvec_0` test cases), so the
 universal roundtrip would fail in those constructors. The
 precondition is carried at the `BasicSupported` layer rather than
 tightening `Supported` itself, which would be a more invasive
-spec adjustment.
+spec adjustment. `listVar` has no positivity precondition: the
+empty list is the empty buffer.
 
 -/
 
@@ -125,6 +141,15 @@ inductive SSZType.BasicSupported : SSZType → Prop
   | vectorFixed : ∀ {t : SSZType} {n : Nat},
                   0 < n → SSZType.BasicSupported t → t.isFixedSize = true →
                   SSZType.BasicSupported (.vector t n)
+  /-- Fixed-length vector with variable-size element type and
+  non-empty length. Decoded via the offset-table path
+  (`Proofs/CollectionVar.lean`). The `n > 0` precondition mirrors
+  the spec's zero-length rejection; `maxByteLength (.vector t n) <
+  MAX_LENGTH` is the uint32-overflow guard, same as `containerVar`. -/
+  | vectorVar : ∀ {t : SSZType} {n : Nat},
+                0 < n → SSZType.BasicSupported t → t.isFixedSize = false →
+                SSZType.maxByteLength (.vector t n) < MAX_LENGTH →
+                SSZType.BasicSupported (.vector t n)
   /-- Variable-length list (up to `cap`) with fixed-size element
   type and positive element size. The `0 < t.fixedByteSize`
   precondition rules out the `.container []`-element pathology
@@ -134,6 +159,16 @@ inductive SSZType.BasicSupported : SSZType → Prop
                 SSZType.BasicSupported t → t.isFixedSize = true →
                 0 < t.fixedByteSize →
                 SSZType.BasicSupported (.list t cap)
+  /-- Variable-length list (up to `cap`) with variable-size element
+  type. Decoded via the offset-table path; the empty list is the
+  empty buffer. No `0 < t.fixedByteSize` (that pathology is
+  specific to the fixed-element list decoder). The
+  `maxByteLength (.list t cap) < MAX_LENGTH` precondition is the
+  uint32-overflow guard. -/
+  | listVar : ∀ {t : SSZType} {cap : Nat},
+              SSZType.BasicSupported t → t.isFixedSize = false →
+              SSZType.maxByteLength (.list t cap) < MAX_LENGTH →
+              SSZType.BasicSupported (.list t cap)
   /-- Bit-packed fixed-width vector. The `n > 0` precondition
   mirrors the spec's zero-length rejection, same as `vectorFixed`.
   Roundtrip closes in `Proofs/BitPack.lean`. -/
@@ -193,8 +228,10 @@ The module docstring's claim that `BasicSupported` is a subset of
 turns the claim into a build-enforced invariant: each
 `BasicSupported` constructor maps to its `Supported` counterpart,
 dropping the proof-only preconditions (`0 < n` on `vectorFixed` /
-`bitvector`, `0 < t.fixedByteSize` on `listFixed`) that
-`BasicSupported` carries and `Supported` does not. -/
+`vectorVar` / `bitvector`, `0 < t.fixedByteSize` on `listFixed`,
+`maxByteLength s < MAX_LENGTH` on `vectorVar` / `listVar` /
+`containerVar`) that `BasicSupported` carries and `Supported` does
+not. -/
 
 mutual
 
@@ -214,8 +251,12 @@ theorem SSZType.supported_of_basicSupported : ∀ {s : SSZType},
   | _, .bool => .bool
   | _, .vectorFixed _h_pos h_t h_t_fixed =>
       .vectorFixed (SSZType.supported_of_basicSupported h_t) h_t_fixed
+  | _, .vectorVar _h_pos h_t h_var _h_max =>
+      .vectorVar (SSZType.supported_of_basicSupported h_t) h_var
   | _, .listFixed h_t h_t_fixed _h_sz_pos =>
       .listFixed (SSZType.supported_of_basicSupported h_t) h_t_fixed
+  | _, .listVar h_t h_var _h_max =>
+      .listVar (SSZType.supported_of_basicSupported h_t) h_var
   | _, .bitvector _h_pos => .bitvector
   | _, .bitlist => .bitlist
   | _, .containerFixed h_fs =>

--- a/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
+++ b/packages/SizzLean/SizzLean/Spec/BasicSupported.lean
@@ -86,7 +86,7 @@ size, which `Proofs/CollectionVar.lean`'s size walker bounds by
 `maxByteLength s`, so bounding *that* by `MAX_LENGTH = 2 ^ 32`
 keeps every offset's `UInt32` round-trip exact. Schemas whose
 static max exceeds `MAX_LENGTH` (large-cap lists of variable
-elements among them) stay outside `BasicSupported`; etheorem#61
+elements among them) stay outside `BasicSupported`; etheorem#77
 tracks the value-level relaxation.
 
 ## Why `0 < n` on `vectorFixed` / `vectorVar` / `bitvector`
@@ -95,10 +95,9 @@ The spec rejects `n = 0` at *decode* time for these shapes
 (`ssz_generic/basic_vector/invalid/vec_*_0` and
 `ssz_generic/bitvector/invalid/bitvec_0` test cases), so the
 universal roundtrip would fail in those constructors. The
-precondition is carried at the `BasicSupported` layer rather than
-tightening `Supported` itself, which would be a more invasive
-spec adjustment. `listVar` has no positivity precondition: the
-empty list is the empty buffer.
+`BasicSupported` layer carries the precondition. `Supported`
+remains the structural codec predicate. `listVar` has no
+positivity precondition: the empty list is the empty buffer.
 
 -/
 

--- a/packages/SizzLean/SizzLean/Spec/Supported.lean
+++ b/packages/SizzLean/SizzLean/Spec/Supported.lean
@@ -76,17 +76,30 @@ inductive SSZType.Supported : SSZType → Prop
   | bool           : SSZType.Supported .bool
   | bitvector      : ∀ {n : Nat}, SSZType.Supported (.bitvector n)
   | bitlist        : ∀ {cap : Nat}, SSZType.Supported (.bitlist cap)
-  /-- `vector` decode handles only fixed-size element types; the
-  variable-size offset-table read is not implemented. The
-  `isFixedSize = true` witness mirrors `listFixed`. -/
+  /-- `vector` decode of a fixed-size element type. The
+  `isFixedSize = true` witness routes encode / decode onto
+  `serializeFixedElems` / `deserializeFixedElems`. -/
   | vectorFixed    : ∀ {t : SSZType} {n : Nat},
                      SSZType.Supported t → t.isFixedSize = true →
                      SSZType.Supported (.vector t n)
-  /-- `list` decode is implemented for fixed-size element types.
-  The `isFixedSize = true` witness on `t` is what makes the
+  /-- `vector` decode of a variable-size element type, via the
+  offset-table path (`serializeVarElemsAux` /
+  `deserializeVarElems`). The `isFixedSize = false` witness
+  routes encode / decode onto that path. -/
+  | vectorVar      : ∀ {t : SSZType} {n : Nat},
+                     SSZType.Supported t → t.isFixedSize = false →
+                     SSZType.Supported (.vector t n)
+  /-- `list` decode of a fixed-size element type. The
+  `isFixedSize = true` witness on `t` is what makes the
   Roundtrip proof discharge for this arm. -/
   | listFixed      : ∀ {t : SSZType} {cap : Nat},
                      SSZType.Supported t → t.isFixedSize = true →
+                     SSZType.Supported (.list t cap)
+  /-- `list` decode of a variable-size element type, via the
+  offset-table path. Empty lists are the empty buffer; non-empty
+  lists recover `count` from `off₀ / 4`. -/
+  | listVar        : ∀ {t : SSZType} {cap : Nat},
+                     SSZType.Supported t → t.isFixedSize = false →
                      SSZType.Supported (.list t cap)
   /-- `container` decode is implemented for all-fixed-size
   field lists. -/
@@ -151,8 +164,20 @@ inductive SSZType.SupportedBounded : SSZType → Prop
   | vectorFixed    : ∀ {t : SSZType} {n : Nat},
                      SSZType.SupportedBounded t → t.isFixedSize = true →
                      SSZType.SupportedBounded (.vector t n)
+  /-- Mirrors `Supported.vectorVar`: a vector of bounded
+  variable-size elements is itself bounded (the static max is
+  `n * (4 + maxByteLength t)`). -/
+  | vectorVar      : ∀ {t : SSZType} {n : Nat},
+                     SSZType.SupportedBounded t → t.isFixedSize = false →
+                     SSZType.SupportedBounded (.vector t n)
   | listFixed      : ∀ {t : SSZType} {cap : Nat},
                      SSZType.SupportedBounded t → t.isFixedSize = true →
+                     SSZType.SupportedBounded (.list t cap)
+  /-- Mirrors `Supported.listVar`: a capped list of bounded
+  variable-size elements is itself bounded (the static max is
+  `cap * (4 + maxByteLength t)`). -/
+  | listVar        : ∀ {t : SSZType} {cap : Nat},
+                     SSZType.SupportedBounded t → t.isFixedSize = false →
                      SSZType.SupportedBounded (.list t cap)
   | containerFixed : ∀ {fs : List SSZType},
                      SSZType.SupportedBoundedFieldsFixed fs →

--- a/packages/SizzLean/SizzLean/Spec/Supported.lean
+++ b/packages/SizzLean/SizzLean/Spec/Supported.lean
@@ -166,7 +166,7 @@ inductive SSZType.SupportedBounded : SSZType → Prop
                      SSZType.SupportedBounded (.vector t n)
   /-- Mirrors `Supported.vectorVar`: a vector of bounded
   variable-size elements is itself bounded (the static max is
-  `n * (4 + maxByteLength t)`). -/
+  `n * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`). -/
   | vectorVar      : ∀ {t : SSZType} {n : Nat},
                      SSZType.SupportedBounded t → t.isFixedSize = false →
                      SSZType.SupportedBounded (.vector t n)
@@ -175,7 +175,7 @@ inductive SSZType.SupportedBounded : SSZType → Prop
                      SSZType.SupportedBounded (.list t cap)
   /-- Mirrors `Supported.listVar`: a capped list of bounded
   variable-size elements is itself bounded (the static max is
-  `cap * (4 + maxByteLength t)`). -/
+  `cap * (BYTES_PER_LENGTH_OFFSET + maxByteLength t)`). -/
   | listVar        : ∀ {t : SSZType} {cap : Nat},
                      SSZType.SupportedBounded t → t.isFixedSize = false →
                      SSZType.SupportedBounded (.list t cap)

--- a/packages/SizzLean/SizzLeanTests/ReprExamples.lean
+++ b/packages/SizzLean/SizzLeanTests/ReprExamples.lean
@@ -313,4 +313,58 @@ example :
                     (.cons (.listFixed .uintN32 rfl (by decide)) .nil))
                   (by decide) (by decide)) emptyListContainer
 
+/-! ### Variable-element collection arm examples (`vectorVar` / `listVar`)
+
+`BasicSupported` also covers `.vector t n` / `.list t cap` when
+`t` is variable-size, decoded through the offset-table path
+(`Proofs/CollectionVar.lean`). The witness for `vectorVar` is
+`0 < n`, `BasicSupported t`, `t.isFixedSize = false`, and
+`maxByteLength (.vector t n) < MAX_LENGTH`. `listVar` drops the
+positivity precondition (the empty list is the empty buffer). -/
+
+/-- Homogeneous variable elements, `n > 0`: two `.bitlist 8`. -/
+example (v : SSZType.interp (.vector (.bitlist 8) 2)) :
+    SSZType.deserialize (.vector (.bitlist 8) 2)
+        (SSZType.serialize (.vector (.bitlist 8) 2) v) =
+      Except.ok (v, (SSZType.serialize (.vector (.bitlist 8) 2) v).size) :=
+  decode_encode (.vectorVar (by decide) .bitlist rfl (by decide)) v
+
+/-- Count recovered from the first offset: `.list (.bitlist 8) 4`. -/
+example (xs : SSZType.interp (.list (.bitlist 8) 4)) :
+    SSZType.deserialize (.list (.bitlist 8) 4)
+        (SSZType.serialize (.list (.bitlist 8) 4) xs) =
+      Except.ok (xs, (SSZType.serialize (.list (.bitlist 8) 4) xs).size) :=
+  decode_encode (.listVar .bitlist rfl (by decide)) xs
+
+/-- Empty-list / empty-buffer identity. -/
+private def emptyBitlistList : SSZType.interp (.list (.bitlist 8) 4) :=
+  ⟨#[], by decide⟩
+
+example :
+    SSZType.deserialize (.list (.bitlist 8) 4)
+        (SSZType.serialize (.list (.bitlist 8) 4) emptyBitlistList) =
+      Except.ok (emptyBitlistList,
+        (SSZType.serialize (.list (.bitlist 8) 4) emptyBitlistList).size) :=
+  decode_encode (.listVar .bitlist rfl (by decide)) emptyBitlistList
+
+/-- Nested variable collection: `.vector (.list (.uintN 8) 4) 2`. -/
+example (v : SSZType.interp (.vector (.list (.uintN 8) 4) 2)) :
+    SSZType.deserialize (.vector (.list (.uintN 8) 4) 2)
+        (SSZType.serialize (.vector (.list (.uintN 8) 4) 2) v) =
+      Except.ok (v, (SSZType.serialize (.vector (.list (.uintN 8) 4) 2) v).size) :=
+  decode_encode (.vectorVar (by decide)
+                  (.listFixed .uintN8 rfl (by decide)) rfl (by decide)) v
+
+/-- Variable-element container: `.list (.container [.uintN 8, .bitlist 8]) 2`. -/
+example (xs : SSZType.interp (.list (.container [.uintN 8, .bitlist 8]) 2)) :
+    SSZType.deserialize (.list (.container [.uintN 8, .bitlist 8]) 2)
+        (SSZType.serialize (.list (.container [.uintN 8, .bitlist 8]) 2) xs) =
+      Except.ok (xs,
+        (SSZType.serialize (.list (.container [.uintN 8, .bitlist 8]) 2) xs).size) :=
+  decode_encode (.listVar
+                  (.containerVar
+                    (.cons .uintN8 (.cons .bitlist .nil))
+                    (by decide) (by decide))
+                  rfl (by decide)) xs
+
 end SizzLeanTests.ReprExamples

--- a/packages/SizzLean/SizzLeanTests/ReprExamples.lean
+++ b/packages/SizzLean/SizzLeanTests/ReprExamples.lean
@@ -13,27 +13,27 @@ hand-written instance on a two-field `Pair` structure and its
 corresponding piece of library machinery is correct, so a green
 build is a passed gate.
 
-Lives in `SizzLeanTests/` rather than `SizzLean/Repr/` so the
-fixture structures (`Pair`, `DPair`) don't ride along on every
-`import SizzLean`, they're acceptance tests, not part of the
-user-facing surface.
+This module lives in `SizzLeanTests/`. The fixture structures
+(`Pair`, `DPair`) stay off the user-facing `import SizzLean`
+surface.
 
 ## Why `Pair {a b : Bool}` as the example
 
 `SSZ.roundtrip` is gated by `SSZType.BasicSupported r.shape`
-(`Repr/Class.lean`); `BasicSupported` covers the four
-native-width integers (`.uintN 8` / `16` / `32` / `64`), `.bool`,
-the bit shapes, and the fixed-size composites (see
-`Spec/BasicSupported.lean`). The smallest non-trivial user
-structure that lives in `BasicSupported` is a two-`Bool`
-container, exactly the `Pair` defined below.
+(`Repr/Class.lean`). `BasicSupported` covers all six `uintN`
+widths, `.bool`, the bit shapes, fixed-element and
+variable-element collections, and fixed-field or mixed-field
+containers. See `Spec/BasicSupported.lean`. The smallest
+non-trivial user structure in this set is the two-`Bool`
+container `Pair` below.
 
 The integer examples after the `Pair` block exercise the four
 `uintN` arms of `BasicSupported`: thin wrappers around
 `UInt8` / `UInt16` / `UInt32` / `UInt64`, each closing
-`SSZ.roundtrip` via the corresponding constructor. Composite
-arms (`vectorFixed`, `listFixed`, `containerFixed`) are exercised
-further down at the spec-level `decode_encode`.
+`SSZ.roundtrip` via the corresponding constructor. The composite
+constructors (`vectorFixed`, `vectorVar`, `listFixed`, `listVar`,
+`containerFixed`, `containerVar`) are exercised further down at
+the spec-level `decode_encode`.
 -/
 
 set_option autoImplicit false
@@ -138,11 +138,11 @@ example (x : BitVec 256) : SSZ.deserialize (SSZ.serialize x) = .ok x :=
 
 /-! ### Composite arm examples
 
-`BasicSupported` also covers general `vectorFixed`, `listFixed`,
-and `containerFixed`. Each arm carries small side-conditions
-(`0 < n` for vectors, `0 < t.fixedByteSize` for lists, an
-`allFixedSize` field list for containers); the witnesses are
-constructed inline below.
+`BasicSupported` covers fixed-element and variable-element
+collections plus fixed-field and mixed-field containers. Their
+witnesses carry the relevant positivity, fixed-size, field-list,
+and offset-bound conditions. The examples construct those
+witnesses inline.
 
 These examples exercise the *spec-level* `decode_encode` rather
 than the user-surface `SSZ.roundtrip`. The user-surface path

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -117,32 +117,31 @@ first cut; Phase 3 validated the implementation empirically against
 the pyspec `ethereum/consensus-spec-tests` release vectors;
 Phase 4 built the performance layer on top of the now-known-good
 library; **Phase 5 (Stage 18) widens the three theorems** toward
-universal `Supported` coverage. As of this writing
+complete `BasicSupported` constructor coverage. As of this writing
 `BasicSupported` covers `uintN 8/16/32/64` and `uintN 128/256`
 (the wide arms via the `Nat`-digit codec proof in
 `Proofs/UIntWide.lean`, with no `bv_decide` axiom), `bool`,
-fixed-size `vector` and `list`, `bitvector`, `bitlist` (both via
-the bit-packing inverse in `Proofs/BitPack.lean`), and `container`
-over any field list, whether every field is fixed-size
+`vector` and `list` over fixed-size or variable-size element types,
+`bitvector`, `bitlist` (both via the bit-packing inverse in
+`Proofs/BitPack.lean`), and `container` over any field list.
+Container fields can all be fixed-size
 (recursively, the `containerFixed` constructor) or the list mixes
 fixed- and variable-size fields (the `containerVar` constructor,
 decoded via the offset-table codec proved in
 `Proofs/ContainerVar.lean` and `Proofs/Roundtrip.lean`'s
-`decode_encode_containerVar_aux`), and `vector` / `list` over a
-variable-size element type (the `vectorVar` / `listVar`
-constructors, proved in `Proofs/CollectionVar.lean`). See
+`decode_encode_containerVar_aux`). The `vectorVar` and `listVar`
+proofs live in `Proofs/CollectionVar.lean`. See
 `Spec/BasicSupported.lean` and the README's *Proof coverage*
-table. One gap remains toward universal `Supported` coverage:
-the schema-level `maxByteLength s < MAX_LENGTH` guard on
-`containerVar` / `vectorVar` / `listVar` (real `BeaconState` /
-`BeaconBlockBody` shapes sit outside it; see etheorem#61 for the
-value-level relaxation). The `SSZ.roundtrip` user-surface
-corollary is gated by `BasicSupported r.shape` until that
-relaxes too. The asterisk on
+table. `Supported` remains a structural codec predicate and admits
+zero-width schemas that the decoder rejects. `BasicSupported`
+carries the proof guards. Value-level offset guards remain tracked
+for `containerVar` (etheorem#61) and `vectorVar` / `listVar`
+(etheorem#77). The `SSZ.roundtrip` user-surface corollary mirrors
+the `BasicSupported r.shape` gate. The asterisk on
 "verified by inheritance" is intentional and small: passing
 empirical conformance is what makes both the performance
-investment in Phase 4 and the research-grade proof investment in
-Phase 5 well-targeted rather than speculative.
+investment in Phase 4 and the proof investment in Phase 5 target
+a conformance-tested implementation.
 
 **What the cache layer adds.** SSZ's `hash_tree_root` is the dominant cost
 in any consensus-state pipeline: a cold root of `BeaconState` hashes tens
@@ -1502,7 +1501,7 @@ plans as to the document itself.
 | **2: User surface** | Layer 3 (`SSZRepr` + deriving handler) and the Day-1 `FFI/Sha256` `@[extern] opaque` instance. | FFI/Sha256 has no dependency on the verification frontier. SHA-256 is opaque from Day 1; its NIST-conformance assertion is in the TCB. The `SSZ.roundtrip` user-surface corollary is gated by `BasicSupported r.shape` until Stage 18 widens it. The cached Merkle-tree work (Layer 4) has moved to Phase 4. |
 | **3: Application + empirical validation** | Layer 5 (Eth types) + `SizzLeanTests/Sha256Vectors` (consumes `ethereum/consensus-spec-tests` release vectors). | Conformance runs against the verified spec functions (`SSZ.hashTreeRoot` from Layer 1, uncached). This is the empirical safety net for both the verified and asserted-equivalent paths, and the gating signal for both Phase 4 (performance) and Phase 5 (proofs): passing here is what makes either investment well-targeted. |
 | **4: Production primitives + deferred hardening** | Layer 4 (`Tree`, `TreeBacked`, the cached Merkle layer); pure-Lean `Hasher/Sha256Spec.lean` + `@[csimp]` (removes the FFI assertion from TCB); performance work (`ViewDU`-style deferred-update overlay, batched SHA-256, hash-consing). | All stages independent and order-agnostic among themselves. The cache layer lands here (not Phase 2) because it's a *performance* layer asserted equivalent to the spec; deferring it past empirical validation means its property tests have a known-good reference oracle (the spec, validated in Phase 3). The Approach C `profile%` macro is not on the plan; see §8 for the rationale (no fork through Gloas uses EIP-7495 / EIP-7916 / EIP-8016 forms). |
-| **5: Complete formal verification** | **Stage 18: widen `BasicSupported` toward `SSZType.Supported` / `SupportedBounded`, closing `decode_encode`, `serialize_injective`, `encode_size_le_max` arm by arm.** Currently closed: `uintN 8/16/32/64/128/256`, `bool`, `vector` and `list` over a fixed-size or variable-size element type, `bitvector`, `bitlist`, and `container` over any field list (fixed-only, recursively, or mixed fixed/variable via the offset-table codec, subject to `maxByteLength s < MAX_LENGTH`). Open: the value-level relaxation of the size guard (etheorem#61). | Positioned last by design: empirical conformance from Phase 3 ensures the proof effort targets a known-correct implementation, not a speculative one. The publishable non-malleability artefact lands when the remaining arms close. |
+| **5: Complete formal verification** | **Stage 18: close `decode_encode`, `serialize_injective`, and `encode_size_le_max` for each `BasicSupported` constructor.** All current constructors are closed: `uintN 8/16/32/64/128/256`, `bool`, fixed-element and variable-element `vector` / `list`, `bitvector`, `bitlist`, and fixed-field or mixed-field `container`. Value-level offset-guard widening remains for `containerVar` (etheorem#61) and `vectorVar` / `listVar` (etheorem#77). | Positioned last by design: empirical conformance from Phase 3 gives the proofs a known-correct implementation. The publishable non-malleability result states its `BasicSupported` scope and trust footprint directly. |
 
 The single highest-risk implementation item is gindex arithmetic in
 `Node.setAt`. Mitigation: structural recursion on an explicit `List Bool`

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -128,15 +128,17 @@ over any field list, whether every field is fixed-size
 fixed- and variable-size fields (the `containerVar` constructor,
 decoded via the offset-table codec proved in
 `Proofs/ContainerVar.lean` and `Proofs/Roundtrip.lean`'s
-`decode_encode_containerVar_aux`). See `Spec/BasicSupported.lean`
-and the README's *Proof coverage* table. Two gaps remain toward
-universal `Supported` coverage: `vector` / `list` over a
-variable-size element type, and the schema-level
-`maxByteLengthFields fs < MAX_LENGTH` guard on `containerVar`
-(real `BeaconState` / `BeaconBlockBody` shapes sit outside it;
-see etheorem#61 for the value-level relaxation). The
-`SSZ.roundtrip` user-surface corollary is gated by
-`BasicSupported r.shape` until those close too. The asterisk on
+`decode_encode_containerVar_aux`), and `vector` / `list` over a
+variable-size element type (the `vectorVar` / `listVar`
+constructors, proved in `Proofs/CollectionVar.lean`). See
+`Spec/BasicSupported.lean` and the README's *Proof coverage*
+table. One gap remains toward universal `Supported` coverage:
+the schema-level `maxByteLength s < MAX_LENGTH` guard on
+`containerVar` / `vectorVar` / `listVar` (real `BeaconState` /
+`BeaconBlockBody` shapes sit outside it; see etheorem#61 for the
+value-level relaxation). The `SSZ.roundtrip` user-surface
+corollary is gated by `BasicSupported r.shape` until that
+relaxes too. The asterisk on
 "verified by inheritance" is intentional and small: passing
 empirical conformance is what makes both the performance
 investment in Phase 4 and the research-grade proof investment in
@@ -1500,7 +1502,7 @@ plans as to the document itself.
 | **2: User surface** | Layer 3 (`SSZRepr` + deriving handler) and the Day-1 `FFI/Sha256` `@[extern] opaque` instance. | FFI/Sha256 has no dependency on the verification frontier. SHA-256 is opaque from Day 1; its NIST-conformance assertion is in the TCB. The `SSZ.roundtrip` user-surface corollary is gated by `BasicSupported r.shape` until Stage 18 widens it. The cached Merkle-tree work (Layer 4) has moved to Phase 4. |
 | **3: Application + empirical validation** | Layer 5 (Eth types) + `SizzLeanTests/Sha256Vectors` (consumes `ethereum/consensus-spec-tests` release vectors). | Conformance runs against the verified spec functions (`SSZ.hashTreeRoot` from Layer 1, uncached). This is the empirical safety net for both the verified and asserted-equivalent paths, and the gating signal for both Phase 4 (performance) and Phase 5 (proofs): passing here is what makes either investment well-targeted. |
 | **4: Production primitives + deferred hardening** | Layer 4 (`Tree`, `TreeBacked`, the cached Merkle layer); pure-Lean `Hasher/Sha256Spec.lean` + `@[csimp]` (removes the FFI assertion from TCB); performance work (`ViewDU`-style deferred-update overlay, batched SHA-256, hash-consing). | All stages independent and order-agnostic among themselves. The cache layer lands here (not Phase 2) because it's a *performance* layer asserted equivalent to the spec; deferring it past empirical validation means its property tests have a known-good reference oracle (the spec, validated in Phase 3). The Approach C `profile%` macro is not on the plan; see §8 for the rationale (no fork through Gloas uses EIP-7495 / EIP-7916 / EIP-8016 forms). |
-| **5: Complete formal verification** | **Stage 18: widen `BasicSupported` toward `SSZType.Supported` / `SupportedBounded`, closing `decode_encode`, `serialize_injective`, `encode_size_le_max` arm by arm.** Currently closed: `uintN 8/16/32/64/128/256`, `bool`, fixed-size `vector` and `list`, `bitvector`, `bitlist`, and `container` over any field list (fixed-only, recursively, or mixed fixed/variable via the offset-table codec, subject to `maxByteLengthFields fs < MAX_LENGTH`). Open: `vector` / `list` over a variable-size element type, and the value-level relaxation of the `containerVar` size guard (etheorem#61). | Positioned last by design: empirical conformance from Phase 3 ensures the proof effort targets a known-correct implementation, not a speculative one. The publishable non-malleability artefact lands when the remaining arms close. |
+| **5: Complete formal verification** | **Stage 18: widen `BasicSupported` toward `SSZType.Supported` / `SupportedBounded`, closing `decode_encode`, `serialize_injective`, `encode_size_le_max` arm by arm.** Currently closed: `uintN 8/16/32/64/128/256`, `bool`, `vector` and `list` over a fixed-size or variable-size element type, `bitvector`, `bitlist`, and `container` over any field list (fixed-only, recursively, or mixed fixed/variable via the offset-table codec, subject to `maxByteLength s < MAX_LENGTH`). Open: the value-level relaxation of the size guard (etheorem#61). | Positioned last by design: empirical conformance from Phase 3 ensures the proof effort targets a known-correct implementation, not a speculative one. The publishable non-malleability artefact lands when the remaining arms close. |
 
 The single highest-risk implementation item is gindex arithmetic in
 `Node.setAt`. Mitigation: structural recursion on an explicit `List Bool`

--- a/packages/SizzLean/docs/ARCHITECTURE.md
+++ b/packages/SizzLean/docs/ARCHITECTURE.md
@@ -123,8 +123,8 @@ complete `BasicSupported` constructor coverage. As of this writing
 `Proofs/UIntWide.lean`, with no `bv_decide` axiom), `bool`,
 `vector` and `list` over fixed-size or variable-size element types,
 `bitvector`, `bitlist` (both via the bit-packing inverse in
-`Proofs/BitPack.lean`), and `container` over any field list.
-Container fields can all be fixed-size
+`Proofs/BitPack.lean`), and `container` over any field list,
+whether every field is fixed-size
 (recursively, the `containerFixed` constructor) or the list mixes
 fixed- and variable-size fields (the `containerVar` constructor,
 decoded via the offset-table codec proved in
@@ -139,9 +139,9 @@ for `containerVar` (etheorem#61) and `vectorVar` / `listVar`
 (etheorem#77). The `SSZ.roundtrip` user-surface corollary mirrors
 the `BasicSupported r.shape` gate. The asterisk on
 "verified by inheritance" is intentional and small: passing
-empirical conformance is what makes both the performance
-investment in Phase 4 and the proof investment in Phase 5 target
-a conformance-tested implementation.
+empirical conformance is what points both the Phase 4 performance
+work and the Phase 5 proof work at an implementation already known
+to match the spec.
 
 **What the cache layer adds.** SSZ's `hash_tree_root` is the dominant cost
 in any consensus-state pipeline: a cold root of `BeaconState` hashes tens

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1390,11 +1390,12 @@ conformance pays the empirical-validation tax first.
 
 ### Stage 18: Complete the three central theorems: **in progress**
 
-**Goal.** Close the publishable correctness story: `decode_encode`,
-`serialize_injective`, and `encode_size_le_max` universally over all
-implemented arms (i.e. `SSZType.Supported` /
-`SSZType.SupportedBounded`, defined in `Spec/Supported.lean`).
-Replaces the Stage 5–6 first-cut theorems on `BasicSupported`.
+**Goal.** Close `decode_encode`, `serialize_injective`, and
+`encode_size_le_max` for every constructor admitted by
+`BasicSupported`. Keep each proof guard explicit. `Supported` and
+`SupportedBounded` describe structural codec coverage; they also
+admit zero-width schemas that the decoder rejects, so they cannot
+gate a universal roundtrip statement as currently defined.
 
 **Current coverage (shipped).**
 
@@ -1419,14 +1420,15 @@ prerequisite the composite arms recurse through and is reused by
 the three theorems' composite-arm dispatch.
 
 **Remaining deliverables.**
-- Value-level relaxation of the `maxByteLength s < MAX_LENGTH`
-  guard on `containerVar` / `vectorVar` / `listVar`
-  (etheorem#61): the schema-level bound is correct for uint32
-  offsets, but it excludes the real `BeaconState` /
-  `BeaconBlockBody` shapes whose static max exceeds `2^32`.
-- The `SSZ.roundtrip` user-surface corollary keeps its
-  `BasicSupported r.shape` precondition until that guard
-  relaxes too.
+- Relax the `containerVar` schema-level offset bound to a
+  value-level condition (etheorem#61). This admits real
+  `BeaconState` / `BeaconBlockBody` values whose static max exceeds
+  `2^32`.
+- Apply the equivalent value-level relaxation to `vectorVar` and
+  `listVar` (etheorem#77).
+- Keep `SSZ.roundtrip` gated by `BasicSupported r.shape`. Any
+  future gate change must preserve the decoder's schema-validity
+  conditions.
 
 Shipped since the original scoping:
 `packages/SizzLean/SizzLean/Proofs/BitPack.lean` carries the
@@ -1466,20 +1468,17 @@ roundtrip as a parameter, so they sit outside the mutual block
 `supported_of_basicSupported` subset theorem grew matching arms
 in the same change.
 
-**Final acceptance.** Three theorems closed universally over
-`Supported` / `SupportedBounded` with no `sorry`, no `native_decide`
-on the proof path. The current shipping cut closes every codec-implemented
-composite arm, leaving the schema-level `maxByteLength s <
-MAX_LENGTH` guard on `containerVar` / `vectorVar` / `listVar`
-(etheorem#61 tracks the value-level relaxation);
-`decode_encode`'s axiom footprint is exactly four
-`_native.bv_decide.ax_*` axioms (three from the multi-byte `uintN`
-arms, one from the uint32 offset codec bridge shared by
-`containerVar` / `vectorVar` / `listVar`) plus the standard kernel axioms (the bit arms add
-none), and `encode_size_le_max` adds none. Note that the
-`bv_decide` axioms are a documented deviation from the original
-Stage 18 acceptance and could be removed by replacing `bv_decide`
-with hand-written `BitVec` proofs (substantially more code).
+**Current acceptance.** All three theorems cover every current
+`BasicSupported` constructor with no `sorry` and no
+`native_decide` on the proof path. This includes every
+codec-implemented composite constructor under its explicit proof
+guards. `decode_encode` has exactly four
+`_native.bv_decide.ax_*` axioms. Three come from the multi-byte
+`uintN` arms. The fourth comes from the uint32 offset codec bridge
+shared by `containerVar`, `vectorVar`, and `listVar`. The bit arms
+add none. `encode_size_le_max` adds no nonstandard axioms. The
+`bv_decide` certificates are a documented change from the original
+Stage 18 target. Hand-written `BitVec` proofs could remove them.
 
 **Risk.** Lowered from the original "highest in project" since
 the composite arms (general `vector` / `list` / `container`,
@@ -1489,7 +1488,7 @@ trick, first on `(BasicSupported, BasicSupportedFieldsFixed)` and
 then reused on `(BasicSupported, BasicSupportedFields)` for
 `containerVar`, resolved the closure-termination issue cleanly
 both times. Remaining risk concentrates in the value-level
-relaxation of the size guard (etheorem#61).
+size-guard relaxations (etheorem#61 and etheorem#77).
 
 **Notes.** Each arm's arrival extends `SSZ.roundtrip`
 automatically; downstream Eth-types instances pick up the wider
@@ -1586,4 +1585,4 @@ normalized form modeled first.
 | 2: User surface | Stages 7–9 | complete |
 | 3: Application + empirical validation | Stages 10–11, **11.1** | **complete.** `ssz_generic`: **1865/1865 cases pass**. `ssz_static` (minimal preset, full `--all` sweep): **38991/38991 cases pass** across all seven mainline forks (`phase0`, `altair`, `bellatrix`, `capella`, `deneb`, `electra`, `fulu`), zero failures, zero skipped. Conformance pinned at consensus-spec-tests **v1.6.0-beta.0** in `scripts/run_conformance.py` so the Fulu / Gloas containers track the post-v1.5.0 main-branch spec (Fulu BeaconState is now its own struct with `proposer_lookahead`; Gloas BeaconState is its own struct with the nine EIP-7732 ePBS fields). Preset duplication is eliminated by the `ssz_struct_for_presets` macro (`packages/LeanEthCS/LeanEthCS/PresetStruct.lean`); preset-sensitive containers are written once with `@@CONST` / `@%TypeName` placeholders and emitted twice (`.Minimal` / `.Mainnet`). Mainnet validated at `--limit 2` across all forks (1641/1641); mainnet `--all` is a `workflow_dispatch` button. CLI dispatch uses the `<preset>/<fork>:<type>` identifier scheme (legacy `<fork>:<type>` defaults to minimal). **CI integration**: `.github/workflows/lean_action_ci.yml` runs the conformance script at `--limit 1` on every push/PR. **Stage 11.1, harness modernisation:** `eth_ssz_vector_runner batch` mode (one process spawn per sweep, tab-separated request/response over stdin/stdout, ~70× speedup on `ssz_generic`); `tqdm` progress bar; per-fork explicit `Inherited.lean` re-exports in LeanEthCS killing the inheritance heuristic in the dispatcher; Tests/ rename to package-prefixed `SizzLeanTests/` / `LeanSha256Tests/` for umbrella-build namespace disambiguation. EIP-7441 (Whisk) deferred per scope; EIP-7732 (ePBS) Gloas containers tracked (BeaconState shape implemented; supporting types `Builder`, `BuilderPendingPayment`, `BuilderPendingWithdrawal`, and `ExecutionPayloadBid` ship in `Forks/Gloas/`). |
 | 4: Production primitives + deferred hardening | Stages 12, 13, 14a–d, **14e**, 15, 17a–e (Stage 16 dropped, see note) | **Cache backbone + ergonomic surface + Sha256Spec green: 14a–e + 15 in.** Stage 12: three hand-built trees match `Spec.SSZType.hashTreeRoot` via `native_decide`. Stage 13: 200-case randomized property test (`gindexBits` on `List Bool` so the Nimbus Feb-2025 gindex bug class is unrepresentable). Stage 14a: `TreeBacked` scaffold. Stage 14b: `Node.ofShape` produces interior-populated trees byte-identical to the spec; coherence verified on 8 composite types. Stage 14c: cached `setField` operations; property tests pass for 100 + 30 mutations. Stage 14d: `Node.setManyAt` batched walker (100-case property test on disjoint distinct paths) plus `sszUpdate t with f := v, g.h := w, vec[i] := x` term-elaborated syntax (50-case flat-multi + 20-case nested-path + 30-case vector-index + 30-case alias-coverage gates). Index syntax handles both `Vector` and `SSZList` with composite element types; the list path emits the `[false]` mix-in-length prefix automatically. `TreeBacked H T` / `CachedSSZ H T` pin the hasher in the *type*, picked once at `TreeBacked.ofValue` time, then inferred by every downstream `sszUpdate` / `hashTreeRootCached` call; mixing hashers within one cached value is a type error. Two exploratory pieces were tried and removed: a `derive_tree_setters` macro and `TreeBacked/Container.lean` (hand-written setters obsoleted by `sszUpdate`'s index syntax). **Stage 14e, `SSZ.Box` union + curated public surface:** closed inductive over the two cache flavours with four smart constructors (`SSZ.FastBox` / `SSZ.PureBox` Sha256-pinned, `SSZ.CachedBox` / `SSZ.UncachedBox` hasher-explicit); `sszUpdate` extended with two-arm box dispatch; read-side `sszGet b a.b[i].c` macro mirrors `sszUpdate`'s path syntax and expands to `b.view.a.b[i].c` so user code never types `.view`; `CachedSSZ.ofValue` / `.hashTreeRoot` user-facing aliases. Stage 15: pure-Lean `Sha256Spec` ships as a kernel-reducible Lean SHA-256 implementation, validated empirically against the FFI on 185 cases (5 NIST + 100 random combine + 80 random hash). **Stage 17a (pending overlay):** `pending : Std.TreeMap Nat (PendingWrite T)` where `PendingWrite T = T → Option Node` is a closure that reads the current `view` at commit time and returns `none` for view-side no-op writes (OOB index updates). Cross-statement batching is automatic and free; closure-based read-from-view keeps overlapping parent/child writes mutually consistent. **Stage 17b:** batched SHA-256 FFI primitive (`sha256BatchCombine`) shipped with named axiom and equivalence tests; scalar inner loop in `csrc/sha256_batch.c` for now (AVX-512 swap is 17b.1 follow-up, keeps the FFI surface identical). **Stage 17c:** bounded-LRU hash-consing primitive (`Node.mkPair`) shipped opt-in; default cached path bypasses it. **Stage 17d:** `@[specialize]` on the three `SSZ.serialize/deserialize/hashTreeRoot` surfaces. **Stage 17e:** `Node.commitAndHash` fuses commit + root walk into a single spine walk; `Node.ofShape`'s builders (`ofLeaves`, `ofSubtrees`, `mixInLength`) pre-fill `(some root)` cache slots at construction so `merkleRootWithCache` on a fresh subtree short-circuits in O(1) at the top. **Bench (`packages/SizzLean/SizzLeanBench/`, run via `just sizzlean-bench`):** seven scenarios S1–S7 across small (`Validator` / `ValidatorSet16`), large (`ValidatorSet256`), and realistic (`SizzLeanBench.Fulu.BeaconState`, mainnet preset, ~1024 validators) fixtures. Headline rows: **S6 BlockProcessingLarge** ~2.4× cached vs pure; **S7 FuluStateTransition** ~2.0× cached vs pure. S7's Fulu types live in `SizzLeanBench/Fulu.lean` as a bench-local reference copy so `SizzLeanBench` doesn't need a LeanEthCS dependency (`LeanEthCS` already depends on `SizzLean`, so the reverse would close a cycle). |
-| 5: Complete formal verification | Stage 18 | **in progress.** `BasicSupported` now covers `uintN 8 / 16 / 32 / 64 / 128 / 256`, `bool`, general `vector` / `list` over fixed-size or variable-size elements (`vectorFixed` / `listFixed` / `vectorVar` / `listVar`), `bitvector` / `bitlist` (the `packBitsLE` / `unpackBitsLEAux` inverse plus `msbPos` delimiter recovery, `Proofs/BitPack.lean`), and general `container` over any field list, fixed-only (recursively, `bitvector` fields included, `containerFixed`) or mixed fixed/variable (`containerVar`, the offset-table codec in `Proofs/ContainerVar.lean` + `Proofs/Roundtrip.lean`'s `decode_encode_containerVar_aux`). Shared prereq `Proofs/SerializeSize.lean` lands the `size_serialize_eq_fixedByteSize` mutual proof. Per-arm proofs split across `Proofs/{UInt,UIntWide,Bool,VectorFixed,ListFixed,CollectionVar,ContainerFixed,ContainerVar,FixedElems,BitPack,Roundtrip,SizeBound}.lean`; `decode_encode`'s axiom footprint is four `_native.bv_decide.ax_*` (uintN16/32/64 plus the uint32 offset codec bridge shared by `containerVar` / `vectorVar` / `listVar`; the bit arms and the wide `uintN128/256` arms add none), `encode_size_le_max`'s is zero non-standard axioms. Open gap: the schema-level `maxByteLength s < MAX_LENGTH` guard (etheorem#61). See the Stage 18 section above and the README's *Proof coverage* table. |
+| 5: Complete formal verification | Stage 18 | **in progress.** All current `BasicSupported` constructors have `decode_encode`, `serialize_injective`, and `encode_size_le_max` arms. This includes fixed-element and variable-element collections, bit shapes, and fixed-field or mixed-field containers. `decode_encode` has four `bv_decide` certificates. `encode_size_le_max` has no nonstandard axioms. Value-level offset-guard widening remains for `containerVar` (etheorem#61) and `vectorVar` / `listVar` (etheorem#77). See the Stage 18 section and the README proof table. |

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1483,7 +1483,7 @@ with hand-written `BitVec` proofs (substantially more code).
 
 **Risk.** Lowered from the original "highest in project" since
 the composite arms (general `vector` / `list` / `container`,
-fixed-field and now mixed-field) and both bit arms are now shipped
+fixed-size and variable-size) and both bit arms are now shipped
 without the predicted research-grade difficulty. The mutual-block
 trick, first on `(BasicSupported, BasicSupportedFieldsFixed)` and
 then reused on `(BasicSupported, BasicSupportedFields)` for

--- a/packages/SizzLean/docs/PLAN.md
+++ b/packages/SizzLean/docs/PLAN.md
@@ -1404,7 +1404,9 @@ Replaces the Stage 5–6 first-cut theorems on `BasicSupported`.
 | `.uintN 128 / 256` | ✅ | `Proofs/UIntWide.lean` (`Nat`-digit codec inverse; no `bv_decide` axiom) |
 | `.bool` | ✅ | `Proofs/Bool.lean` |
 | `.vector t n` (general, `0 < n`, fixed-size `t`) | ✅ | `Proofs/VectorFixed.lean` |
+| `.vector t n` (general, `0 < n`, variable-size `t`) | ✅ | `Proofs/CollectionVar.lean` |
 | `.list t cap` (general, fixed-size `t`, `0 < t.fixedByteSize`) | ✅ | `Proofs/ListFixed.lean` |
+| `.list t cap` (general, variable-size `t`) | ✅ | `Proofs/CollectionVar.lean` |
 | `.container fs` (general, `BasicSupportedFieldsFixed fs`) | ✅ | `Proofs/ContainerFixed.lean` (helpers) + `Proofs/Roundtrip.lean` (mutual block) |
 | `.bitvector n` (`0 < n`) | ✅ | `Proofs/BitPack.lean` (`packBitsLE` / `unpackBitsLEAux` inverse) |
 | `.bitlist cap` | ✅ | `Proofs/BitPack.lean` (inverse + `msbPos` delimiter recovery) |
@@ -1417,17 +1419,14 @@ prerequisite the composite arms recurse through and is reused by
 the three theorems' composite-arm dispatch.
 
 **Remaining deliverables.**
-- `vector` / `list` over a variable-size element type
-  (`vectorVar` / `listVar`, no proof arm yet); the mixed-field
-  container work closed the field-list side of this gap but left
-  the element-type side open.
-- Value-level relaxation of `containerVar`'s
-  `maxByteLengthFields fs < MAX_LENGTH` guard (etheorem#61): the
-  schema-level bound is correct for uint32 offsets, but it
-  excludes the real `BeaconState` / `BeaconBlockBody` shapes
-  whose static max exceeds `2^32`.
+- Value-level relaxation of the `maxByteLength s < MAX_LENGTH`
+  guard on `containerVar` / `vectorVar` / `listVar`
+  (etheorem#61): the schema-level bound is correct for uint32
+  offsets, but it excludes the real `BeaconState` /
+  `BeaconBlockBody` shapes whose static max exceeds `2^32`.
 - The `SSZ.roundtrip` user-surface corollary keeps its
-  `BasicSupported r.shape` precondition until that arm lands too.
+  `BasicSupported r.shape` precondition until that guard
+  relaxes too.
 
 Shipped since the original scoping:
 `packages/SizzLean/SizzLean/Proofs/BitPack.lean` carries the
@@ -1457,16 +1456,26 @@ output, decomposed at each cons step via `Proofs/ContainerVar.lean`'s
 the same change, so the two predicates cannot drift apart on this
 constructor either.
 
+Variable-element `.vector` / `.list` landed via `vectorVar` /
+`listVar` constructors on the same three predicates, carrying
+`t.isFixedSize = false` and (on `BasicSupported`) `0 < n` for
+vectors plus `maxByteLength s < MAX_LENGTH` for both. The
+walkers live in `Proofs/CollectionVar.lean` and take the element
+roundtrip as a parameter, so they sit outside the mutual block
+(homogeneous: one `t`, induction on the element list). The
+`supported_of_basicSupported` subset theorem grew matching arms
+in the same change.
+
 **Final acceptance.** Three theorems closed universally over
 `Supported` / `SupportedBounded` with no `sorry`, no `native_decide`
-on the proof path. The current shipping cut closes everything
-except `vector` / `list` over a variable-size element type and
-the schema-level `maxByteLengthFields fs < MAX_LENGTH` guard on
-`containerVar` (etheorem#61 tracks the value-level relaxation);
+on the proof path. The current shipping cut closes every codec-implemented
+composite arm, leaving the schema-level `maxByteLength s <
+MAX_LENGTH` guard on `containerVar` / `vectorVar` / `listVar`
+(etheorem#61 tracks the value-level relaxation);
 `decode_encode`'s axiom footprint is exactly four
 `_native.bv_decide.ax_*` axioms (three from the multi-byte `uintN`
-arms, one from the mixed-field container arm's uint32 offset
-codec bridge) plus the standard kernel axioms (the bit arms add
+arms, one from the uint32 offset codec bridge shared by
+`containerVar` / `vectorVar` / `listVar`) plus the standard kernel axioms (the bit arms add
 none), and `encode_size_le_max` adds none. Note that the
 `bv_decide` axioms are a documented deviation from the original
 Stage 18 acceptance and could be removed by replacing `bv_decide`
@@ -1479,9 +1488,8 @@ without the predicted research-grade difficulty. The mutual-block
 trick, first on `(BasicSupported, BasicSupportedFieldsFixed)` and
 then reused on `(BasicSupported, BasicSupportedFields)` for
 `containerVar`, resolved the closure-termination issue cleanly
-both times. Remaining risk concentrates in the still-open
-variable-element `vector` / `list` arm, and in the value-level
-relaxation of `containerVar`'s size guard (etheorem#61).
+both times. Remaining risk concentrates in the value-level
+relaxation of the size guard (etheorem#61).
 
 **Notes.** Each arm's arrival extends `SSZ.roundtrip`
 automatically; downstream Eth-types instances pick up the wider
@@ -1578,4 +1586,4 @@ normalized form modeled first.
 | 2: User surface | Stages 7–9 | complete |
 | 3: Application + empirical validation | Stages 10–11, **11.1** | **complete.** `ssz_generic`: **1865/1865 cases pass**. `ssz_static` (minimal preset, full `--all` sweep): **38991/38991 cases pass** across all seven mainline forks (`phase0`, `altair`, `bellatrix`, `capella`, `deneb`, `electra`, `fulu`), zero failures, zero skipped. Conformance pinned at consensus-spec-tests **v1.6.0-beta.0** in `scripts/run_conformance.py` so the Fulu / Gloas containers track the post-v1.5.0 main-branch spec (Fulu BeaconState is now its own struct with `proposer_lookahead`; Gloas BeaconState is its own struct with the nine EIP-7732 ePBS fields). Preset duplication is eliminated by the `ssz_struct_for_presets` macro (`packages/LeanEthCS/LeanEthCS/PresetStruct.lean`); preset-sensitive containers are written once with `@@CONST` / `@%TypeName` placeholders and emitted twice (`.Minimal` / `.Mainnet`). Mainnet validated at `--limit 2` across all forks (1641/1641); mainnet `--all` is a `workflow_dispatch` button. CLI dispatch uses the `<preset>/<fork>:<type>` identifier scheme (legacy `<fork>:<type>` defaults to minimal). **CI integration**: `.github/workflows/lean_action_ci.yml` runs the conformance script at `--limit 1` on every push/PR. **Stage 11.1, harness modernisation:** `eth_ssz_vector_runner batch` mode (one process spawn per sweep, tab-separated request/response over stdin/stdout, ~70× speedup on `ssz_generic`); `tqdm` progress bar; per-fork explicit `Inherited.lean` re-exports in LeanEthCS killing the inheritance heuristic in the dispatcher; Tests/ rename to package-prefixed `SizzLeanTests/` / `LeanSha256Tests/` for umbrella-build namespace disambiguation. EIP-7441 (Whisk) deferred per scope; EIP-7732 (ePBS) Gloas containers tracked (BeaconState shape implemented; supporting types `Builder`, `BuilderPendingPayment`, `BuilderPendingWithdrawal`, and `ExecutionPayloadBid` ship in `Forks/Gloas/`). |
 | 4: Production primitives + deferred hardening | Stages 12, 13, 14a–d, **14e**, 15, 17a–e (Stage 16 dropped, see note) | **Cache backbone + ergonomic surface + Sha256Spec green: 14a–e + 15 in.** Stage 12: three hand-built trees match `Spec.SSZType.hashTreeRoot` via `native_decide`. Stage 13: 200-case randomized property test (`gindexBits` on `List Bool` so the Nimbus Feb-2025 gindex bug class is unrepresentable). Stage 14a: `TreeBacked` scaffold. Stage 14b: `Node.ofShape` produces interior-populated trees byte-identical to the spec; coherence verified on 8 composite types. Stage 14c: cached `setField` operations; property tests pass for 100 + 30 mutations. Stage 14d: `Node.setManyAt` batched walker (100-case property test on disjoint distinct paths) plus `sszUpdate t with f := v, g.h := w, vec[i] := x` term-elaborated syntax (50-case flat-multi + 20-case nested-path + 30-case vector-index + 30-case alias-coverage gates). Index syntax handles both `Vector` and `SSZList` with composite element types; the list path emits the `[false]` mix-in-length prefix automatically. `TreeBacked H T` / `CachedSSZ H T` pin the hasher in the *type*, picked once at `TreeBacked.ofValue` time, then inferred by every downstream `sszUpdate` / `hashTreeRootCached` call; mixing hashers within one cached value is a type error. Two exploratory pieces were tried and removed: a `derive_tree_setters` macro and `TreeBacked/Container.lean` (hand-written setters obsoleted by `sszUpdate`'s index syntax). **Stage 14e, `SSZ.Box` union + curated public surface:** closed inductive over the two cache flavours with four smart constructors (`SSZ.FastBox` / `SSZ.PureBox` Sha256-pinned, `SSZ.CachedBox` / `SSZ.UncachedBox` hasher-explicit); `sszUpdate` extended with two-arm box dispatch; read-side `sszGet b a.b[i].c` macro mirrors `sszUpdate`'s path syntax and expands to `b.view.a.b[i].c` so user code never types `.view`; `CachedSSZ.ofValue` / `.hashTreeRoot` user-facing aliases. Stage 15: pure-Lean `Sha256Spec` ships as a kernel-reducible Lean SHA-256 implementation, validated empirically against the FFI on 185 cases (5 NIST + 100 random combine + 80 random hash). **Stage 17a (pending overlay):** `pending : Std.TreeMap Nat (PendingWrite T)` where `PendingWrite T = T → Option Node` is a closure that reads the current `view` at commit time and returns `none` for view-side no-op writes (OOB index updates). Cross-statement batching is automatic and free; closure-based read-from-view keeps overlapping parent/child writes mutually consistent. **Stage 17b:** batched SHA-256 FFI primitive (`sha256BatchCombine`) shipped with named axiom and equivalence tests; scalar inner loop in `csrc/sha256_batch.c` for now (AVX-512 swap is 17b.1 follow-up, keeps the FFI surface identical). **Stage 17c:** bounded-LRU hash-consing primitive (`Node.mkPair`) shipped opt-in; default cached path bypasses it. **Stage 17d:** `@[specialize]` on the three `SSZ.serialize/deserialize/hashTreeRoot` surfaces. **Stage 17e:** `Node.commitAndHash` fuses commit + root walk into a single spine walk; `Node.ofShape`'s builders (`ofLeaves`, `ofSubtrees`, `mixInLength`) pre-fill `(some root)` cache slots at construction so `merkleRootWithCache` on a fresh subtree short-circuits in O(1) at the top. **Bench (`packages/SizzLean/SizzLeanBench/`, run via `just sizzlean-bench`):** seven scenarios S1–S7 across small (`Validator` / `ValidatorSet16`), large (`ValidatorSet256`), and realistic (`SizzLeanBench.Fulu.BeaconState`, mainnet preset, ~1024 validators) fixtures. Headline rows: **S6 BlockProcessingLarge** ~2.4× cached vs pure; **S7 FuluStateTransition** ~2.0× cached vs pure. S7's Fulu types live in `SizzLeanBench/Fulu.lean` as a bench-local reference copy so `SizzLeanBench` doesn't need a LeanEthCS dependency (`LeanEthCS` already depends on `SizzLean`, so the reverse would close a cycle). |
-| 5: Complete formal verification | Stage 18 | **in progress.** `BasicSupported` now covers `uintN 8 / 16 / 32 / 64 / 128 / 256`, `bool`, general `vector` / `list` over fixed-size elements, `bitvector` / `bitlist` (the `packBitsLE` / `unpackBitsLEAux` inverse plus `msbPos` delimiter recovery, `Proofs/BitPack.lean`), and general `container` over any field list, fixed-only (recursively, `bitvector` fields included, `containerFixed`) or mixed fixed/variable (`containerVar`, the offset-table codec in `Proofs/ContainerVar.lean` + `Proofs/Roundtrip.lean`'s `decode_encode_containerVar_aux`). Shared prereq `Proofs/SerializeSize.lean` lands the `size_serialize_eq_fixedByteSize` mutual proof. Per-arm proofs split across `Proofs/{UInt,UIntWide,Bool,VectorFixed,ListFixed,ContainerFixed,ContainerVar,FixedElems,BitPack,Roundtrip,SizeBound}.lean`; `decode_encode`'s axiom footprint is four `_native.bv_decide.ax_*` (uintN16/32/64 plus the mixed-field container arm's uint32 offset codec bridge; the bit arms and the wide `uintN128/256` arms add none), `encode_size_le_max`'s is zero non-standard axioms. Open gaps: `vector` / `list` over a variable-size element type, and the schema-level `maxByteLengthFields fs < MAX_LENGTH` guard on `containerVar` (etheorem#61). See the Stage 18 section above and the README's *Proof coverage* table. |
+| 5: Complete formal verification | Stage 18 | **in progress.** `BasicSupported` now covers `uintN 8 / 16 / 32 / 64 / 128 / 256`, `bool`, general `vector` / `list` over fixed-size or variable-size elements (`vectorFixed` / `listFixed` / `vectorVar` / `listVar`), `bitvector` / `bitlist` (the `packBitsLE` / `unpackBitsLEAux` inverse plus `msbPos` delimiter recovery, `Proofs/BitPack.lean`), and general `container` over any field list, fixed-only (recursively, `bitvector` fields included, `containerFixed`) or mixed fixed/variable (`containerVar`, the offset-table codec in `Proofs/ContainerVar.lean` + `Proofs/Roundtrip.lean`'s `decode_encode_containerVar_aux`). Shared prereq `Proofs/SerializeSize.lean` lands the `size_serialize_eq_fixedByteSize` mutual proof. Per-arm proofs split across `Proofs/{UInt,UIntWide,Bool,VectorFixed,ListFixed,CollectionVar,ContainerFixed,ContainerVar,FixedElems,BitPack,Roundtrip,SizeBound}.lean`; `decode_encode`'s axiom footprint is four `_native.bv_decide.ax_*` (uintN16/32/64 plus the uint32 offset codec bridge shared by `containerVar` / `vectorVar` / `listVar`; the bit arms and the wide `uintN128/256` arms add none), `encode_size_le_max`'s is zero non-standard axioms. Open gap: the schema-level `maxByteLength s < MAX_LENGTH` guard (etheorem#61). See the Stage 18 section above and the README's *Proof coverage* table. |

--- a/packages/SizzLean/docs/proof-coverage.baseline
+++ b/packages/SizzLean/docs/proof-coverage.baseline
@@ -3,12 +3,12 @@
 decode_encode basic-arms 7
 decode_encode bit-shapes 2
 decode_encode fixed-composites 3
-decode_encode variable-composites 1
+decode_encode variable-composites 3
 encode_size_le_max basic-arms 7
 encode_size_le_max bit-shapes 2
 encode_size_le_max fixed-composites 3
-encode_size_le_max variable-composites 1
+encode_size_le_max variable-composites 3
 serialize_injective basic-arms 7
 serialize_injective bit-shapes 2
 serialize_injective fixed-composites 3
-serialize_injective variable-composites 1
+serialize_injective variable-composites 3


### PR DESCRIPTION
## Summary

Third of three PRs for #68. #69 and #70 are on `main`. This slice extends every `BasicSupported` matcher with `vectorVar` and `listVar`.

The PR adds both constructors to `Supported`, `SupportedBounded`, and `BasicSupported`. It then closes `decode_encode`, its `serialize_injective` corollary, and `encode_size_le_max` for both constructors.

The collection walkers live in `Proofs/CollectionVar.lean`. They take the element roundtrip and size bound as parameters, so they remain outside the container mutual block. `Roundtrip.lean` and `SizeBound.lean` add the dispatcher arms. `SerializeSize.lean` adds the impossible fixed-size arms.

Preconditions match #68:

- `vectorVar`: `0 < n`, `BasicSupported t`, `t.isFixedSize = false`, and `maxByteLength (.vector t n) < MAX_LENGTH`
- `listVar`: `BasicSupported t`, `t.isFixedSize = false`, and `maxByteLength (.list t cap) < MAX_LENGTH`

`BasicSupported` remains the theorem gate. `Supported` still admits rejected zero-width shapes. Schema-level size guards remain. #61 tracks the `containerVar` value-level relaxation. #77 tracks the same relaxation for `vectorVar` / `listVar`.

Acceptance examples cover:

- `.vector (.bitlist 8) 2`
- `.list (.bitlist 8) 4`
- the empty-list and empty-buffer identity
- `.vector (.list (.uintN 8) 4) 2`
- `.list (.container [.uintN 8, .bitlist 8]) 2`

The PR updates the README, architecture, plan, API docstrings, and proof-coverage baseline. Variable composite coverage grows from one arm to three. Total admitted arms grow from 13 to 15.

Rebased onto `main` after #70. Leo's CollectionVar prose from the #70 merge is kept.

## Verification

- All PR CI jobs pass
- `lake build SizzLean SizzLeanTests` passes
- `just lint` passes
- `just check-citations` passes
- CI runs `just proof-coverage-check` successfully
- The five acceptance examples typecheck
- `decode_encode` keeps four `_native.bv_decide.ax_*` axioms: three uintN certificates and one shared uint32 bridge certificate
- `encode_size_le_max` uses `propext` and `Quot.sound`

## Test plan

- [x] Build SizzLean and SizzLeanTests
- [x] Check the new theorem axioms
- [x] Typecheck all five acceptance examples
- [x] Run lint and citation checks
- [x] #69 is on `main`
- [x] #70 is on `main`
- [ ] CI on this rebase is green

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.