### PR TITLE
fix(proof-coverage): name the SHA-256 equivalence axioms by their real namespace

### DIFF
--- a/packages/EthCLSpecs/README.md
+++ b/packages/EthCLSpecs/README.md
@@ -142,8 +142,8 @@ column is the fork's own diff, for scale.
 | `Quot.sound` | 45 |
 | `Lean.ofReduceBool` | 0 |
 | `Lean.trustCompiler` | 0 |
-| `SizzLean.sha256Hash_eq_spec` | 0 |
-| `SizzLean.sha256Combine_eq_spec` | 0 |
+| `SizzLean.Hasher.sha256Hash_eq_spec` | 0 |
+| `SizzLean.Hasher.sha256Combine_eq_spec` | 0 |
 | `<theorem>._native.bv_decide.ax_* (bv_decide certificate)` | 3 |
 <!-- proof-coverage:end -->
 

--- a/scripts/ProofCoverage.lean
+++ b/scripts/ProofCoverage.lean
@@ -278,7 +278,7 @@ says so in its docstring. -/
 def allowedAxioms : Array Name :=
   #[`propext, `Classical.choice, `Quot.sound,
     `Lean.ofReduceBool, `Lean.trustCompiler,
-    `SizzLean.sha256Hash_eq_spec, `SizzLean.sha256Combine_eq_spec]
+    `SizzLean.Hasher.sha256Hash_eq_spec, `SizzLean.Hasher.sha256Combine_eq_spec]
 
 /-- The axioms `n`'s proof rests on, transitively. -/
 def axiomsOf (env : Environment) (n : Name) : Array Name :=


### PR DESCRIPTION
## Summary

`allowedAxioms` in `scripts/ProofCoverage.lean` names two axioms that do not
exist. The SHA-256 FFI ≡ pure-Lean equivalences are declared inside
`namespace SizzLean.Hasher`, so `SizzLean.sha256Hash_eq_spec` and
`SizzLean.sha256Combine_eq_spec` match nothing the audit walks. So
`just proof-coverage` rejects any proof that rests on the real axiom, by name,
as an axiom outside every trust class. Nothing on `main` rests on either one
yet, which is why the run is green here. The merkleization proofs I have in
flight rest on `sha256Combine_eq_spec`, and that is where it bites.

## What changed

- `scripts/ProofCoverage.lean`: the two entries read
  `SizzLean.Hasher.sha256Hash_eq_spec` and
  `SizzLean.Hasher.sha256Combine_eq_spec`.
- `packages/EthCLSpecs/README.md`: the generated trust-base rows carry the
  names, so `just proof-coverage-update` rewrote them. `--check` compares that
  block byte for byte, so it has to move with the list or CI goes red. Both
  baselines were rewritten too and came out identical, since they record no
  axiom names.

## Test plan

- [x] `just proof-coverage` is green, and its trust-base tables name the two
      axioms as declared.
- [x] `just proof-coverage-check` passes: 38 claims, both baselines and both
      README blocks match.
- [x] `just lint` is clean.
- [x] `lake build SizzLean EthCLSpecs` (507 jobs, through the recipe).
- [ ] `lake build LeanSha256Tests` / `SizzLeanTests` / `just ethcl-test` /
      `just ethcl-pyspec`: not run. This PR changes one script constant and a
      generated documentation block, and no Lean library module.

## Risk / trust footprint

No axiom, `sorry`, `partial def`, `native_decide`, `unsafe` block, or
`@[extern]` declaration added or removed. The allow-list covers the two axioms
it always meant to cover. Both rows still read 0 on `main`.

## Notes for reviewers

The names are worth checking against `packages/SizzLean/SizzLean/Hasher/Sha256Equiv.lean:88-109`,
which opens `namespace SizzLean.Hasher` and declares both axioms in it.

## LICENSE (LGPL version 3)
 - [x] I have read and accepted LICENSE (LGPL version 3), NOTICE and CLA in the root of this project.
