### PR TITLE
ci: block merge when the PR description drops licence acceptance

### DIFF
--- a/.github/workflows/license_acceptance_guard.yml
+++ b/.github/workflows/license_acceptance_guard.yml
@@ -1,0 +1,55 @@
+name: License acceptance guard
+
+# Blocks merge when the pull request description does not accept the
+# project licence. The PR template ships the acceptance line already
+# ticked, so this job guards against the two ways it stops being true: a
+# contributor unticks the box, or deletes the line. Pair it with a
+# branch-protection rule on the base branch that requires the `check` job
+# below to be green before a PR can merge; the workflow alone only
+# produces a status check, the rule is what enforces it.
+
+on:
+  pull_request:
+    # `edited` matters here: a contributor who restores the line after
+    # opening the PR must get a fresh, green run without pushing a commit.
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require licence acceptance in the PR description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Read the body from the REST API, not from the event payload: on
+          # a re-run the payload holds the description as it was when the
+          # event fired, and the API always holds the current text.
+          body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+
+          # The acceptance line, as the PR template writes it:
+          #
+          #     - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
+          #
+          # The pattern tolerates leading whitespace, `*` or `-` as the list
+          # marker, `x` or `X` in the box, and any wording after "accepted",
+          # so a reworded template still passes. An unticked box fails, and
+          # so does a description with the line deleted.
+          ACCEPT_RE='^[[:space:]]*[-*][[:space:]]+\[[xX]\][[:space:]]+I have read and accepted'
+
+          # GitHub serves the body with CRLF line endings; strip the CR so
+          # the anchors match.
+          if printf '%s\n' "$body" | tr -d '\r' | grep -qE "$ACCEPT_RE"; then
+            echo "Licence acceptance found in the PR description."
+            exit 0
+          fi
+
+          echo "::error title=Licence not accepted::The PR description must accept the project licence. The pull request template ships this line ticked under the 'LICENSE (LGPL version 3)' heading. Restore it, ticked, in your description: '- [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.'"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,3 +225,14 @@ pinned toolchain on every PR.
 The project is licensed under LGPL-3.0-or-later (see
 [`LICENSE`](LICENSE)). By contributing, you agree that your
 contributions are licensed under the same terms.
+
+Every pull request states that agreement in its own description. The
+pull request template ends with the acceptance line, already ticked:
+
+```
+- [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
+```
+
+Leave that line in place. The `License acceptance guard` workflow reads
+the description and fails if the line is unticked or deleted. Restore it
+and the check re-runs on the edit; no new commit is needed.


### PR DESCRIPTION
## Summary

The pull request template ships the licence acceptance line already
ticked, and contributors have unticked it or deleted it. Nothing caught
that. This PR adds a status check that does.

## What changed

- `.github/workflows/license_acceptance_guard.yml`, new. It reads the PR
  description from the REST API and greps for the ticked acceptance
  line. An unticked box fails, and so does a description with the line
  deleted. It runs on `opened`, `edited`, `synchronize` and `reopened`,
  so restoring the line turns the check green without a new commit.
- `CONTRIBUTING.md`: one paragraph under *Licensing* stating the rule.

The pattern tolerates leading whitespace, `-` or `*` as the list marker,
`x` or `X` in the box, and any wording after "accepted", so a reworded
template still passes. CRLF from the API is stripped before matching.

## Test plan

No Lean code changed, so the build and the test suites are untouched.

- [x] The three matching cases checked against the regex locally: the
      ticked template line passes, an unticked box fails, an empty
      description fails.
- [x] This PR's own description exercises the check.

## Risk / trust footprint

None. No axiom, `sorry`, `partial def`, `native_decide`, `unsafe` block
or `@[extern]` declaration is added or removed.

## Notes for reviewers

The workflow only produces a status check. It blocks a merge once a
branch-protection rule on `main` requires the `check` job of `License
acceptance guard`, the same pairing the AI co-author guard needs. Both
jobs are named `check`, so pick them by workflow in the rule UI.

The job is modeled on `.github/workflows/ai_coauthor_guard.yml`: same
trigger shape, same read-only permissions, same `gh api` approach with no
checkout.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
